### PR TITLE
style(cli): disable step header display across plugins

### DIFF
--- a/plugins/titan-plugin-git/titan_plugin_git/steps/branch_steps.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/branch_steps.py
@@ -17,8 +17,8 @@ def get_current_branch_step(ctx: WorkflowContext) -> WorkflowResult:
         Error: If the GitClient is not available or the git command fails.
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("get_head_branch", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("get_head_branch", ctx.current_step, ctx.total_steps)
 
     if not ctx.git:
         error_msg = msg.Steps.Status.GIT_CLIENT_NOT_AVAILABLE

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/prompt_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/prompt_steps.py
@@ -61,8 +61,8 @@ def prompt_for_pr_body_step(ctx: WorkflowContext) -> WorkflowResult:
 
     try:
         # Show step header
-        if ctx.views:
-            ctx.views.step_header("prompt_pr_body", ctx.current_step, ctx.total_steps)
+        # if ctx.views:
+        #     ctx.views.step_header("prompt_pr_body", ctx.current_step, ctx.total_steps)
         body = ctx.views.prompts.ask_multiline(msg.Prompts.ENTER_PR_BODY)
         # Body can be empty
         return Success("PR body captured", metadata={"pr_body": body})

--- a/plugins/titan-plugin-jira/titan_plugin_jira/steps/ai_analyze_issue_step.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/steps/ai_analyze_issue_step.py
@@ -27,8 +27,8 @@ def ai_analyze_issue_requirements_step(ctx: WorkflowContext) -> WorkflowResult:
         ai_analysis (str): AI-generated analysis
         analysis_sections (dict): Structured analysis breakdown
     """
-    if ctx.views:
-        ctx.views.step_header("ai_analyze_issue", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("ai_analyze_issue", ctx.current_step, ctx.total_steps)
 
     # Check if AI is available
     if not ctx.ai or not ctx.ai.is_available():

--- a/plugins/titan-plugin-jira/titan_plugin_jira/steps/get_issue_step.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/steps/get_issue_step.py
@@ -23,8 +23,8 @@ def get_issue_step(ctx: WorkflowContext) -> WorkflowResult:
         Error: Failed to get issue
     """
     # Show step header
-    if ctx.views:
-        ctx.views.step_header("get_issue", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("get_issue", ctx.current_step, ctx.total_steps)
 
     # Check if JIRA client is available
     if not ctx.jira:

--- a/plugins/titan-plugin-jira/titan_plugin_jira/steps/prompt_select_issue_step.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/steps/prompt_select_issue_step.py
@@ -17,8 +17,8 @@ def prompt_select_issue_step(ctx: WorkflowContext) -> WorkflowResult:
         jira_issue_key (str): Selected issue key
         selected_issue (JiraTicket): Selected issue object
     """
-    if ctx.views:
-        ctx.views.step_header("prompt_select_issue", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("prompt_select_issue", ctx.current_step, ctx.total_steps)
 
     # Get issues from previous search
     issues = ctx.get("jira_issues")

--- a/plugins/titan-plugin-jira/titan_plugin_jira/steps/search_saved_query_step.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/steps/search_saved_query_step.py
@@ -53,8 +53,8 @@ def search_saved_query_step(ctx: WorkflowContext) -> WorkflowResult:
             project: "ECAPP"
         ```
     """
-    if ctx.views:
-        ctx.views.step_header("search_saved_query", ctx.current_step, ctx.total_steps)
+    # if ctx.views:
+    #     ctx.views.step_header("search_saved_query", ctx.current_step, ctx.total_steps)
 
     if not ctx.jira:
         if ctx.ui:

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -37,7 +37,7 @@ def test_aiproviderconfig_required_fields():
     assert config.provider == "gemini"
     assert config.model == "gemini-pro"
     assert config.base_url is None
-    assert config.temperature == 0.7  # Default value
+    assert config.temperature == 0.7
     assert config.max_tokens == 4096  # Default value
 
 


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR disables the explicit display of step headers for various workflow steps across the Git, GitHub, and Jira plugins. This change reduces visual noise in the CLI output, creating a more streamlined user experience during workflow execution.

## 🔧 Changes Made
- Disabled `ctx.views.step_header` calls in `titan-plugin-git` (current branch step).
- Disabled `ctx.views.step_header` calls in `titan-plugin-github` (PR body prompt step).
- Disabled `ctx.views.step_header` calls in `titan-plugin-jira` for the following steps:
  - AI issue analysis
  - Get issue
  - Prompt select issue
  - Search saved query
- Minor formatting adjustment in `tests/core/test_models.py`.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published