### PR TITLE
feat(ui): Add option to hide icon in panel widgets

### DIFF
--- a/titan_cli/ui/tui/textual_components.py
+++ b/titan_cli/ui/tui/textual_components.py
@@ -201,19 +201,21 @@ class TextualComponents:
             # App is closing or worker was cancelled
             pass
 
-    def panel(self, text: str, panel_type: str = "info") -> None:
+    def panel(self, text: str, panel_type: str = "info", show_icon: bool = True) -> None:
         """
         Show a panel with consistent styling.
 
         Args:
             text: Text to display in the panel
             panel_type: Type of panel - "info", "success", "warning", or "error"
+            show_icon: Whether to show the type icon (default: True)
 
         Example:
             ctx.textual.panel("Operation completed successfully!", panel_type="success")
             ctx.textual.panel("Warning: This action cannot be undone", panel_type="warning")
+            ctx.textual.panel("Info without icon", panel_type="info", show_icon=False)
         """
-        panel_widget = Panel(text=text, panel_type=panel_type)
+        panel_widget = Panel(text=text, panel_type=panel_type, show_icon=show_icon)
         self.mount(panel_widget)
 
     def dim_text(self, text: str) -> None:

--- a/titan_cli/ui/tui/widgets/panel.py
+++ b/titan_cli/ui/tui/widgets/panel.py
@@ -51,17 +51,19 @@ class Panel(Widget):
     }
     """
 
-    def __init__(self, text: str, panel_type: str = "info", **kwargs):
+    def __init__(self, text: str, panel_type: str = "info", show_icon: bool = True, **kwargs):
         """
         Initialize panel.
 
         Args:
             text: Text to display
             panel_type: Type of panel (info, success, warning, error)
+            show_icon: Whether to show the icon (default: True)
         """
         super().__init__(**kwargs)
         self.text = text
         self.panel_type = panel_type
+        self.show_icon = show_icon
 
         # Add CSS class based on type
         self.add_class(panel_type)
@@ -77,5 +79,12 @@ class Panel(Widget):
         }
 
         icon = icons.get(self.panel_type, Icons.INFO)
+
+        # Format text with or without icon
+        if self.show_icon and icon:
+            text = f"{icon} {self.text}"
+        else:
+            text = self.text
+
         with Container():
-            yield Label(f"{icon} {self.text}")
+            yield Label(text)

--- a/titan_cli/ui/tui/widgets/prompt_selection_list.py
+++ b/titan_cli/ui/tui/widgets/prompt_selection_list.py
@@ -96,7 +96,7 @@ class PromptSelectionList(Widget):
         yield BoldText(self.question)
 
         # Instructions
-        yield DimText("↑/↓: Navegar  │  Space: Seleccionar/Deseleccionar  │  Enter: Continuar")
+        yield DimText("↑/↓: Navigate  │  Space: Select/Deselect  │  Enter: Continue")
 
         # Create Selection objects for SelectionList
         selections = [


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR introduces a new feature allowing the icon in `Panel` widgets to be hidden. This provides greater flexibility for displaying informational messages where an icon might be unnecessary. A minor UI text correction is also included.

## 🔧 Changes Made
- Added a `show_icon: bool` parameter to the `TextualComponents.panel` method and the `Panel` widget.
- Updated the `Panel` widget to conditionally render its icon based on the `show_icon` flag.
- Updated method docstrings with the new parameter and usage examples.
- Corrected instructional text in the `PromptSelectionList` widget from Spanish to English.

## 🧪 Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published