### PR TITLE
chore(release): Revert project version to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "titan-cli"
-version = "0.1.5"
+version = "0.1.4"
 description = "Modular development tools orchestrator - Streamline your workflows with AI integration and intuitive terminal UI"
 authors = ["finxo <finxeto@gmail.com>", "r-pedraza <raulpedrazaleon@gmail.com>"]
 maintainers = ["r-pedraza <raulpedrazaleon@gmail.com>"]


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This pull request reverts the project version in `pyproject.toml` from `0.1.5` back to `0.1.4`. This is a corrective measure to fix an incorrect version tag that was pushed prematurely.

## 🔧 Changes Made
- Updated `pyproject.toml` to set the project `version` back to `0.1.4`.

## 🧪 Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed (Verified build process recognizes the correct version)
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published