### PR TITLE
fix(workflows): Ensure build and tests pass before creating GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: publish-pypi
+    needs: [build-and-test, publish-pypi]
     permissions:
       contents: write  # Only for creating tags and releases
 


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This pull request corrects a potential issue in the release workflow. It ensures that the `create-github-release` job only runs after the `build-and-test` job has successfully completed, preventing releases from being created for code that fails tests or doesn't build.

## 🔧 Changes Made
- Updated the `.github/workflows/release.yml` file.
- Added `build-and-test` to the `needs` array for the `create-github-release` job, making it a required prerequisite.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed (Verified workflow logic; the fix will be confirmed on the next release execution)
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published