### PR TITLE
ci: Add workflow to run tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: '1.8.2'
+
+      - name: Set up Poetry cache
+        uses: actions/cache@v4
+        id: poetry-cache
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run tests
+        run: poetry run pytest


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow (`ci.yml`) that automatically runs the project's test suite (`poetry run pytest`) on every pull request targeting the `main` or `develop` branches.

This is the first step towards enforcing that all tests must pass before a PR can be merged. Once this is in place, the next step is to configure a branch protection rule in the repository settings.

### Pull Request Checklist
- [ ] Verified that the new workflow triggers correctly on a test PR.