### PR TITLE
style(cli): remove step header display from git and github plugin steps

### DIFF
--- a/plugins/titan-plugin-git/titan_plugin_git/steps/ai_commit_message_step.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/ai_commit_message_step.py
@@ -26,8 +26,8 @@ def ai_generate_commit_message(ctx: WorkflowContext) -> WorkflowResult:
         Skip: If no changes, AI not configured, or user declined.
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("ai_commit_message", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("ai_commit_message", ctx.current_step, ctx.total_steps)
 
     # Check if AI is configured
     if not ctx.ai or not ctx.ai.is_available():

--- a/plugins/titan-plugin-git/titan_plugin_git/steps/branch_steps.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/branch_steps.py
@@ -16,9 +16,6 @@ def get_current_branch_step(ctx: WorkflowContext) -> WorkflowResult:
         Success: If the current branch was retrieved successfully.
         Error: If the GitClient is not available or the git command fails.
     """
-    # Show step header
-    if ctx.views:
-        ctx.views.step_header("get_head_branch", ctx.current_step, ctx.total_steps)
 
     if not ctx.git:
         error_msg = msg.Steps.Status.GIT_CLIENT_NOT_AVAILABLE

--- a/plugins/titan-plugin-git/titan_plugin_git/steps/commit_step.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/commit_step.py
@@ -28,8 +28,8 @@ def create_git_commit_step(ctx: WorkflowContext) -> WorkflowResult:
         Skip: If there are no changes to commit or a commit was already created.
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("create_commit", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("create_commit", ctx.current_step, ctx.total_steps)
 
     # Skip if there's nothing to commit
     git_status = ctx.data.get("git_status")

--- a/plugins/titan-plugin-git/titan_plugin_git/steps/push_step.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/push_step.py
@@ -23,8 +23,8 @@ def create_git_push_step(ctx: WorkflowContext) -> WorkflowResult:
         Error: If the push operation fails.
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("push", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("push", ctx.current_step, ctx.total_steps)
 
     if not ctx.git:
         return Error(msg.Steps.Push.GIT_CLIENT_NOT_AVAILABLE)

--- a/plugins/titan-plugin-git/titan_plugin_git/steps/status_step.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/status_step.py
@@ -24,8 +24,8 @@ def get_git_status_step(ctx: WorkflowContext) -> WorkflowResult:
         Skip: If user cancels when uncommitted changes are detected.
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("git_status", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("git_status", ctx.current_step, ctx.total_steps)
 
     if not ctx.git:
         return Error(msg.Steps.Status.GIT_CLIENT_NOT_AVAILABLE)

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/ai_pr_step.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/ai_pr_step.py
@@ -41,8 +41,8 @@ def ai_suggest_pr_description(ctx: WorkflowContext) -> WorkflowResult:
         Error: Failed to generate PR description
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("ai_pr_description", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("ai_pr_description", ctx.current_step, ctx.total_steps)
 
     # Check if AI is configured
     if not ctx.ai or not ctx.ai.is_available():

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/prompt_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/prompt_steps.py
@@ -26,8 +26,8 @@ def prompt_for_pr_title_step(ctx: WorkflowContext) -> WorkflowResult:
 
     try:
         # Show step header
-        if ctx.views:
-            ctx.views.step_header("prompt_pr_title", ctx.current_step, ctx.total_steps)
+        # if ctx.views:
+        #     ctx.views.step_header("prompt_pr_title", ctx.current_step, ctx.total_steps)
         title = ctx.views.prompts.ask_text(msg.Prompts.ENTER_PR_TITLE)
         if not title:
             return Error("PR title cannot be empty.")


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR updates the Git and GitHub plugins to suppress the automatic display of step headers during workflow execution. By removing these headers, the CLI output becomes less cluttered, focusing the user's attention on the actual prompts and status updates rather than step transitions.

## 🔧 Changes Made
- **titan-plugin-git**: Disabled `step_header` calls in `ai_commit_message_step`, `commit_step`, `push_step`, `status_step`, and removed the call entirely in `branch_steps`.
- **titan-plugin-github**: Disabled `step_header` calls in `ai_pr_step` and `prompt_steps`.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published