### PR TITLE
feat(github): add PR auto-assignment functionality with configurable option

### DIFF
--- a/plugins/titan-plugin-github/README.md
+++ b/plugins/titan-plugin-github/README.md
@@ -1,0 +1,268 @@
+# Titan Plugin - GitHub
+
+GitHub integration plugin for Titan CLI with AI-powered PR creation and management.
+
+## Features
+
+- Pull Request creation and management
+- AI-powered PR title and description generation
+- PR review workflows
+- Auto-assignment of PRs to creator
+- Integration with gh CLI for seamless authentication
+
+## Installation
+
+This plugin is installed automatically with Titan CLI when gh CLI is configured.
+
+## Prerequisites
+
+### gh CLI Installation
+
+The GitHub plugin uses `gh CLI` for all GitHub operations. Install it:
+
+```bash
+# macOS
+brew install gh
+
+# Linux
+# See https://github.com/cli/cli#installation
+
+# Windows
+# See https://github.com/cli/cli#installation
+```
+
+### Authentication
+
+Authenticate with GitHub using gh CLI:
+
+```bash
+gh auth login
+```
+
+This will:
+1. Open a browser for OAuth authentication
+2. Store credentials securely in your system keychain
+3. Configure git to use gh CLI for GitHub operations
+
+**Important**: Do NOT set `GITHUB_TOKEN` environment variable as it will conflict with gh CLI authentication.
+
+## Configuration
+
+### Project Configuration
+
+Configure in `.titan/config.toml` (project-level):
+
+```toml
+[plugins.github]
+enabled = true
+
+[plugins.github.config]
+repo_owner = "your-org"
+repo_name = "your-repo"
+default_branch = "master"  # or "main", "develop"
+default_reviewers = ["reviewer1", "reviewer2"]
+pr_template_path = ".github/pull_request_template.md"
+auto_assign_prs = true  # Auto-assign PRs to creator
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `repo_owner` | string | **required** | GitHub repository owner (user or organization) |
+| `repo_name` | string | **required** | GitHub repository name |
+| `default_branch` | string | `null` | Default branch for PRs (falls back to repo default) |
+| `default_reviewers` | list | `[]` | Default reviewers to add to PRs |
+| `pr_template_path` | string | `null` | Path to PR template file |
+| `auto_assign_prs` | boolean | `false` | Automatically assign PRs to the creator |
+
+## Usage
+
+### Available Workflows
+
+#### Create PR with AI
+AI-powered PR creation with automatic commit message and PR description generation:
+
+```bash
+titan
+# Select: Run Workflow → Create Pull Request with AI
+```
+
+This workflow:
+1. Runs pre-commit hooks (linting, tests)
+2. Generates AI commit message from changes
+3. Creates commit
+4. Generates AI PR title and description
+5. Pushes to remote
+6. Creates pull request
+7. **Auto-assigns PR to you** (if `auto_assign_prs = true`)
+
+### Available Steps
+
+The GitHub plugin provides reusable workflow steps:
+
+#### `create_pr`
+Creates a pull request with AI-generated or manual title/description.
+
+**Inputs:**
+- `pr_title` (string): PR title
+- `pr_body` (string, optional): PR description
+- `pr_head_branch` (string): Feature branch
+- `pr_is_draft` (boolean, optional): Create as draft PR
+
+**Outputs:**
+- `pr_number` (int): Created PR number
+- `pr_url` (string): PR URL
+
+#### `assign_pr`
+Assigns users to a pull request (reusable step).
+
+**Inputs:**
+- `pr_number` (int): PR number to assign
+- `assignees` (list[string], optional): GitHub usernames. Defaults to current user if not provided.
+
+**Example workflow:**
+```yaml
+steps:
+  - id: create_pr
+    name: "Create PR"
+    plugin: github
+    step: create_pr
+
+  - id: assign_reviewers
+    name: "Assign Reviewers"
+    plugin: github
+    step: assign_pr
+    params:
+      assignees: ["reviewer1", "reviewer2"]
+```
+
+#### `ai_suggest_pr_description`
+Generates AI-powered PR title and description from commits.
+
+#### `prompt_for_pr_title`
+Prompts user for PR title (fallback when AI is rejected).
+
+#### `prompt_for_pr_body`
+Prompts user for PR body/description (fallback when AI is rejected).
+
+### Auto-Assignment Feature
+
+When `auto_assign_prs` is enabled in configuration:
+
+- **Automatic**: PRs are automatically assigned to the creator
+- **Seamless**: No manual action required
+- **Non-blocking**: If assignment fails, the PR is still created successfully
+- **User-friendly**: Shows confirmation message when assigned
+
+**Example output:**
+```
+✅ Pull request #123 created: https://github.com/org/repo/pull/123
+ℹ️  Assigned PR to your-username
+```
+
+**If assignment fails:**
+```
+✅ Pull request #123 created: https://github.com/org/repo/pull/123
+⚠️  Could not auto-assign PR: permission denied
+```
+
+### Manual PR Assignment
+
+You can also assign PRs manually using gh CLI:
+
+```bash
+gh pr edit <pr-number> --add-assignee @me
+```
+
+## Troubleshooting
+
+### gh CLI not authenticated
+
+**Error:**
+```
+❌ Plugin 'github' failed to initialize:
+GitHub CLI is not authenticated. Run: gh auth login
+```
+
+**Solution:**
+```bash
+gh auth login
+```
+
+### GITHUB_TOKEN conflicts
+
+**Error:**
+```
+❌ GITHUB_TOKEN environment variable has invalid token
+```
+
+**Solution:**
+Remove GITHUB_TOKEN from your shell configuration:
+
+```bash
+# Remove from ~/.zshrc or ~/.bashrc
+# Then reload:
+source ~/.zshrc
+```
+
+Or unset in current session:
+```bash
+unset GITHUB_TOKEN
+```
+
+### Multiple gh accounts
+
+**Error:**
+```
+⚠️ gh CLI has authenticated account but it's not active
+```
+
+**Solution:**
+```bash
+gh auth switch
+# Select the account you want to use
+```
+
+### Permission denied for assignment
+
+**Error:**
+```
+⚠️ Could not auto-assign PR: permission denied
+```
+
+**Cause:** Your GitHub token doesn't have `repo` scope.
+
+**Solution:**
+```bash
+gh auth refresh -h github.com -s repo
+```
+
+## Development
+
+Run tests:
+```bash
+cd plugins/titan-plugin-github
+poetry run pytest
+```
+
+## Architecture
+
+### gh CLI Wrapper
+
+This plugin uses `gh CLI` as a wrapper for all GitHub operations:
+
+**Advantages:**
+- ✅ No Python dependencies for GitHub API
+- ✅ OAuth authentication handled by gh CLI
+- ✅ Secure token storage in system keychain
+- ✅ Independent updates from Titan
+- ✅ Complete GitHub API coverage
+
+**See:** [Issue #71](https://github.com/masmovil/titan-cli/issues/71) for detailed discussion on this architectural decision.
+
+## Related Documentation
+
+- [gh CLI Documentation](https://cli.github.com/manual/)
+- [GitHub API Documentation](https://docs.github.com/en/rest)
+- [Titan CLI Documentation](../../README.md)

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/github_client.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/github_client.py
@@ -1033,3 +1033,44 @@ class GitHubClient:
             )
         except GitHubAPIError as e:
             raise GitHubAPIError(msg.GitHub.PR_CREATION_FAILED.format(error=e))
+
+    def assign_pr(self, pr_number: int, assignees: List[str]) -> None:
+        """
+        Assign users to a pull request
+
+        Args:
+            pr_number: PR number
+            assignees: List of GitHub usernames to assign
+                      Use "@me" to assign to current user
+
+        Raises:
+            GitHubAPIError: If assignment fails
+
+        Examples:
+            >>> # Assign to current user
+            >>> client.assign_pr(123, ["@me"])
+
+            >>> # Assign to specific users
+            >>> client.assign_pr(123, ["user1", "user2"])
+
+            >>> # Assign to current user (resolved)
+            >>> current_user = client.get_current_user()
+            >>> client.assign_pr(123, [current_user])
+        """
+        try:
+            args = ["pr", "edit", str(pr_number)]
+
+            # Add each assignee
+            for assignee in assignees:
+                args.extend(["--add-assignee", assignee])
+
+            args.extend(self._get_repo_arg())
+
+            self._run_gh_command(args)
+
+        except GitHubAPIError as e:
+            raise GitHubAPIError(
+                msg.GitHub.API_ERROR.format(
+                    error_msg=f"Failed to assign PR: {e}"
+                )
+            )

--- a/plugins/titan-plugin-github/titan_plugin_github/plugin.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/plugin.py
@@ -113,10 +113,12 @@ class GitHubPlugin(TitanPlugin):
         Returns a dictionary of available workflow steps.
         """
         from .steps.create_pr_step import create_pr_step
+        from .steps.assign_pr_step import assign_pr_step
         from .steps.prompt_steps import prompt_for_pr_title_step, prompt_for_pr_body_step
         from .steps.ai_pr_step import ai_suggest_pr_description
         return {
             "create_pr": create_pr_step,
+            "assign_pr": assign_pr_step,
             "prompt_for_pr_title": prompt_for_pr_title_step,
             "prompt_for_pr_body": prompt_for_pr_body_step,
             "ai_suggest_pr_description": ai_suggest_pr_description,

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/assign_pr_step.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/assign_pr_step.py
@@ -1,0 +1,64 @@
+# plugins/titan-plugin-github/titan_plugin_github/steps/assign_pr_step.py
+from titan_cli.engine import WorkflowContext, WorkflowResult, Success, Error
+from ..exceptions import GitHubAPIError
+
+
+def assign_pr_step(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    Assigns users to a GitHub pull request.
+
+    Requires:
+        ctx.github: An initialized GitHubClient.
+
+    Inputs (from ctx.data):
+        pr_number (int): The PR number to assign.
+        assignees (list[str], optional): List of GitHub usernames to assign.
+                                        If not provided, assigns to current user (@me).
+
+    Returns:
+        Success: If the PR is assigned successfully.
+        Error: If any required context arguments are missing or if the API call fails.
+
+    Examples:
+        # Auto-assign to current user
+        ctx.data["pr_number"] = 123
+        # assignees not provided, defaults to current user
+
+        # Assign to specific users
+        ctx.data["pr_number"] = 123
+        ctx.data["assignees"] = ["user1", "user2"]
+    """
+    # 1. Get GitHub client from context
+    if not ctx.github:
+        return Error("GitHub client is not available in the workflow context.")
+
+    # 2. Get required data from context
+    pr_number = ctx.get("pr_number")
+    if not pr_number:
+        return Error("Missing required context: pr_number")
+
+    # 3. Get assignees (default to current user)
+    assignees = ctx.get("assignees")
+    if not assignees:
+        try:
+            current_user = ctx.github.get_current_user()
+            assignees = [current_user]
+        except Exception as e:
+            return Error(f"Failed to get current user: {e}")
+
+    # 4. Assign the PR
+    try:
+        ctx.github.assign_pr(pr_number, assignees)
+
+        assignee_list = ", ".join(assignees)
+        ctx.ui.text.success(f"Assigned PR #{pr_number} to: {assignee_list}")
+
+        return Success(
+            f"Successfully assigned PR #{pr_number}",
+            metadata={"pr_number": pr_number, "assignees": assignees},
+        )
+
+    except GitHubAPIError as e:
+        return Error(f"Failed to assign PR: {e}")
+    except Exception as e:
+        return Error(f"An unexpected error occurred while assigning PR: {e}")


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Adds automatic PR assignment feature to the GitHub plugin, allowing PRs to be automatically assigned to their creator. Includes a new `auto_assign_prs` configuration option and a reusable `assign_pr` workflow step for manual assignment scenarios.

## 🔧 Changes Made
- Added `assign_pr()` method to GitHubClient for assigning users to PRs via gh CLI
- Implemented `auto_assign_prs` configuration option (default: false)
- Created reusable `assign_pr` workflow step with assignee list support
- Integrated auto-assignment into `create_pr_with_ai` workflow
- Added comprehensive README documentation covering installation, configuration, and usage
- Included troubleshooting guide for common authentication and permission issues

## 🧪 Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published