### PR TITLE
fix: Fetch remote branch before creating worktree

### DIFF
--- a/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
@@ -54,6 +54,9 @@ def setup_worktree(
         except Exception:
             pass
 
+        # Fetch the branch so the remote ref exists locally
+        git_client.fetch(remote, branch)
+
         # Create new worktree from remote branch in detached mode
         # This avoids "branch already checked out" errors and works even if branch doesn't exist locally
         remote_ref = f"{remote}/{branch}"


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR fixes a potential error in the `setup_worktree` operation where creating a worktree from a remote branch could fail. The failure occurred if the branch existed on the remote but its reference had not yet been fetched to the local repository. This change ensures the branch is fetched before the worktree is created.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- In `setup_worktree`, added a `git_client.fetch` call for the specified remote and branch.
- This ensures the remote reference (e.g., `origin/feature-branch`) is available locally before the `git worktree add` command is executed.


## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed