### PR TITLE
feat(plugins): introduce global and project-level configuration scopes

### DIFF
--- a/titan_cli/core/plugins/models.py
+++ b/titan_cli/core/plugins/models.py
@@ -30,15 +30,43 @@ class JiraPluginConfig(BaseModel):
     Credentials (base_url, email, api_token) should be configured at global level (~/.titan/config.toml).
     Project-specific settings (default_project) can override at project level (.titan/config.toml).
     """
-    base_url: Optional[str] = Field(None, description="JIRA instance URL (e.g., 'https://jira.company.com')")
-    email: Optional[str] = Field(None, description="User email for authentication")
+    base_url: Optional[str] = Field(
+        None,
+        description="JIRA instance URL (e.g., 'https://jira.company.com')",
+        json_schema_extra={"config_scope": "global"}
+    )
+    email: Optional[str] = Field(
+        None,
+        description="User email for authentication",
+        json_schema_extra={"config_scope": "global"}
+    )
     # api_token is stored in secrets, not in config.toml
     # It appears in the JSON schema for interactive configuration but is optional in the model
-    api_token: Optional[str] = Field(None, description="JIRA API token (Personal Access Token)", json_schema_extra={"format": "password", "required_in_schema": True})
-    default_project: Optional[str] = Field(None, description="Default JIRA project key (e.g., 'ECAPP', 'PROJ')")
-    timeout: int = Field(30, description="Request timeout in seconds")
-    enable_cache: bool = Field(True, description="Enable caching for API responses")
-    cache_ttl: int = Field(300, description="Cache time-to-live in seconds")
+    api_token: Optional[str] = Field(
+        None,
+        description="JIRA API token (Personal Access Token)",
+        json_schema_extra={"format": "password", "required_in_schema": True}
+    )
+    default_project: Optional[str] = Field(
+        None,
+        description="Default JIRA project key (e.g., 'ECAPP', 'PROJ')",
+        json_schema_extra={"config_scope": "project"}
+    )
+    timeout: int = Field(
+        30,
+        description="Request timeout in seconds",
+        json_schema_extra={"config_scope": "global"}
+    )
+    enable_cache: bool = Field(
+        True,
+        description="Enable caching for API responses",
+        json_schema_extra={"config_scope": "global"}
+    )
+    cache_ttl: int = Field(
+        300,
+        description="Cache time-to-live in seconds",
+        json_schema_extra={"config_scope": "global"}
+    )
 
     @field_validator('base_url')
     @classmethod

--- a/titan_cli/core/plugins/plugin_registry.py
+++ b/titan_cli/core/plugins/plugin_registry.py
@@ -20,10 +20,19 @@ class PluginRegistry:
         logger = logging.getLogger('titan_cli.ui.tui.screens.project_setup_wizard')
 
         discovered = entry_points(group='titan.plugins')
-        self._discovered_plugin_names = [ep.name for ep in discovered]
+
+        # Deduplicate entry points (can happen in dev mode with editable installs)
+        seen = {}
+        unique_eps = []
+        for ep in discovered:
+            if ep.name not in seen:
+                seen[ep.name] = ep
+                unique_eps.append(ep)
+
+        self._discovered_plugin_names = [ep.name for ep in unique_eps]
         logger.debug(f"PluginRegistry.discover() - Found {len(self._discovered_plugin_names)} plugins: {self._discovered_plugin_names}")
 
-        for ep in discovered:
+        for ep in unique_eps:
             try:
                 logger.debug(f"Loading plugin: {ep.name}")
                 plugin_class = ep.load()


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This pull request introduces a distinction between global and project-level configurations for plugins. Previously, all plugin settings were saved to the project's local `config.toml`. This change allows user-specific settings (like API credentials and base URLs) to be saved globally in `~/.titan/config.toml`, while project-specific settings remain in the project's `.titan/config.toml`, improving configuration management and user experience.

## 🔧 Changes Made
- **`JiraPluginConfig` Model:** Added `config_scope` metadata to Pydantic model fields to declare whether a setting is `global` or `project`.
- **`PluginConfigWizardScreen`:** Updated the configuration wizard to read the `config_scope` metadata. It now intelligently separates settings and writes them to the appropriate global or project configuration file.
- **`PluginRegistry`:** Added deduplication for discovered plugin entry points to prevent issues in development environments with editable installs.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published