### PR TITLE
feat(ai): Add dynamic model fetching from LLM Tools in config wizard

### DIFF
--- a/titan_cli/ai/llm_tools.py
+++ b/titan_cli/ai/llm_tools.py
@@ -1,0 +1,115 @@
+"""
+LLM Tools API client for fetching available models.
+
+This module provides utilities to detect and interact with LLM Tools
+(LiteLLM) endpoints for dynamically fetching available AI models.
+"""
+import requests
+from typing import List, Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class LLMModel:
+    """Model information from LLM Tools API."""
+
+    id: str
+    name: str
+    description: Optional[str] = None
+
+def is_llm_tools_url(base_url: str) -> bool:
+    """
+    Check if a base_url is an LLM Tools endpoint.
+
+    Args:
+        base_url: The base URL to check
+
+    Returns:
+        True if URL contains llm.tools pattern
+
+    Examples:
+        >>> is_llm_tools_url("https://llm.tools.example.com")
+        True
+        >>> is_llm_tools_url("https://api.anthropic.com")
+        False
+    """
+    if not base_url:
+        return False
+    return "llm.tools" in base_url.lower()
+
+
+def fetch_available_models(
+    base_url: str,
+    api_key: str,
+    provider_filter: Optional[str] = None,
+) -> List[LLMModel]:
+    """
+    Fetch available models from LLM Tools API (LiteLLM format).
+
+    The API uses OpenAI-compatible format and returns a list of available
+    models with their metadata.
+
+    Args:
+        base_url: LLM Tools endpoint URL
+        api_key: API key for authentication (required)
+        provider_filter: Filter by provider ("anthropic" or "gemini")
+
+    Returns:
+        List of available models filtered by provider
+
+    Raises:
+        requests.RequestException: If API call fails
+        ValueError: If api_key is not provided
+
+    Examples:
+        >>> models = fetch_available_models(
+        ...     "https://llm.tools.example.com",
+        ...     "sk-1234",
+        ...     provider_filter="anthropic"
+        ... )
+        >>> len(models) > 0
+        True
+    """
+    if not api_key:
+        raise ValueError("API key is required to fetch models from LLM Tools")
+
+    # LiteLLM uses OpenAI-compatible endpoint
+    endpoint = f"{base_url.rstrip('/')}/v1/models"
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    response = requests.get(endpoint, headers=headers, timeout=10)
+    response.raise_for_status()
+
+    data = response.json()
+
+    # Parse OpenAI-compatible response
+    models = []
+    for model_data in data.get("data", []):
+        model_id = model_data.get("id", "")
+        owned_by = model_data.get("owned_by", "").lower()
+
+        # Filter by provider if specified
+        # Note: LLM Tools API doesn't use owned_by correctly, so we filter by model name
+        if provider_filter:
+            model_id_lower = model_id.lower()
+
+            # Filter by model name pattern
+            if provider_filter == "anthropic":
+                # Only include models with "claude" in the name
+                if "claude" not in model_id_lower:
+                    continue
+            elif provider_filter == "gemini":
+                # Only include models with "gemini" in the name
+                if "gemini" not in model_id_lower:
+                    continue
+
+        models.append(
+            LLMModel(
+                id=model_id,
+                name=model_id,  # LiteLLM doesn't provide display name
+                description=f"Provider: {owned_by}",
+            )
+        )
+
+    return models

--- a/titan_cli/ui/tui/screens/ai_config.py
+++ b/titan_cli/ui/tui/screens/ai_config.py
@@ -494,5 +494,9 @@ class AIConfigScreen(BaseScreen):
             self.app.notify(f"Failed to delete provider: {e}", severity="error")
 
     def action_back(self) -> None:
-        """Go back to main menu."""
-        self.app.pop_screen()
+        """Go back to main menu (ESC key)."""
+        self.dismiss()
+
+    def action_go_back(self) -> None:
+        """Go back to main menu (Back button)."""
+        self.dismiss()

--- a/titan_cli/ui/tui/screens/base.py
+++ b/titan_cli/ui/tui/screens/base.py
@@ -101,6 +101,19 @@ class BaseScreen(Screen):
         status_bar.ai_info = ai_info
         status_bar.project_name = project_name
 
+    def on_resume(self) -> None:
+        """Called when screen is resumed (e.g., after another screen is dismissed)."""
+        # Refresh status bar with latest config values
+        if self.show_status_bar:
+            try:
+                # Reload config from disk to get latest changes
+                self.config.load()
+
+                status_bar = self.query_one("#status-bar", StatusBarWidget)
+                self._update_status_bar(status_bar)
+            except Exception:
+                pass  # Status bar might not be mounted yet
+
     def on_header_widget_back_pressed(self, message: HeaderWidget.BackPressed) -> None:
         """Handle back button press from header."""
         self.action_go_back()

--- a/titan_cli/ui/tui/screens/main_menu.py
+++ b/titan_cli/ui/tui/screens/main_menu.py
@@ -10,6 +10,7 @@ from textual.widgets.option_list import Option
 from textual.containers import Container
 
 from titan_cli.ui.tui.icons import Icons
+from titan_cli.ui.tui.widgets import StatusBarWidget
 from .base import BaseScreen
 
 from .cli_launcher import CLILauncherScreen
@@ -151,7 +152,19 @@ class MainMenuScreen(BaseScreen):
 
     def handle_ai_config_action(self) -> None:
         """Handle AI Configuration action."""
-        self.app.push_screen(AIConfigScreen(self.config))
+        def on_ai_config_closed(result) -> None:
+            """Callback when AI config screen is closed."""
+            # Refresh status bar with latest config
+            try:
+                # Reload config from disk
+                self.config.load()
+
+                status_bar = self.query_one("#status-bar", StatusBarWidget)
+                self._update_status_bar(status_bar)
+            except Exception as e:
+                self.app.notify(f"Error refreshing status bar: {e}", severity="error")
+
+        self.app.push_screen(AIConfigScreen(self.config), callback=on_ai_config_closed)
 
     def handle_switch_project_action(self) -> None:
         """Handle Switch Project action."""

--- a/titan_cli/ui/tui/widgets/styled_option_list.py
+++ b/titan_cli/ui/tui/widgets/styled_option_list.py
@@ -54,6 +54,13 @@ class StyledOptionList(OptionList):
         option_list = StyledOptionList(*options)
     """
 
+    DEFAULT_CSS = """
+    StyledOptionList > .option-list--option {
+        padding: 1 2;
+        margin-bottom: 1;
+    }
+    """
+
     def __init__(self, *options: StyledOption, **kwargs):
         """
         Initialize StyledOptionList with styled options.
@@ -105,3 +112,20 @@ class StyledOptionList(OptionList):
         # Add new options
         for opt in options:
             self.add_styled_option(opt)
+
+    def get_selected_id(self) -> str | None:
+        """
+        Get the ID of the currently highlighted option.
+
+        Returns:
+            The ID of the highlighted option, or None if nothing is highlighted
+        """
+        if self.highlighted is None:
+            return None
+
+        # Get the highlighted option
+        option = self.get_option_at_index(self.highlighted)
+        if option is None:
+            return None
+
+        return option.id


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This pull request introduces a feature to dynamically fetch available AI models within the configuration wizard. When a user is setting up a "Corporate" provider that uses an LLM Tools (LiteLLM) compatible endpoint, the wizard will now automatically query the API for a list of models, improving the user experience by eliminating the need for manual model name entry.

## 🔧 Changes Made
- **New `llm_tools` Module:** A new module, `titan_cli/ai/llm_tools.py`, has been created to interact with LLM Tools endpoints. It includes a function `fetch_available_models` to retrieve models from the OpenAI-compatible `/v1/models` endpoint.
- **Enhanced Configuration Wizard:** The `AIConfigWizardScreen` is updated to integrate this new capability.
    - The wizard step order is adjusted to collect the API key *before* the model selection step, which is necessary for authenticated API calls.
    - Logic has been added to detect LLM Tools URLs and trigger the dynamic model fetching process.
    - The UI now displays a loading indicator while fetching, presents the models in a selectable list, and gracefully handles errors or empty results by falling back to manual input.
- **UI Refinements:** Minor refactoring in `AIConfigScreen` to use `self.dismiss()` for consistent screen navigation.

## 🧪 Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
    - Verified the wizard correctly identifies LLM Tools URLs.
    - Tested the model fetching flow with a valid endpoint and API key.
    - Confirmed the UI correctly displays fetched models.
    - Ensured the wizard falls back to manual input on API failure or when no models are found.
- [ ] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published