### PR TITLE
chore(jira): update default email and adjust issue sorting

### DIFF
--- a/.titan/config.toml
+++ b/.titan/config.toml
@@ -26,5 +26,5 @@ enabled = true
 
 [plugins.jira.config]
 base_url = "https://jiranext.masorange.es"
-email = "raul.pedraza@masmovil.com"
+email = "alejandro.lopezr@masmovil.com"
 default_project = "ECAPP"

--- a/plugins/titan-plugin-jira/titan_plugin_jira/utils/saved_queries.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/utils/saved_queries.py
@@ -18,8 +18,8 @@ class SavedQueries:
 
     # ==================== PERSONAL QUERIES ====================
 
-    OPEN_ISSUES = 'project = {project} AND status IN ("Open", "Ready to Dev") ORDER BY priority DESC'
-    """All issues that are Open or Ready to Dev in the specified project (regardless of assignee), ordered by priority"""
+    OPEN_ISSUES = 'project = {project} AND status IN ("Open", "Ready to Dev") ORDER BY updated DESC'
+    """All issues that are Open or Ready to Dev in the specified project (regardless of assignee), ordered by last updated"""
 
     MY_OPEN_ISSUES = 'project = {project} AND assignee = currentUser() AND status IN ("Open", "Ready to Dev") ORDER BY updated DESC'
     """Issues assigned to you that are Open or Ready to Dev in the specified project"""


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Updates the default email configuration for the Jira plugin to reflect current ownership. Additionally, modifies the sorting criteria for the `OPEN_ISSUES` query to prioritize recently updated items over priority.

## 🔧 Changes Made
- Updated default email in `.titan/config.toml` from `raul.pedraza@masmovil.com` to `alejandro.lopezr@masmovil.com`.
- Changed `OPEN_ISSUES` JQL query sort order from `ORDER BY priority DESC` to `ORDER BY updated DESC` to surface recent activity first.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented ...