### PR TITLE
fix(git): increase max_tokens limit for AI commit message generation

### DIFF
--- a/plugins/titan-plugin-git/titan_plugin_git/steps/ai_commit_message_step.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/ai_commit_message_step.py
@@ -107,7 +107,7 @@ Return ONLY the single-line commit message, absolutely nothing else."""
         from titan_cli.ai.models import AIMessage
 
         messages = [AIMessage(role="user", content=prompt)]
-        response = ctx.ai.generate(messages, max_tokens=150, temperature=0.7)
+        response = ctx.ai.generate(messages, max_tokens=300, temperature=0.7)
 
         commit_message = response.content.strip()
 


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Increases the token limit for AI-generated commit messages from 150 to 300. This resolves issues where detailed commit messages for larger changes were being truncated abruptly by the AI model.

## 🔧 Changes Made
- Updated `max_tokens` parameter in the `ai.generate` call within `ai_commit_message_step.py` from 150 to 300.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I h...