### PR TITLE
docs: Add development setup guide for parallel workflow

### DIFF
--- a/.claude/docs/development-setup.md
+++ b/.claude/docs/development-setup.md
@@ -1,0 +1,410 @@
+# Development Setup Guide
+
+> **Audience:** Contributors and developers working on Titan CLI codebase
+
+> **For end users:** See [README.md](../../README.md) for installation instructions
+
+---
+
+## 🎯 Overview
+
+When developing Titan CLI, you can run two versions side-by-side:
+
+- **`titan`** - Production version (stable release from PyPI via `pipx install titan-cli`)
+- **`titan-dev`** - Development version (your local codebase)
+
+**Important:** The `titan-dev` command is **only for contributors** who clone the repository. It is NOT included in the PyPI package and is NOT available to end users.
+
+This setup allows you to:
+- Use stable `titan` for your daily work
+- Test changes with `titan-dev` without breaking your workflow
+- Switch between versions easily
+
+---
+
+## 📊 Command Availability
+
+| Command | End Users (PyPI) | Contributors (Repo) | How to Get |
+|---------|-----------------|---------------------|------------|
+| `titan` | ✅ Available | ✅ Available (optional) | `pipx install titan-cli` |
+| `titan-dev` | ❌ Not available | ✅ Available | `make dev-install` (repo only) |
+
+**Key points:**
+- ✅ `titan` is the production command, available to everyone via PyPI
+- ✅ `titan-dev` is ONLY for contributors who clone the repository
+- ❌ `titan-dev` is NOT included in the PyPI package
+- ⚠️ Both commands share the same config (`~/.titan/config.toml`)
+
+### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         END USERS (PyPI)                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  $ pipx install titan-cli                                      │
+│                                                                 │
+│  ~/.local/bin/titan ──────┐                                    │
+│                           │                                     │
+│                           ▼                                     │
+│            ~/.local/share/pipx/venvs/titan-cli/bin/titan       │
+│                                                                 │
+│  ✅ Can use: titan                                             │
+│  ❌ Cannot use: titan-dev (doesn't exist)                      │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────┐
+│                    CONTRIBUTORS (Repository)                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  $ git clone https://github.com/masorange/titan-cli.git       │
+│  $ cd titan-cli                                                │
+│  $ make dev-install                                            │
+│                                                                 │
+│  ~/.local/bin/titan-dev ──────┐                               │
+│                               │                                 │
+│                               ▼                                 │
+│                  ~/git/titan-cli/.venv/bin/titan               │
+│                               │                                 │
+│                               ▼                                 │
+│                  ~/git/titan-cli/titan_cli/  (source code)     │
+│                                                                 │
+│  Optional (if also installed for daily use):                   │
+│  ~/.local/bin/titan ─────> pipx installation                   │
+│                                                                 │
+│  ✅ Can use: titan-dev (local changes)                         │
+│  ✅ Can use: titan (stable, optional)                          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 📦 Installation
+
+### Prerequisites
+
+- Python 3.10+
+- `pipx` (recommended) or `pip`
+- `poetry` (for dependency management)
+
+```bash
+# Install pipx if not already installed
+python3 -m pip install --user pipx
+python3 -m pipx ensurepath
+
+# Install poetry
+pipx install poetry
+```
+
+### 1️⃣ Production Installation (Optional)
+
+Install the stable version from PyPI:
+
+```bash
+pipx install titan-cli
+```
+
+Verify:
+```bash
+titan --version
+```
+
+**Where it lives:**
+- Binary: `~/.local/bin/titan` → `~/.local/share/pipx/venvs/titan-cli/bin/titan`
+- Config: `~/.titan/config.toml`
+- State: `~/.local/state/titan/` (logs, cache)
+
+### 2️⃣ Development Installation (Required)
+
+Clone the repository and set up the development environment:
+
+```bash
+# 1. Clone repository
+git clone https://github.com/masorange/titan-cli.git
+cd titan-cli
+
+# 2. Install dependencies with Poetry
+poetry install
+
+# 3. Create titan-dev launcher (automated)
+make dev-install
+
+# OR manually create the script:
+cat > ~/.local/bin/titan-dev <<'EOF'
+#!/bin/bash
+# titan-dev - Development version of Titan CLI
+REPO_PATH="$HOME/git/titan-cli"  # Adjust to your clone path
+exec "$REPO_PATH/.venv/bin/titan" "$@"
+EOF
+chmod +x ~/.local/bin/titan-dev
+
+# 4. Verify installation
+titan-dev --version
+```
+
+**Where it lives:**
+- Source: `~/git/titan-cli/` (or your clone location)
+- Virtualenv: `~/git/titan-cli/.venv/`
+- Binary: `~/.local/bin/titan-dev` (wrapper script)
+- Config: `./.titan/config.toml` (in each project)
+
+---
+
+## 🔧 Development Workflow
+
+### Running Titan in Development Mode
+
+```bash
+# Option 1: Use titan-dev alias (recommended)
+titan-dev
+
+# Option 2: Use poetry run
+cd ~/git/titan-cli
+poetry run titan
+
+# Option 3: Activate virtualenv and run directly
+cd ~/git/titan-cli
+poetry shell
+titan
+```
+
+### Development vs Production Separation
+
+**Key differences:**
+
+| Aspect | Production (`titan`) | Development (`titan-dev`) |
+|--------|---------------------|---------------------------|
+| **Command** | `titan` | `titan-dev` |
+| **Source** | Installed package | Local codebase |
+| **Updates** | `pipx upgrade titan-cli` | `git pull` |
+| **Plugins** | Installed separately | Included in repo |
+| **Config** | `~/.titan/config.toml` | Uses same config |
+| **Logs** | `~/.local/state/titan/logs/` | Same location |
+
+**IMPORTANT:** Both versions share the same configuration directory (`~/.titan/`) and project configs (`./.titan/`). Be careful when testing breaking config changes.
+
+### Recommended Setup for Development
+
+1. **Use separate test projects** for development:
+   ```bash
+   mkdir ~/titan-test-projects
+   cd ~/titan-test-projects
+   git clone <some-test-repo>
+   cd <test-repo>
+   titan-dev  # Test your changes here
+   ```
+
+2. **Keep production titan for real work**:
+   ```bash
+   cd ~/work/production-project
+   titan  # Use stable version for critical work
+   ```
+
+---
+
+## 🧪 Testing Changes
+
+### Quick Test Loop
+
+```bash
+# 1. Make changes to code
+vim ~/git/titan-cli/titan_cli/some_file.py
+
+# 2. Test immediately (no reinstall needed with poetry)
+titan-dev
+
+# 3. Run unit tests
+cd ~/git/titan-cli
+poetry run pytest
+
+# 4. Run specific plugin tests
+poetry run pytest plugins/titan-plugin-git/tests/
+```
+
+### Testing with Different Environments
+
+**Test with different Python versions:**
+```bash
+# Use pyenv to switch Python versions
+pyenv install 3.10.0
+pyenv local 3.10.0
+poetry env use 3.10.0
+poetry install
+```
+
+**Test with fresh config:**
+```bash
+# Temporarily rename your config
+mv ~/.titan ~/.titan.backup
+titan-dev  # Will run first-time setup
+
+# Restore when done
+rm -rf ~/.titan
+mv ~/.titan.backup ~/.titan
+```
+
+---
+
+## 🔍 Debugging
+
+### Development Mode Logging
+
+Enable verbose logging for debugging:
+
+```bash
+# When logging architecture is implemented:
+titan-dev --debug
+titan-dev --verbose
+TITAN_DEBUG=1 titan-dev
+```
+
+**Future:** When logging is implemented (see architecture proposal), logs will be at:
+- `~/.local/state/titan/logs/titan.log` (JSON, rotating)
+- Console (colorized when `--verbose` or `--debug`)
+
+### Textual Devtools (TUI Debugging)
+
+For debugging the Textual TUI:
+
+```bash
+# Terminal 1: Start devtools console
+textual console
+
+# Terminal 2: Run titan-dev
+cd ~/git/titan-cli
+textual run --dev titan_cli/ui/tui/textual_workflow_executor.py TitanApp
+
+# Logs will appear in Terminal 1
+```
+
+See: [Textual Devtools Guide](https://textual.textualize.io/guide/devtools/)
+
+---
+
+## 📁 Project Structure (Development)
+
+```
+~/git/titan-cli/                    # Development repository
+├── .venv/                          # Poetry virtualenv
+│   └── bin/titan                   # Development binary
+├── titan_cli/                      # Main package
+├── plugins/                        # Built-in plugins
+│   ├── titan-plugin-git/
+│   ├── titan-plugin-github/
+│   └── titan-plugin-jira/
+├── tests/                          # Unit tests
+├── .claude/                        # Claude Code docs
+├── pyproject.toml                  # Poetry config
+└── poetry.lock                     # Locked dependencies
+
+~/.local/bin/
+├── titan -> ~/.local/share/pipx/venvs/titan-cli/bin/titan  # Production
+└── titan-dev                       # Development wrapper script
+
+~/.titan/
+└── config.toml                     # Global config (shared)
+
+~/.local/state/titan/               # Runtime data (future)
+└── logs/
+    └── titan.log                   # Application logs
+```
+
+---
+
+## 🚀 Releasing Changes
+
+### Development to Production Flow
+
+```bash
+# 1. Develop and test with titan-dev
+titan-dev  # Test your changes
+
+# 2. Run full test suite
+cd ~/git/titan-cli
+poetry run pytest
+poetry run pytest --cov
+
+# 3. Update version in pyproject.toml
+# Follow semantic versioning
+
+# 4. Create release (maintainers only)
+git tag v0.1.12
+git push origin v0.1.12
+
+# 5. Build and publish (CI/CD or manual)
+poetry build
+poetry publish
+
+# 6. Upgrade production version
+pipx upgrade titan-cli
+```
+
+---
+
+## 🛠️ Troubleshooting
+
+### `titan-dev` not found
+
+```bash
+# Check if script exists
+ls -la ~/.local/bin/titan-dev
+
+# If not, create it manually
+make dev-install
+
+# Ensure ~/.local/bin is in PATH
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+### Changes not reflected in `titan-dev`
+
+```bash
+# Ensure you're using editable install
+cd ~/git/titan-cli
+poetry install
+
+# Verify virtualenv is active
+which titan-dev
+# Should show: ~/.local/bin/titan-dev
+
+titan-dev --version
+# Should show version from pyproject.toml
+```
+
+### Plugin changes not working
+
+```bash
+# Plugins are editable by default in Poetry
+# Verify in pyproject.toml:
+#   [tool.poetry.group.dev.dependencies]
+#   titan-plugin-git = {path = "plugins/titan-plugin-git", develop = true}
+
+# If needed, reinstall plugins
+cd ~/git/titan-cli
+poetry install
+```
+
+### Want to test a specific branch
+
+```bash
+cd ~/git/titan-cli
+git checkout feature/my-feature
+poetry install  # Reinstall deps if changed
+titan-dev  # Now uses the feature branch
+```
+
+---
+
+## 📚 Related Documentation
+
+- [CLAUDE.md](../../CLAUDE.md) - AI development guide
+- [DEVELOPMENT.md](../../DEVELOPMENT.md) - Architecture overview
+- [Plugin Architecture](.claude/docs/plugin-architecture.md) - Plugin development
+- [Textual Guide](.claude/docs/textual.md) - TUI development
+
+---
+
+**Last updated:** 2026-02-17

--- a/.claude/docs/development-vs-production.md
+++ b/.claude/docs/development-vs-production.md
@@ -1,0 +1,258 @@
+# Development vs Production: Understanding `titan` vs `titan-dev`
+
+> Quick reference for contributors
+
+---
+
+## 🎯 TL;DR
+
+- **End users:** Install with `pipx install titan-cli` → Get `titan` command only
+- **Contributors:** Clone repo + `make dev-install` → Get both `titan` (production) and `titan-dev` (development)
+
+---
+
+## 📦 What Gets Installed Where
+
+### End Users (PyPI Installation)
+
+```bash
+pipx install titan-cli
+```
+
+**What they get:**
+```
+~/.local/bin/titan → ~/.local/share/pipx/venvs/titan-cli/bin/titan
+```
+
+**Defined in:** `pyproject.toml`
+```toml
+[tool.poetry.scripts]
+titan = "titan_cli.cli:app"  # ✅ Only titan, no titan-dev
+```
+
+**They can only use:** `titan`
+
+---
+
+### Contributors (Repository Clone)
+
+```bash
+git clone https://github.com/masorange/titan-cli.git
+cd titan-cli
+make dev-install
+```
+
+**What they get:**
+```
+~/.local/bin/titan     → pipx installation (optional, production version)
+~/.local/bin/titan-dev → bash script → ~/git/titan-cli/.venv/bin/titan
+~/git/titan-cli/.venv/ → poetry virtualenv with editable install
+```
+
+**The titan-dev script content:**
+```bash
+#!/bin/bash
+# titan-dev - Development version of Titan CLI
+exec /home/alex/git/titan-cli/.venv/bin/titan "$@"
+```
+
+**They can use:** Both `titan` (stable) and `titan-dev` (local changes)
+
+---
+
+## 🔒 Security: Ensuring titan-dev Stays Local
+
+### ✅ What We Do Right
+
+1. **Not in pyproject.toml scripts:**
+   ```toml
+   [tool.poetry.scripts]
+   titan = "titan_cli.cli:app"  # ✅ Only titan
+   # NO titan-dev here
+   ```
+
+2. **Created only by Makefile:**
+   - `make dev-install` creates `~/.local/bin/titan-dev`
+   - This target is NOT run during `poetry build` or `poetry publish`
+   - Script is never part of the distributed package
+
+3. **Not in .gitignore:**
+   - The script lives in `~/.local/bin/`, not in the repo
+   - Nothing to accidentally commit
+
+4. **Clear documentation:**
+   - README.md clearly separates "For Users" vs "For Contributors"
+   - DEVELOPMENT.md explicitly states it's for contributors only
+   - This guide explains the architecture
+
+### ❌ What Would Be Wrong
+
+```toml
+# DON'T DO THIS:
+[tool.poetry.scripts]
+titan = "titan_cli.cli:app"
+titan-dev = "titan_cli.cli:app"  # ❌ Would ship to all users!
+```
+
+---
+
+## 🧪 Testing the Separation
+
+### Test 1: Fresh PyPI Install (Simulating End User)
+
+```bash
+# In a different machine or clean environment
+pipx install titan-cli
+
+# Should work:
+titan --version  # ✅ Works
+
+# Should NOT work:
+titan-dev --version  # ❌ Command not found
+```
+
+### Test 2: Development Install (Contributor)
+
+```bash
+# Clone and setup
+git clone https://github.com/masorange/titan-cli.git
+cd titan-cli
+make dev-install
+
+# Both should work:
+titan --version      # ✅ Production (if installed)
+titan-dev --version  # ✅ Development
+```
+
+### Test 3: Build and Check Package
+
+```bash
+# Build the package
+cd ~/git/titan-cli
+poetry build
+
+# Extract and check
+cd dist
+tar -tzf titan_cli-0.1.11.tar.gz | grep bin
+# Should NOT contain any bin/titan-dev
+
+# Check wheel
+unzip -l titan_cli-0.1.11-py3-none-any.whl | grep scripts
+# Should only list titan, not titan-dev
+```
+
+---
+
+## 🔄 Development Workflow
+
+### Making Changes
+
+```bash
+# 1. Edit code
+vim ~/git/titan-cli/titan_cli/some_file.py
+
+# 2. Test immediately (no reinstall needed)
+titan-dev
+
+# Changes are reflected immediately because:
+# - Poetry installs in editable mode (-e flag)
+# - titan-dev points to .venv/bin/titan
+# - .venv/bin/titan uses the source code directly
+```
+
+### Releasing to Production
+
+```bash
+# 1. Bump version in pyproject.toml
+vim pyproject.toml  # Update version = "0.1.12"
+
+# 2. Build package
+poetry build
+
+# 3. Publish to PyPI
+poetry publish
+
+# 4. Users update
+pipx upgrade titan-cli
+
+# They ONLY get 'titan' command, never 'titan-dev'
+```
+
+---
+
+## 📁 File Locations Summary
+
+### End User Installation
+
+| What | Location |
+|------|----------|
+| Binary | `~/.local/bin/titan` → `~/.local/share/pipx/venvs/titan-cli/bin/titan` |
+| Config | `~/.titan/config.toml` |
+| Project config | `./.titan/config.toml` (in each project) |
+| Logs (future) | `~/.local/state/titan/logs/` |
+
+### Development Installation
+
+| What | Location |
+|------|----------|
+| Source code | `~/git/titan-cli/` (or wherever cloned) |
+| Virtualenv | `~/git/titan-cli/.venv/` |
+| Dev binary | `~/.local/bin/titan-dev` (bash wrapper script) |
+| Config | Same as end user (`~/.titan/config.toml`) ⚠️ |
+| Project config | Same as end user (`./.titan/config.toml`) ⚠️ |
+
+**⚠️ Warning:** Both `titan` and `titan-dev` share the same configuration files. Be careful when testing breaking config changes.
+
+---
+
+## 🚨 Common Mistakes to Avoid
+
+### ❌ Mistake 1: Adding titan-dev to pyproject.toml
+
+```toml
+# WRONG:
+[tool.poetry.scripts]
+titan-dev = "titan_cli.cli:app"  # ❌ Ships to all users!
+```
+
+### ❌ Mistake 2: Committing the titan-dev script to repo
+
+```bash
+# WRONG:
+git add ~/.local/bin/titan-dev  # ❌ Lives outside repo
+```
+
+### ❌ Mistake 3: Documenting titan-dev in README without warning
+
+```markdown
+# WRONG in README.md:
+Run `titan-dev` to start the application.
+# ❌ End users don't have titan-dev!
+```
+
+### ✅ Correct: Separate documentation
+
+- **README.md**: Only mentions `titan` for end users
+- **DEVELOPMENT.md**: Explains `titan-dev` for contributors
+- **This guide**: Architecture details for maintainers
+
+---
+
+## 🎓 For New Contributors
+
+When you start contributing to Titan CLI:
+
+1. **Read DEVELOPMENT.md first** - Understand the development setup
+2. **Run `make dev-install`** - Sets up titan-dev for you
+3. **Use `titan-dev` for testing** - Your local changes
+4. **Keep `titan` for daily work** - Stable version (optional)
+
+When you see `titan-dev` in documentation, it means:
+- ✅ You're reading contributor documentation
+- ✅ You need to have cloned the repo
+- ✅ You need to have run `make dev-install`
+- ❌ This command doesn't exist for end users
+
+---
+
+**Last updated:** 2026-02-17

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,17 +251,29 @@ When creating new steps or refactoring existing ones:
 
 ## Project Setup
 
-### Development Installation
+### For Contributors (Development Mode)
 
+**📖 [Complete Development Setup Guide](.claude/docs/development-setup.md)**
+
+Quick start:
 ```bash
-# Install in editable mode with dev dependencies
-pip install -e ".[dev]"
+# Clone repository
+git clone https://github.com/masorange/titan-cli.git
+cd titan-cli
 
-# Install plugins
-pip install -e plugins/titan-plugin-git
-pip install -e plugins/titan-plugin-github
-pip install -e plugins/titan-plugin-jira
+# Setup development environment
+make dev-install
+
+# Run development version
+titan-dev
 ```
+
+**What this does:**
+- Installs dependencies with Poetry (`.venv/`)
+- Creates `~/.local/bin/titan-dev` script pointing to local codebase
+- Allows immediate testing of code changes
+
+**Important:** The `titan-dev` command is for contributors only. End users who install from PyPI only get `titan`.
 
 ### Configuration
 
@@ -304,7 +316,12 @@ enabled = true
 
 ## Main Commands
 
+### For End Users
+
 ```bash
+# Install from PyPI (production version)
+pipx install titan-cli
+
 # Launch interactive TUI (run from project directory)
 cd /path/to/your/project
 titan
@@ -322,10 +339,27 @@ titan
 # Other commands:
 titan version           # Show version
 titan tui               # Explicitly launch TUI
-
-# Development (from repo):
-poetry run titan        # Run from source
 ```
+
+### For Contributors (Development)
+
+```bash
+# Setup development environment (one-time)
+make dev-install
+
+# Run development version (uses local codebase)
+titan-dev
+
+# Alternative ways to run:
+poetry run titan        # Run from poetry virtualenv
+cd ~/git/titan-cli && poetry shell && titan  # Activate venv first
+
+# Run tests
+make test               # All tests
+poetry run pytest       # Direct pytest
+```
+
+**Key difference:** `titan` is the production version from PyPI, `titan-dev` runs your local codebase changes.
 
 ## Current Project Status
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,24 +8,34 @@
 
 ## 🛠️ Development Setup
 
+> **Important:** This guide is for contributors who want to develop Titan CLI. If you just want to use Titan, see [README.md](README.md) for user installation.
+
 ### Prerequisites
 
-- Python 3.9+
-- pipx
+- Python 3.10+
+- `poetry` (dependency management)
+- `pipx` (optional, for production version)
 
 ### Installation for Development
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/your-org/titan-cli.git
+git clone https://github.com/masorange/titan-cli.git
 cd titan-cli
 
-# 2. Install titan-cli in editable mode
-pipx install -e .
+# 2. Install dependencies and create titan-dev launcher
+make dev-install
 
 # 3. Verify installation
-titan --help
+titan-dev --version
 ```
+
+**What this does:**
+- Installs all dependencies with Poetry in a local virtualenv (`.venv/`)
+- Creates a `~/.local/bin/titan-dev` script that points to your local codebase
+- Allows you to test changes immediately without reinstalling
+
+**Note:** The `titan-dev` command is **only for developers**. End users who install from PyPI with `pipx install titan-cli` only get the `titan` command.
 
 ### Initial Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,61 @@
 # Titan CLI - Makefile
 # Development commands for initial setup
 
-.PHONY: help install clean
+.PHONY: help install dev-install test clean
 
 # Default target
 help:
 	@echo "Titan CLI - Available commands:"
 	@echo ""
-	@echo "Development:"
-	@echo "  make install        Install in development mode using pipx"
+	@echo "For Contributors:"
+	@echo "  make dev-install    Setup development environment (creates titan-dev)"
+	@echo "  make test           Run all tests"
+	@echo ""
+	@echo "For Users:"
+	@echo "  make install        Install production version (NOT recommended - use pipx)"
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean          Remove basic build artifacts"
+	@echo ""
+	@echo "Note: Contributors should use 'make dev-install' to get titan-dev command."
+	@echo "      End users should use 'pipx install titan-cli' instead."
 
-# Install in development mode using pipx
+# Setup development environment (CONTRIBUTORS ONLY)
+dev-install:
+	@echo "🔧 Setting up development environment..."
+	@echo ""
+	@echo "1️⃣  Installing dependencies with Poetry..."
+	poetry install
+	@echo ""
+	@echo "2️⃣  Creating titan-dev launcher..."
+	@mkdir -p ~/.local/bin
+	@echo '#!/bin/bash' > ~/.local/bin/titan-dev
+	@echo '# titan-dev - Development version of Titan CLI' >> ~/.local/bin/titan-dev
+	@echo 'exec "$(shell pwd)/.venv/bin/titan" "$$@"' >> ~/.local/bin/titan-dev
+	@chmod +x ~/.local/bin/titan-dev
+	@echo ""
+	@echo "✅ Development environment ready!"
+	@echo ""
+	@echo "Usage:"
+	@echo "  titan-dev           Run development version from local codebase"
+	@echo "  poetry run titan    Alternative way to run"
+	@echo ""
+	@echo "Verify installation:"
+	@~/.local/bin/titan-dev --version || echo "⚠️  Make sure ~/.local/bin is in your PATH"
+
+# Install production version (NOT recommended - use pipx instead)
 install:
-	@echo "📦 Installing in development mode using pipx..."
-	pipx install -e .
+	@echo "⚠️  This installs from local source, not PyPI."
+	@echo "⚠️  For production use: pipx install titan-cli"
+	@echo ""
+	@echo "📦 Installing from local source..."
+	pipx install .
 	@echo "✅ Installed. Run 'titan' to verify."
+
+# Run tests
+test:
+	@echo "🧪 Running all tests..."
+	poetry run pytest
 
 # Clean basic build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -23,21 +23,31 @@ pipx install titan-cli
 
 # Verify installation
 titan --version
+
+# Launch Titan
+titan
 ```
 
-### For Development
+**Note:** This installs the stable production version. You only get the `titan` command.
 
+### For Contributors (Development Setup)
+
+**See [DEVELOPMENT.md](DEVELOPMENT.md) for complete development setup.**
+
+Quick start:
 ```bash
 # Clone repository
 git clone https://github.com/masorange/titan-cli.git
 cd titan-cli
 
-# Install with Poetry (editable mode)
-poetry install
+# Setup development environment
+make dev-install
 
 # Run development version
-poetry run titan-dev
+titan-dev
 ```
+
+**Note:** Development setup creates a `titan-dev` command that runs from your local codebase, allowing you to test changes immediately. This command is **not available** to end users who install from PyPI.
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR introduces a comprehensive `development-setup.md` guide for contributors. It details a new parallel development workflow, enabling developers to use a stable, production `titan` command alongside a `titan-dev` command that runs directly from their local source code. This separation improves the contributor experience by allowing safe testing of local changes without impacting a user's primary workflow.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added a new documentation file: `.claude/docs/development-setup.md`.
- Documents the new `titan-dev` command, a wrapper script for running the local development version of the CLI.
- Provides detailed instructions for setting up both production (via PyPI) and development (from the local repository) environments.
- Includes comparison tables and an architecture diagram to clarify the differences between the `titan` and `titan-dev` environments.
- Outlines a recommended development and testing workflow for contributors working on the codebase.

## 🧪 Testing
<!-- How has this been tested? -->
The instructions and commands outlined in the new `development-setup.md` guide have been manually executed and verified to ensure they are accurate and functional.
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All tests passing

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published