### PR TITLE
feat: Verify installed version and simplify relaunch command

### DIFF
--- a/titan_cli/cli.py
+++ b/titan_cli/cli.py
@@ -50,17 +50,17 @@ def main(ctx: typer.Context):
                     result = perform_update()
 
                     if result["success"]:
-                        typer.echo(f"✅ Successfully updated to v{latest} using {result['method']}")
+                        installed_version = result.get("installed_version", latest)
+                        typer.echo(f"✅ Successfully updated to v{installed_version} using {result['method']}")
                         typer.echo("🔄 Relaunching Titan with new version...")
                         typer.echo()
 
-                        # Relaunch titan using subprocess
-                        # Note: sys.executable and sys.argv are controlled by the Python runtime,
-                        # not user input, so this is safe from command injection
+                        # Relaunch titan
+                        # Use 'titan' command directly (works for both pipx and pip)
                         subprocess.run(
-                            [sys.executable, "-m", "titan_cli.cli"] + sys.argv[1:],
-                            shell=False,  # Explicitly disable shell to prevent injection
-                            check=False   # Don't raise on non-zero exit
+                            ["titan"] + sys.argv[1:],
+                            shell=False,
+                            check=False
                         )
                         raise typer.Exit(0)
                     else:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This pull request enhances the reliability of the CLI's auto-update feature. It introduces a verification step to confirm the version actually installed after an update, providing more accurate feedback to the user. Additionally, it simplifies the application relaunch logic to be more robust across different installation methods (pip vs. pipx).

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Refactored `perform_update` to capture subprocess output and verify success by checking the newly installed version.
- Added helper functions (`_get_installed_version_pipx`, `_get_installed_version_pip`) to query the installed package version.
- Modified the success message to display the verified installed version rather than assuming the latest version was installed.
- Simplified the relaunch command to `titan` which works reliably for both `pipx` and standard `pip` installations.
- Added timeouts to `subprocess` calls to prevent the update process from hanging indefinitely.

## 🧪 Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

Manual testing was conducted to verify the update flow for both `pipx` and `pip` installations. The process was tested for successful updates, failed updates, and timeouts.

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published