### PR TITLE
fix: Provide helpful guidance for common PR creation failures

### DIFF
--- a/plugins/titan-plugin-github/titan_plugin_github/steps/create_pr_step.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/create_pr_step.py
@@ -99,7 +99,20 @@ def create_pr_step(ctx: WorkflowContext) -> WorkflowResult:
             metadata={"pr_number": pr["number"], "pr_url": pr["url"]},
         )
     except GitHubAPIError as e:
-        ctx.textual.error_text(f"Failed to create pull request: {e}")
+        error_msg = str(e)
+
+        # Check for common errors and provide helpful guidance
+        if "No commits between" in error_msg or "Head sha can't be blank" in error_msg:
+            ctx.textual.error_text(f"Failed to create pull request: {e}")
+            ctx.textual.text("")
+            ctx.textual.warning_text("💡 The branch might not be pushed to the remote repository.")
+            ctx.textual.text("")
+            ctx.textual.dim_text("To fix this, push your branch and try again:")
+            ctx.textual.dim_text(f"  git push -u origin {head}")
+            ctx.textual.text("")
+        else:
+            ctx.textual.error_text(f"Failed to create pull request: {e}")
+
         ctx.textual.end_step("error")
         return Error(f"Failed to create pull request: {e}")
     except Exception as e:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR improves the user experience when creating a pull request fails due to a common, correctable error. Specifically, it detects when a user tries to create a PR from a branch that has not yet been pushed to the remote repository. In this scenario, it now provides helpful guidance and the exact command to resolve the issue.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Updated the error handling logic within the `create_pr_step` function.
- Added a check for specific GitHub API error messages ("No commits between..." or "Head sha can't be blank").
- When these errors are detected, a user-friendly warning is displayed along with the `git push` command needed to fix the problem.
- For all other API errors, the original error-handling behavior is preserved.

## 🧪 Testing
<!-- How has this been tested? -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published