### PR TITLE
feat(cli): support dual-mode plugin installation from local path or PyPI

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,49 @@
 
 ---
 
+## 🛠️ Development Setup
+
+### Prerequisites
+
+- Python 3.9+
+- pipx
+
+### Installation for Development
+
+```bash
+# 1. Clone the repository
+git clone https://github.com/your-org/titan-cli.git
+cd titan-cli
+
+# 2. Install titan-cli in editable mode
+pipx install -e .
+
+# 3. Verify installation
+titan --help
+```
+
+### Initial Configuration
+
+After installation, configure Titan for your projects:
+
+```bash
+# 1. Navigate to your projects directory (parent of all your projects)
+cd ~/projects  # or wherever you keep your projects
+
+# 2. Launch Titan interactive menu
+titan
+
+# 3. Follow the setup wizard:
+#    - Set project root (e.g., ~/projects)
+#    - Configure a project from the "Project Management" menu
+#    - Install plugins from the "Plugin Management" menu
+#      (plugins will be installed from local ./plugins/ directory automatically)
+```
+
+**Note:** With editable installation (`-e` flag), Titan will automatically detect local plugins in the repository and install them from there. No need to manually inject plugins.
+
+---
+
 ## 🎨 UI Architecture and Theming
 
 The UI components are organized to ensure consistency, reusability, and maintainability.

--- a/titan_cli/cli.py
+++ b/titan_cli/cli.py
@@ -292,22 +292,30 @@ def _show_plugin_management_menu(prompts: PromptsRenderer, text: TextRenderer, c
             text.info(f"Installing {plugin_to_install}...")
 
             try:
-                # Build a robust path to the plugin directory, independent of CWD
+                # Detect if we're in development (local plugins/) or production (installed from PyPI)
                 cli_file_path = Path(__file__).resolve()
                 project_root = cli_file_path.parent.parent
                 plugin_path = project_root / "plugins" / plugin_to_install
 
-                if not plugin_path.exists():
-                    text.error(f"Plugin source directory not found at: {plugin_path}")
-                    continue
-
-                # Use subprocess.run to execute the command with the absolute path
-                result = subprocess.run(
-                    ["pipx", "inject", "titan-cli", str(plugin_path)],
-                    capture_output=True,
-                    text=True,
-                    check=False
-                )
+                # Check if local plugin directory exists (development mode)
+                if plugin_path.exists():
+                    # Development mode: install from local path
+                    text.body(f"Installing from local path: {plugin_path}", style="dim")
+                    result = subprocess.run(
+                        ["pipx", "inject", "titan-cli", str(plugin_path)],
+                        capture_output=True,
+                        text=True,
+                        check=False
+                    )
+                else:
+                    # Production mode: install from PyPI
+                    text.body(f"Installing from PyPI: {plugin_to_install}", style="dim")
+                    result = subprocess.run(
+                        ["pipx", "inject", "titan-cli", plugin_to_install],
+                        capture_output=True,
+                        text=True,
+                        check=False
+                    )
 
                 if result.returncode == 0:
                     text.success(f"Successfully installed {plugin_to_install}.")


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR enhances the plugin installation logic within the CLI to support both development and production environments. It intelligently detects whether to install a plugin from a local source path (for contributors) or fetch it from PyPI (for end-users), and updates the development documentation accordingly.

## 🔧 Changes Made
- Modified `titan_cli/cli.py` to check for the existence of a local plugin directory before installing.
- Implemented logic to run `pipx inject titan-cli <path>` if the local path exists, falling back to `pipx inject titan-cli <package_name>` for PyPI installation.
- Added extensive setup instructions to `DEVELOPMENT.md` covering prerequisites, editable installation, and initial configuration.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

**Manual Test Scenarios:**
1. Verified local installation works when running from the repo root (editable mode).
2. Verified PyPI fallback logic by simulating a missing local plugins directory.

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of ...