### PR TITLE
feat: Add global plugin source override with user-local precedence

### DIFF
--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -440,3 +440,164 @@ def test_get_plugin_source_reads_project_override(tmp_path: Path, monkeypatch, m
         assert config_instance.get_plugin_source_path("github") == plugin_repo.resolve()
     finally:
         os.chdir(original_cwd)
+
+
+def test_get_plugin_source_prefers_global_override_over_project(tmp_path: Path, monkeypatch, mocker):
+    """
+    Plugin source selection is user-local and global source overrides must win
+    over project-level source metadata.
+    """
+    mocker.patch('titan_cli.core.config.PluginRegistry')
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    titan_dir = project_dir / ".titan"
+    titan_dir.mkdir()
+
+    global_plugin_repo = tmp_path / "plugins" / "global-github"
+    global_plugin_repo.mkdir(parents=True)
+    project_plugin_repo = tmp_path / "plugins" / "project-github"
+    project_plugin_repo.mkdir(parents=True)
+
+    with open(titan_dir / "config.toml", "wb") as f:
+        tomli_w.dump(
+            {
+                "project": {"name": "Project"},
+                "plugins": {
+                    "github": {
+                        "enabled": True,
+                        "source": {
+                            "channel": "stable",
+                            "path": str(project_plugin_repo),
+                        },
+                    }
+                },
+            },
+            f,
+        )
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump(
+            {
+                "plugins": {
+                    "github": {
+                        "source": {
+                            "channel": "dev_local",
+                            "path": str(global_plugin_repo),
+                        }
+                    }
+                }
+            },
+            f,
+        )
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        config_instance = TitanConfig()
+
+        assert config_instance.get_plugin_source_channel("github") == "dev_local"
+        assert config_instance.get_plugin_source_path("github") == global_plugin_repo.resolve()
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_set_global_plugin_source_writes_user_config(tmp_path: Path, monkeypatch, mocker):
+    """Global plugin source overrides should be written to user config."""
+    mocker.patch('titan_cli.core.config.PluginRegistry')
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump({}, f)
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+    monkeypatch.setattr(TitanConfig, "_find_project_config", lambda self, path: None)
+
+    config_instance = TitanConfig()
+    config_instance.set_global_plugin_source("github", "dev_local", "/tmp/local-github")
+
+    with open(global_config_path, "rb") as f:
+        import tomli
+        data = tomli.load(f)
+
+    assert data["plugins"]["github"]["source"]["channel"] == "dev_local"
+    assert data["plugins"]["github"]["source"]["path"] == "/tmp/local-github"
+
+
+def test_clear_global_plugin_source_removes_only_source_block(tmp_path: Path, monkeypatch, mocker):
+    """Clearing a global plugin source should preserve other global plugin settings."""
+    mocker.patch('titan_cli.core.config.PluginRegistry')
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump(
+            {
+                "plugins": {
+                    "github": {
+                        "enabled": True,
+                        "config": {"org": "acme"},
+                        "source": {
+                            "channel": "dev_local",
+                            "path": "/tmp/local-github",
+                        },
+                    }
+                }
+            },
+            f,
+        )
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+    monkeypatch.setattr(TitanConfig, "_find_project_config", lambda self, path: None)
+
+    config_instance = TitanConfig()
+    config_instance.clear_global_plugin_source("github")
+
+    with open(global_config_path, "rb") as f:
+        import tomli
+        data = tomli.load(f)
+
+    assert "source" not in data["plugins"]["github"]
+    assert data["plugins"]["github"]["enabled"] is True
+    assert data["plugins"]["github"]["config"]["org"] == "acme"
+
+
+def test_save_global_config_preserves_existing_plugin_source(tmp_path: Path, monkeypatch, mocker):
+    """Saving AI config should not erase existing global plugin source overrides."""
+    mocker.patch('titan_cli.core.config.PluginRegistry')
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump(
+            {
+                "plugins": {
+                    "github": {
+                        "source": {
+                            "channel": "dev_local",
+                            "path": "/tmp/local-github",
+                        }
+                    }
+                }
+            },
+            f,
+        )
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+    monkeypatch.setattr(TitanConfig, "_find_project_config", lambda self, path: None)
+
+    config_instance = TitanConfig(skip_plugin_init=True)
+    config_instance.config.ai = None
+    config_instance._save_global_config()
+
+    with open(global_config_path, "rb") as f:
+        import tomli
+        data = tomli.load(f)
+
+    assert data["plugins"]["github"]["source"]["channel"] == "dev_local"
+    assert data["plugins"]["github"]["source"]["path"] == "/tmp/local-github"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -601,3 +601,44 @@ def test_save_global_config_preserves_existing_plugin_source(tmp_path: Path, mon
 
     assert data["plugins"]["github"]["source"]["channel"] == "dev_local"
     assert data["plugins"]["github"]["source"]["path"] == "/tmp/local-github"
+
+
+def test_global_source_override_does_not_enable_plugin_in_other_projects(tmp_path: Path, monkeypatch, mocker):
+    """A global source-only override must not implicitly enable the plugin."""
+    mocker.patch('titan_cli.core.config.PluginRegistry')
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    titan_dir = project_dir / ".titan"
+    titan_dir.mkdir()
+    with open(titan_dir / "config.toml", "wb") as f:
+        tomli_w.dump({"project": {"name": "Project"}}, f)
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump(
+            {
+                "plugins": {
+                    "ragnarok": {
+                        "source": {
+                            "channel": "stable",
+                            "path": "/tmp/ragnarok-plugin",
+                        }
+                    }
+                }
+            },
+            f,
+        )
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        config_instance = TitanConfig()
+
+        assert config_instance.is_plugin_enabled("ragnarok") is False
+        assert "ragnarok" not in config_instance.get_enabled_plugins()
+    finally:
+        os.chdir(original_cwd)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -527,6 +527,7 @@ def test_set_global_plugin_source_writes_user_config(tmp_path: Path, monkeypatch
 
     assert data["plugins"]["github"]["source"]["channel"] == "dev_local"
     assert data["plugins"]["github"]["source"]["path"] == "/tmp/local-github"
+    assert "enabled" not in data["plugins"]["github"]
 
 
 def test_clear_global_plugin_source_removes_only_source_block(tmp_path: Path, monkeypatch, mocker):
@@ -625,6 +626,48 @@ def test_global_source_override_does_not_enable_plugin_in_other_projects(tmp_pat
                             "channel": "stable",
                             "path": "/tmp/ragnarok-plugin",
                         }
+                    }
+                }
+            },
+            f,
+        )
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        config_instance = TitanConfig()
+
+        assert config_instance.is_plugin_enabled("ragnarok") is False
+        assert "ragnarok" not in config_instance.get_enabled_plugins()
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_project_must_explicitly_enable_plugin(tmp_path: Path, monkeypatch, mocker):
+    """A plugin remains disabled unless the current project explicitly enables it."""
+    mocker.patch('titan_cli.core.config.PluginRegistry')
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    titan_dir = project_dir / ".titan"
+    titan_dir.mkdir()
+    with open(titan_dir / "config.toml", "wb") as f:
+        tomli_w.dump({"project": {"name": "Project"}}, f)
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump(
+            {
+                "plugins": {
+                    "ragnarok": {
+                        "config": {"platform": "android"},
+                        "source": {
+                            "channel": "stable",
+                            "path": "/tmp/ragnarok-plugin",
+                        },
                     }
                 }
             },

--- a/tests/core/test_local_sources.py
+++ b/tests/core/test_local_sources.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import tomli_w
+
+from titan_cli.core.plugins.local_sources import get_local_plugin_validation_error
+
+
+def test_validate_local_plugin_repo_rejects_missing_directory(tmp_path: Path):
+    missing_path = tmp_path / "missing-plugin"
+
+    error = get_local_plugin_validation_error(missing_path, "github")
+
+    assert error == "The selected path does not exist or is not a directory."
+
+
+def test_validate_local_plugin_repo_requires_pyproject(tmp_path: Path):
+    repo_path = tmp_path / "plugin-repo"
+    repo_path.mkdir()
+
+    error = get_local_plugin_validation_error(repo_path, "github")
+
+    assert error == "The selected path does not contain a pyproject.toml file."
+
+
+def test_validate_local_plugin_repo_requires_titan_entry_points(tmp_path: Path):
+    repo_path = tmp_path / "plugin-repo"
+    repo_path.mkdir()
+
+    with open(repo_path / "pyproject.toml", "wb") as f:
+        tomli_w.dump(
+            {
+                "project": {
+                    "name": "example-plugin",
+                    "version": "0.1.0",
+                }
+            },
+            f,
+        )
+
+    error = get_local_plugin_validation_error(repo_path, "github")
+
+    assert error == "This repository does not declare any 'titan.plugins' entry points."
+
+
+def test_validate_local_plugin_repo_requires_selected_plugin_name(tmp_path: Path):
+    repo_path = tmp_path / "plugin-repo"
+    repo_path.mkdir()
+
+    with open(repo_path / "pyproject.toml", "wb") as f:
+        tomli_w.dump(
+            {
+                "project": {
+                    "name": "example-plugin",
+                    "version": "0.1.0",
+                    "entry-points": {
+                        "titan.plugins": {
+                            "jira": "example.plugin:JiraPlugin",
+                        }
+                    },
+                }
+            },
+            f,
+        )
+
+    error = get_local_plugin_validation_error(repo_path, "github")
+
+    assert error == "This repository does not provide the 'github' plugin. Available plugins: jira"
+
+
+def test_validate_local_plugin_repo_accepts_matching_plugin(tmp_path: Path):
+    repo_path = tmp_path / "plugin-repo"
+    repo_path.mkdir()
+
+    with open(repo_path / "pyproject.toml", "wb") as f:
+        tomli_w.dump(
+            {
+                "project": {
+                    "name": "example-plugin",
+                    "version": "0.1.0",
+                    "entry-points": {
+                        "titan.plugins": {
+                            "github": "example.plugin:GitHubPlugin",
+                        }
+                    },
+                }
+            },
+            f,
+        )
+
+    error = get_local_plugin_validation_error(repo_path, "github")
+
+    assert error is None

--- a/tests/core/test_local_sources.py
+++ b/tests/core/test_local_sources.py
@@ -90,3 +90,30 @@ def test_validate_local_plugin_repo_accepts_matching_plugin(tmp_path: Path):
     error = get_local_plugin_validation_error(repo_path, "github")
 
     assert error is None
+
+
+def test_validate_local_plugin_repo_accepts_poetry_plugin_entry_points(tmp_path: Path):
+    repo_path = tmp_path / "plugin-repo"
+    repo_path.mkdir()
+
+    with open(repo_path / "pyproject.toml", "wb") as f:
+        tomli_w.dump(
+            {
+                "tool": {
+                    "poetry": {
+                        "name": "example-plugin",
+                        "version": "0.1.0",
+                        "plugins": {
+                            "titan.plugins": {
+                                "github": "example.plugin:GitHubPlugin",
+                            }
+                        },
+                    }
+                }
+            },
+            f,
+        )
+
+    error = get_local_plugin_validation_error(repo_path, "github")
+
+    assert error is None

--- a/tests/core/test_plugin_registry.py
+++ b/tests/core/test_plugin_registry.py
@@ -285,3 +285,13 @@ def test_apply_source_overrides_marks_missing_path_as_failure():
     assert isinstance(failed_plugins["sample"], PluginLoadError)
     assert "dev_local source requires a local path" in str(failed_plugins["sample"])
     assert registry.get_plugin("sample") is None
+
+
+def test_list_enabled_delegates_to_config_effective_enabled_plugins():
+    registry = PluginRegistry(discover_on_init=False)
+
+    config = MagicMock()
+    config.get_enabled_plugins.return_value = ["git", "github"]
+
+    assert registry.list_enabled(config) == ["git", "github"]
+    config.get_enabled_plugins.assert_called_once_with()

--- a/titan_cli/core/config.py
+++ b/titan_cli/core/config.py
@@ -183,18 +183,6 @@ class TitanConfig:
             else:
                 merged[key] = value
 
-        # A global plugin source override must not implicitly enable a plugin
-        # for projects that do not configure it.
-        plugins_cfg = merged.get("plugins", {})
-        if isinstance(plugins_cfg, dict):
-            for plugin_data in plugins_cfg.values():
-                if (
-                    isinstance(plugin_data, dict)
-                    and "source" in plugin_data
-                    and "enabled" not in plugin_data
-                ):
-                    plugin_data["enabled"] = False
-
         return merged
 
     @property
@@ -219,7 +207,7 @@ class TitanConfig:
             return []
         return [
             name for name, plugin_cfg in self.config.plugins.items()
-            if plugin_cfg.enabled
+            if self.is_plugin_enabled(name)
         ]
 
     def get_plugin_warnings(self) -> List[str]:
@@ -270,8 +258,17 @@ class TitanConfig:
             raise ConfigWriteError(file_path=str(self._global_config_path), original_exception=e)
 
     def is_plugin_enabled(self, plugin_name: str) -> bool:
-        """Check if plugin is enabled"""
+        """Check if a plugin is effectively enabled for the current project.
+
+        This is the source of truth for plugin activation. Do not infer enabled
+        state from the merged plugin model alone, because global plugin metadata
+        may exist without the plugin being explicitly enabled in the current
+        project's config.
+        """
         if not self.config or not self.config.plugins:
+            return False
+        project_plugins = self.project_config.get("plugins", {}) if self.project_config else {}
+        if plugin_name not in project_plugins:
             return False
         plugin_cfg = self.config.plugins.get(plugin_name)
         return plugin_cfg.enabled if plugin_cfg else False
@@ -305,8 +302,6 @@ class TitanConfig:
         plugins_table = config_data.setdefault("plugins", {})
         plugin_table = plugins_table.setdefault(plugin_name, {})
         source_table = plugin_table.setdefault("source", {})
-
-        plugin_table.setdefault("enabled", False)
 
         source_table["channel"] = channel
         if path:

--- a/titan_cli/core/config.py
+++ b/titan_cli/core/config.py
@@ -139,6 +139,12 @@ class TitanConfig:
                         if pk != "config":
                             final_plugin_data[pk] = pv
 
+                    # Plugin source is a user-local concern. If global config already
+                    # defines a source override, preserve it instead of letting the
+                    # project config overwrite it.
+                    if "source" in plugin_data_global:
+                        final_plugin_data["source"] = plugin_data_global["source"]
+
                     # Handle the nested 'config' dictionary separately (deep merge)
                     config_section_global = plugin_data_global.get("config", {})
                     config_section_project = plugin_data_project.get("config", {})
@@ -216,12 +222,6 @@ class TitanConfig:
 
     def _save_global_config(self):
         """Saves the current state of the global config to disk."""
-        if not self._global_config_path.parent.exists():
-            try:
-                self._global_config_path.parent.mkdir(parents=True)
-            except OSError as e:
-                raise ConfigWriteError(file_path=str(self._global_config_path), original_exception=e)
-
         existing_global_config = {}
         if self._global_config_path.exists():
             try:
@@ -238,10 +238,20 @@ class TitanConfig:
         if 'ai' in config_to_save:
             existing_global_config['ai'] = config_to_save['ai']
 
+        self._write_global_config(existing_global_config)
+
+    def _write_global_config(self, data: dict) -> None:
+        """Write raw global config data to disk."""
+        if not self._global_config_path.parent.exists():
+            try:
+                self._global_config_path.parent.mkdir(parents=True)
+            except OSError as e:
+                raise ConfigWriteError(file_path=str(self._global_config_path), original_exception=e)
+
         try:
             with open(self._global_config_path, "wb") as f:
                 import tomli_w
-                tomli_w.dump(existing_global_config, f)
+                tomli_w.dump(data, f)
         except ImportError as e:
             raise ConfigWriteError(file_path=str(self._global_config_path), original_exception=e)
         except Exception as e:
@@ -271,6 +281,42 @@ class TitanConfig:
         if not plugin_cfg or not getattr(plugin_cfg, "source", None) or not plugin_cfg.source.path:
             return None
         return Path(plugin_cfg.source.path).expanduser().resolve()
+
+    def set_global_plugin_source(
+        self,
+        plugin_name: str,
+        channel: str,
+        path: Optional[str] = None,
+    ) -> None:
+        """Persist a plugin source override in the global user config."""
+        config_data = self._load_toml(self._global_config_path)
+        plugins_table = config_data.setdefault("plugins", {})
+        plugin_table = plugins_table.setdefault(plugin_name, {})
+        source_table = plugin_table.setdefault("source", {})
+
+        source_table["channel"] = channel
+        if path:
+            source_table["path"] = path
+        else:
+            source_table.pop("path", None)
+
+        self._write_global_config(config_data)
+
+    def clear_global_plugin_source(self, plugin_name: str) -> None:
+        """Remove a plugin source override from the global user config."""
+        config_data = self._load_toml(self._global_config_path)
+        plugins_table = config_data.get("plugins", {})
+        plugin_table = plugins_table.get(plugin_name)
+        if not plugin_table:
+            return
+
+        plugin_table.pop("source", None)
+        if not plugin_table:
+            plugins_table.pop(plugin_name, None)
+        if not plugins_table and "plugins" in config_data:
+            config_data.pop("plugins", None)
+
+        self._write_global_config(config_data)
 
     def get_status_bar_info(self) -> dict:
         """

--- a/titan_cli/core/config.py
+++ b/titan_cli/core/config.py
@@ -183,6 +183,18 @@ class TitanConfig:
             else:
                 merged[key] = value
 
+        # A global plugin source override must not implicitly enable a plugin
+        # for projects that do not configure it.
+        plugins_cfg = merged.get("plugins", {})
+        if isinstance(plugins_cfg, dict):
+            for plugin_data in plugins_cfg.values():
+                if (
+                    isinstance(plugin_data, dict)
+                    and "source" in plugin_data
+                    and "enabled" not in plugin_data
+                ):
+                    plugin_data["enabled"] = False
+
         return merged
 
     @property
@@ -293,6 +305,8 @@ class TitanConfig:
         plugins_table = config_data.setdefault("plugins", {})
         plugin_table = plugins_table.setdefault(plugin_name, {})
         source_table = plugin_table.setdefault("source", {})
+
+        plugin_table.setdefault("enabled", False)
 
         source_table["channel"] = channel
         if path:

--- a/titan_cli/core/plugins/local_sources.py
+++ b/titan_cli/core/plugins/local_sources.py
@@ -1,0 +1,40 @@
+"""
+Local plugin source helpers.
+"""
+
+from pathlib import Path
+
+import tomli
+
+
+def get_local_plugin_validation_error(repo_path: Path, plugin_name: str) -> str | None:
+    """Validate that a local repository exposes the selected Titan plugin."""
+    if not repo_path.exists() or not repo_path.is_dir():
+        return "The selected path does not exist or is not a directory."
+
+    pyproject_path = repo_path / "pyproject.toml"
+    if not pyproject_path.exists():
+        return "The selected path does not contain a pyproject.toml file."
+
+    try:
+        with open(pyproject_path, "rb") as f:
+            pyproject_data = tomli.load(f)
+    except Exception as e:
+        return f"Could not read pyproject.toml: {e}"
+
+    entry_points = (
+        pyproject_data.get("project", {})
+        .get("entry-points", {})
+        .get("titan.plugins", {})
+    )
+    if not entry_points:
+        return "This repository does not declare any 'titan.plugins' entry points."
+
+    if plugin_name not in entry_points:
+        available = ", ".join(sorted(entry_points.keys()))
+        return (
+            f"This repository does not provide the '{plugin_name}' plugin."
+            + (f" Available plugins: {available}" if available else "")
+        )
+
+    return None

--- a/titan_cli/core/plugins/local_sources.py
+++ b/titan_cli/core/plugins/local_sources.py
@@ -7,6 +7,28 @@ from pathlib import Path
 import tomli
 
 
+def _get_titan_plugin_entry_points(pyproject_data: dict) -> dict:
+    """Return Titan plugin entry points from supported pyproject layouts."""
+    project_entry_points = (
+        pyproject_data.get("project", {})
+        .get("entry-points", {})
+        .get("titan.plugins", {})
+    )
+    if project_entry_points:
+        return project_entry_points
+
+    poetry_entry_points = (
+        pyproject_data.get("tool", {})
+        .get("poetry", {})
+        .get("plugins", {})
+        .get("titan.plugins", {})
+    )
+    if poetry_entry_points:
+        return poetry_entry_points
+
+    return {}
+
+
 def get_local_plugin_validation_error(repo_path: Path, plugin_name: str) -> str | None:
     """Validate that a local repository exposes the selected Titan plugin."""
     if not repo_path.exists() or not repo_path.is_dir():
@@ -22,11 +44,7 @@ def get_local_plugin_validation_error(repo_path: Path, plugin_name: str) -> str 
     except Exception as e:
         return f"Could not read pyproject.toml: {e}"
 
-    entry_points = (
-        pyproject_data.get("project", {})
-        .get("entry-points", {})
-        .get("titan.plugins", {})
-    )
+    entry_points = _get_titan_plugin_entry_points(pyproject_data)
     if not entry_points:
         return "This repository does not declare any 'titan.plugins' entry points."
 

--- a/titan_cli/core/plugins/plugin_registry.py
+++ b/titan_cli/core/plugins/plugin_registry.py
@@ -245,15 +245,11 @@ class PluginRegistry:
         Returns:
             List of enabled plugin names
         """
-        if not config or not config.config or not config.config.plugins:
+        if not config:
             return []
-
-        enabled = []
-        for plugin_name, plugin_config in config.config.plugins.items():
-            if hasattr(plugin_config, 'enabled') and plugin_config.enabled:
-                enabled.append(plugin_name)
-
-        return enabled
+        if hasattr(config, "get_enabled_plugins"):
+            return config.get_enabled_plugins()
+        return []
 
     def list_failed(self) -> Dict[str, Exception]:
         """

--- a/titan_cli/core/plugins/plugin_registry.py
+++ b/titan_cli/core/plugins/plugin_registry.py
@@ -49,7 +49,9 @@ def _load_dev_local_plugin(repo_path: Path, plugin_name: str) -> TitanPlugin:
     plugin_class = getattr(module, class_name)
     if not issubclass(plugin_class, TitanPlugin):
         raise TypeError("Plugin class must inherit from TitanPlugin")
-    return plugin_class()
+    plugin = plugin_class()
+    plugin._dev_local_package_root = package_root
+    return plugin
 
 
 class PluginRegistry:
@@ -61,6 +63,7 @@ class PluginRegistry:
         self._discovered_plugin_names: List[str] = []
         self._plugin_versions: Dict[str, str] = {}
         self._dev_local_sys_paths: set[str] = set()
+        self._dev_local_package_roots: set[str] = set()
         if discover_on_init:
             self.discover()
 
@@ -200,8 +203,12 @@ class PluginRegistry:
                 continue
 
             try:
-                self._plugins[plugin_name] = _load_dev_local_plugin(repo_path, plugin_name)
+                plugin = _load_dev_local_plugin(repo_path, plugin_name)
+                self._plugins[plugin_name] = plugin
                 self._dev_local_sys_paths.add(str(repo_path))
+                package_root = getattr(plugin, "_dev_local_package_root", None)
+                if package_root:
+                    self._dev_local_package_roots.add(package_root)
                 self._plugin_versions[plugin_name] = "dev_local"
                 if plugin_name not in self._discovered_plugin_names:
                     self._discovered_plugin_names.append(plugin_name)
@@ -271,6 +278,16 @@ class PluginRegistry:
             while repo_path in sys.path:
                 sys.path.remove(repo_path)
         self._dev_local_sys_paths.clear()
+
+        for package_root in list(self._dev_local_package_roots):
+            stale_modules = [
+                name for name in list(sys.modules)
+                if name == package_root or name.startswith(f"{package_root}.")
+            ]
+            for name in stale_modules:
+                sys.modules.pop(name, None)
+        self._dev_local_package_roots.clear()
+
         importlib.invalidate_caches()
 
         self._plugins.clear()

--- a/titan_cli/core/plugins/plugin_registry.py
+++ b/titan_cli/core/plugins/plugin_registry.py
@@ -60,6 +60,7 @@ class PluginRegistry:
         self._failed_plugins: Dict[str, Exception] = {}
         self._discovered_plugin_names: List[str] = []
         self._plugin_versions: Dict[str, str] = {}
+        self._dev_local_sys_paths: set[str] = set()
         if discover_on_init:
             self.discover()
 
@@ -200,6 +201,7 @@ class PluginRegistry:
 
             try:
                 self._plugins[plugin_name] = _load_dev_local_plugin(repo_path, plugin_name)
+                self._dev_local_sys_paths.add(str(repo_path))
                 self._plugin_versions[plugin_name] = "dev_local"
                 if plugin_name not in self._discovered_plugin_names:
                     self._discovered_plugin_names.append(plugin_name)
@@ -265,6 +267,12 @@ class PluginRegistry:
 
     def reset(self):
         """Resets the registry, clearing all loaded plugins and re-discovering."""
+        for repo_path in list(self._dev_local_sys_paths):
+            while repo_path in sys.path:
+                sys.path.remove(repo_path)
+        self._dev_local_sys_paths.clear()
+        importlib.invalidate_caches()
+
         self._plugins.clear()
         self._failed_plugins.clear()
         self._plugin_versions.clear()

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -154,6 +154,20 @@ class PluginManagementScreen(BaseScreen):
         height: auto;
     }
 
+    .source-switch-row {
+        height: 3;
+        width: auto;
+        align: left middle;
+        margin-top: 1;
+    }
+
+    .source-switch-row DimText {
+        width: auto;
+        height: 3;
+        margin-right: 1;
+        content-align: left middle;
+    }
+
     .button-container {
         height: auto;
         min-height: 5;
@@ -188,7 +202,7 @@ class PluginManagementScreen(BaseScreen):
                 left_panel = Container(id="left-panel")
                 left_panel.border_title = "Installed Plugins"
                 with left_panel:
-                    yield OptionList(id="plugin-list")
+                    yield OptionList()
                     yield Button(f"{Icons.PLUGIN} Install Plugin", variant="primary", id="install-plugin-button")
 
                 # Right panel: Plugin details and actions
@@ -207,8 +221,11 @@ class PluginManagementScreen(BaseScreen):
         """Load and display installed plugins."""
         self.installed_plugins = self.config.registry.list_installed()
 
-        plugin_list = self.query_one("#plugin-list", OptionList)
+        left_panel = self.query_one("#left-panel", Container)
+        plugin_list = left_panel.query_one(OptionList)
         plugin_list.clear_options()
+        plugin_list.clear_cached_dimensions()
+        plugin_list._clear_arrangement_cache()
 
         # Find plugins enabled in config but not installed
         missing_plugins = []
@@ -251,6 +268,7 @@ class PluginManagementScreen(BaseScreen):
         all_plugins = self.installed_plugins + [f"missing:{p}" for p in missing_plugins]
         if all_plugins:
             plugin_list.highlighted = 0
+            plugin_list.refresh(repaint=True, layout=True)
             first = all_plugins[0]
             if first.startswith("missing:"):
                 plugin_name = first.removeprefix("missing:")
@@ -401,10 +419,17 @@ class PluginManagementScreen(BaseScreen):
         if active_rec:
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
-            details.mount(DimText(f"  Active: {source_label}"))
             if is_enabled and is_community_plugin and switch_value:
-                details.mount(self._build_source_switch(switch_value))
+                details.mount(
+                    Horizontal(
+                        DimText("  Active:"),
+                        self._build_source_switch(switch_value),
+                        classes="source-switch-row",
+                    )
+                )
                 self._source_switch_plugin = plugin_name
+            else:
+                details.mount(DimText(f"  Active: {source_label}"))
             if active_channel == PluginChannel.DEV_LOCAL and active_path:
                 details.mount(DimText(f"  Path: {active_path}"))
             elif active_rec.repo_url:
@@ -415,10 +440,17 @@ class PluginManagementScreen(BaseScreen):
         elif active_channel == PluginChannel.DEV_LOCAL and active_path:
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
-            details.mount(DimText("  Active: Development Source"))
             if is_enabled and is_community_plugin and switch_value:
-                details.mount(self._build_source_switch(switch_value))
+                details.mount(
+                    Horizontal(
+                        DimText("  Active:"),
+                        self._build_source_switch(switch_value),
+                        classes="source-switch-row",
+                    )
+                )
                 self._source_switch_plugin = plugin_name
+            else:
+                details.mount(DimText("  Active: Development Source"))
             details.mount(DimText(f"  Path: {active_path}"))
         else:
             self._source_switch_plugin = None
@@ -501,7 +533,8 @@ class PluginManagementScreen(BaseScreen):
                 )
 
             self.config.load()
-            self._load_plugins()
+            self.installed_plugins = self.config.registry.list_installed()
+            self._show_plugin_details(self.selected_plugin)
             self.app.notify(
                 f"Plugin source for '{self.selected_plugin}' changed to "
                 f"{'Development Source' if event.value == PluginChannel.DEV_LOCAL else 'Stable'}.",
@@ -664,7 +697,8 @@ class PluginManagementScreen(BaseScreen):
             str(repo_path),
         )
         self.config.load()
-        self._load_plugins()
+        self.installed_plugins = self.config.registry.list_installed()
+        self._show_plugin_details(self.selected_plugin)
         logger.info(
             "plugin_dev_source_configured",
             plugin=self.selected_plugin,
@@ -786,7 +820,8 @@ class PluginManagementScreen(BaseScreen):
         if self.config.get_plugin_source_channel(self.selected_plugin) == PluginChannel.DEV_LOCAL:
             self.config.clear_global_plugin_source(self.selected_plugin)
             self.config.load()
-            self._load_plugins()
+            self.installed_plugins = self.config.registry.list_installed()
+            self._show_plugin_details(self.selected_plugin)
             self.app.notify(
                 f"Development source removed for '{self.selected_plugin}'",
                 severity="information",

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -396,10 +396,11 @@ class PluginManagementScreen(BaseScreen):
         active_channel = self.config.get_plugin_source_channel(plugin_name)
         active_path = self.config.get_plugin_source_path(plugin_name)
         switch_value = self._get_source_switch_value(active_channel, active_path, active_rec)
+        source_label = "Development Source" if active_channel == PluginChannel.DEV_LOCAL else "Stable"
         if active_rec:
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
-            details.mount(DimText(f"  Channel: {active_channel}"))
+            details.mount(DimText(f"  Active: {source_label}"))
             if switch_value:
                 details.mount(self._build_source_switch(switch_value))
                 self._source_switch_plugin = plugin_name
@@ -413,7 +414,7 @@ class PluginManagementScreen(BaseScreen):
         elif active_channel == PluginChannel.DEV_LOCAL and active_path:
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
-            details.mount(DimText(f"  Channel: {active_channel}"))
+            details.mount(DimText("  Active: Development Source"))
             if switch_value:
                 details.mount(self._build_source_switch(switch_value))
                 self._source_switch_plugin = plugin_name
@@ -427,7 +428,7 @@ class PluginManagementScreen(BaseScreen):
         details.mount(DimText(f"  Press e to {action_verb} this plugin"))
         details.mount(DimText("  Press c to configure this plugin"))
         if active_channel == PluginChannel.DEV_LOCAL:
-            details.mount(DimText("  Press u to remove the dev local source"))
+            details.mount(DimText("  Press u to remove the development source"))
         elif active_rec:
             details.mount(DimText("  Press u to uninstall this plugin"))
         details.mount(DimText("  Press d to configure a local development path"))
@@ -492,7 +493,8 @@ class PluginManagementScreen(BaseScreen):
             self.config.load()
             self._load_plugins()
             self.app.notify(
-                f"Plugin source for '{self.selected_plugin}' changed to '{event.value}'.",
+                f"Plugin source for '{self.selected_plugin}' changed to "
+                f"{'Development Source' if event.value == PluginChannel.DEV_LOCAL else 'Stable'}.",
                 severity="information",
             )
         except Exception as e:
@@ -754,7 +756,10 @@ class PluginManagementScreen(BaseScreen):
             self.config.clear_global_plugin_source(self.selected_plugin)
             self.config.load()
             self._load_plugins()
-            self.app.notify(f"Dev local source removed for '{self.selected_plugin}'", severity="information")
+            self.app.notify(
+                f"Development source removed for '{self.selected_plugin}'",
+                severity="information",
+            )
             return
 
         record = get_community_plugin_by_titan_name(self.selected_plugin)

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -393,6 +393,7 @@ class PluginManagementScreen(BaseScreen):
                         details.mount(DimText(f"  {key}: {value}"))
 
         active_rec = get_community_plugin_by_titan_name(plugin_name)
+        is_community_plugin = self._is_community_plugin(plugin_name)
         active_channel = self.config.get_plugin_source_channel(plugin_name)
         active_path = self.config.get_plugin_source_path(plugin_name)
         switch_value = self._get_source_switch_value(active_channel, active_path, active_rec)
@@ -401,7 +402,7 @@ class PluginManagementScreen(BaseScreen):
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
             details.mount(DimText(f"  Active: {source_label}"))
-            if switch_value:
+            if is_community_plugin and switch_value:
                 details.mount(self._build_source_switch(switch_value))
                 self._source_switch_plugin = plugin_name
             if active_channel == PluginChannel.DEV_LOCAL and active_path:
@@ -415,7 +416,7 @@ class PluginManagementScreen(BaseScreen):
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
             details.mount(DimText("  Active: Development Source"))
-            if switch_value:
+            if is_community_plugin and switch_value:
                 details.mount(self._build_source_switch(switch_value))
                 self._source_switch_plugin = plugin_name
             details.mount(DimText(f"  Path: {active_path}"))
@@ -431,15 +432,17 @@ class PluginManagementScreen(BaseScreen):
             details.mount(DimText("  Press u to remove the development source"))
         elif active_rec:
             details.mount(DimText("  Press u to uninstall this plugin"))
-        details.mount(DimText("  Press d to configure a local development path"))
+        if is_community_plugin:
+            details.mount(DimText("  Press d to configure a local development path"))
 
         # Buttons
         details.mount(Text(""))  # Spacer
         buttons = [
             Button("Enable/Disable", variant="default", id="toggle-button"),
             Button("Configure", variant="primary", id="configure-button"),
-            Button("Set Dev Path", variant="default", id="set-dev-path-button"),
         ]
+        if is_community_plugin:
+            buttons.append(Button("Set Dev Path", variant="default", id="set-dev-path-button"))
         if active_channel == PluginChannel.STABLE and active_rec:
             buttons.append(Button("Update", variant="warning", id="update-button"))
         if active_channel == PluginChannel.DEV_LOCAL or active_rec:
@@ -465,23 +468,30 @@ class PluginManagementScreen(BaseScreen):
 
     def on_segmented_switch_changed(self, event: SegmentedSwitch.Changed) -> None:
         """Handle source switch changes."""
-        if event.sender.id != "plugin-source-switch":
-            return
-
         if not self._source_switch_plugin or self._source_switch_plugin != self.selected_plugin:
             return
 
         try:
+            active_path = self.config.get_plugin_source_path(self.selected_plugin)
+
             if event.value == PluginChannel.STABLE:
-                self.config.clear_global_plugin_source(self.selected_plugin)
-            elif event.value == PluginChannel.DEV_LOCAL:
-                active_path = self.config.get_plugin_source_path(self.selected_plugin)
                 if not active_path:
                     self.app.notify(
                         "No local development path is configured for this plugin.",
                         severity="warning",
                     )
-                    event.sender.set_value(PluginChannel.STABLE)
+                    return
+                self.config.set_global_plugin_source(
+                    self.selected_plugin,
+                    PluginChannel.STABLE,
+                    str(active_path),
+                )
+            elif event.value == PluginChannel.DEV_LOCAL:
+                if not active_path:
+                    self.app.notify(
+                        "No local development path is configured for this plugin.",
+                        severity="warning",
+                    )
                     return
 
                 self.config.set_global_plugin_source(
@@ -509,7 +519,6 @@ class PluginManagementScreen(BaseScreen):
                 SegmentedSwitchOption(value=PluginChannel.DEV_LOCAL, label="Develop"),
             ],
             value=value,
-            id="plugin-source-switch",
         )
 
     def _get_source_switch_value(
@@ -525,6 +534,10 @@ class PluginManagementScreen(BaseScreen):
             if active_record:
                 return PluginChannel.STABLE
         return None
+
+    def _is_community_plugin(self, plugin_name: str) -> bool:
+        """Return whether the plugin is managed as a community plugin."""
+        return get_community_plugin_by_titan_name(plugin_name) is not None
 
     def action_toggle_plugin(self) -> None:
         """Toggle enable/disable state of selected plugin."""
@@ -611,6 +624,13 @@ class PluginManagementScreen(BaseScreen):
             self.app.notify("Please select a plugin", severity="warning")
             return
 
+        if not self._is_community_plugin(self.selected_plugin):
+            self.app.notify(
+                "Development source is only available for community plugins.",
+                severity="warning",
+            )
+            return
+
         current_path = self.config.get_plugin_source_path(self.selected_plugin)
 
         self.app.push_screen(
@@ -629,6 +649,12 @@ class PluginManagementScreen(BaseScreen):
         repo_path = Path(path_value).expanduser().resolve()
         error = get_local_plugin_validation_error(repo_path, self.selected_plugin)
         if error:
+            logger.warning(
+                "plugin_dev_source_validation_failed",
+                plugin=self.selected_plugin,
+                path=str(repo_path),
+                error=error,
+            )
             self.app.notify(error, severity="error")
             return
 
@@ -639,6 +665,11 @@ class PluginManagementScreen(BaseScreen):
         )
         self.config.load()
         self._load_plugins()
+        logger.info(
+            "plugin_dev_source_configured",
+            plugin=self.selected_plugin,
+            path=str(repo_path),
+        )
         self.app.notify(
             f"Development path configured for '{self.selected_plugin}'.",
             severity="information",

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -165,6 +165,12 @@ class PluginManagementScreen(BaseScreen):
         width: auto;
         height: 3;
         margin-right: 1;
+        margin-top: 1;
+        content-align: left middle;
+    }
+
+    .source-switch-row SegmentedSwitch {
+        height: 3;
         content-align: left middle;
     }
 
@@ -552,6 +558,7 @@ class PluginManagementScreen(BaseScreen):
                 SegmentedSwitchOption(value=PluginChannel.DEV_LOCAL, label="Develop"),
             ],
             value=value,
+            boxed=False,
         )
 
     def _get_source_switch_value(

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -421,7 +421,7 @@ class PluginManagementScreen(BaseScreen):
         active_channel = self.config.get_plugin_source_channel(plugin_name)
         active_path = self.config.get_plugin_source_path(plugin_name)
         switch_value = self._get_source_switch_value(active_channel, active_path, active_rec)
-        source_label = "Development Source" if active_channel == PluginChannel.DEV_LOCAL else "Stable"
+        source_label = "Development Source" if active_channel == PluginChannel.DEV_LOCAL else PluginChannel.STABLE
         if active_rec:
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
@@ -543,7 +543,7 @@ class PluginManagementScreen(BaseScreen):
             self._show_plugin_details(self.selected_plugin)
             self.app.notify(
                 f"Plugin source for '{self.selected_plugin}' changed to "
-                f"{'Development Source' if event.value == PluginChannel.DEV_LOCAL else 'Stable'}.",
+                f"{'Development Source' if event.value == PluginChannel.DEV_LOCAL else PluginChannel.STABLE}.",
                 severity="information",
             )
         except Exception as e:

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -8,6 +8,8 @@ Screen for managing installed plugins:
 """
 
 from textual.app import ComposeResult
+from pathlib import Path
+
 from textual.widgets import OptionList, Static
 from textual.widgets.option_list import Option
 from textual.containers import Container, Horizontal, VerticalScroll
@@ -21,10 +23,14 @@ from titan_cli.ui.tui.widgets import (
     BoldText,
     BoldPrimaryText,
     WarningText,
+    SegmentedSwitch,
+    SegmentedSwitchOption,
+    DevSourcePathModal,
 )
 from .base import BaseScreen
 from .plugin_config_wizard import PluginConfigWizardScreen
 from .install_plugin_screen import InstallPluginScreen
+from titan_cli.core.plugins.local_sources import get_local_plugin_validation_error
 from titan_cli.core.plugins.community import (
     CommunityPluginRecord,
     PluginChannel,
@@ -62,6 +68,7 @@ class PluginManagementScreen(BaseScreen):
         ("q", "go_back", "Back"),
         Binding("e", "toggle_plugin", "Enable/Disable"),
         Binding("c", "configure_plugin", "Configure"),
+        Binding("d", "set_dev_source", "Set Dev Path"),
         Binding("i", "install_plugin", "Install"),
         Binding("r", "remove_plugin_from_project", "Remove from Project"),
         Binding("u", "uninstall_plugin", "Uninstall"),
@@ -171,6 +178,7 @@ class PluginManagementScreen(BaseScreen):
         self.selected_plugin = None
         self.selected_missing_plugin = None
         self.installed_plugins = []
+        self._source_switch_plugin = None
 
     def compose_content(self) -> ComposeResult:
         """Compose the plugin management screen."""
@@ -387,10 +395,14 @@ class PluginManagementScreen(BaseScreen):
         active_rec = get_community_plugin_by_titan_name(plugin_name)
         active_channel = self.config.get_plugin_source_channel(plugin_name)
         active_path = self.config.get_plugin_source_path(plugin_name)
+        switch_value = self._get_source_switch_value(active_channel, active_path, active_rec)
         if active_rec:
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
             details.mount(DimText(f"  Channel: {active_channel}"))
+            if switch_value:
+                details.mount(self._build_source_switch(switch_value))
+                self._source_switch_plugin = plugin_name
             if active_channel == PluginChannel.DEV_LOCAL and active_path:
                 details.mount(DimText(f"  Path: {active_path}"))
             elif active_rec.repo_url:
@@ -402,7 +414,12 @@ class PluginManagementScreen(BaseScreen):
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
             details.mount(DimText(f"  Channel: {active_channel}"))
+            if switch_value:
+                details.mount(self._build_source_switch(switch_value))
+                self._source_switch_plugin = plugin_name
             details.mount(DimText(f"  Path: {active_path}"))
+        else:
+            self._source_switch_plugin = None
 
         details.mount(Text(""))  # Spacer
         details.mount(BoldText("Actions:"))
@@ -413,12 +430,14 @@ class PluginManagementScreen(BaseScreen):
             details.mount(DimText("  Press u to remove the dev local source"))
         elif active_rec:
             details.mount(DimText("  Press u to uninstall this plugin"))
+        details.mount(DimText("  Press d to configure a local development path"))
 
         # Buttons
         details.mount(Text(""))  # Spacer
         buttons = [
             Button("Enable/Disable", variant="default", id="toggle-button"),
             Button("Configure", variant="primary", id="configure-button"),
+            Button("Set Dev Path", variant="default", id="set-dev-path-button"),
         ]
         if active_channel == PluginChannel.STABLE and active_rec:
             buttons.append(Button("Update", variant="warning", id="update-button"))
@@ -440,6 +459,70 @@ class PluginManagementScreen(BaseScreen):
             self.action_update_plugin()
         elif event.button.id == "uninstall-button":
             self.action_uninstall_plugin()
+        elif event.button.id == "set-dev-path-button":
+            self.action_set_dev_source()
+
+    def on_segmented_switch_changed(self, event: SegmentedSwitch.Changed) -> None:
+        """Handle source switch changes."""
+        if event.sender.id != "plugin-source-switch":
+            return
+
+        if not self._source_switch_plugin or self._source_switch_plugin != self.selected_plugin:
+            return
+
+        try:
+            if event.value == PluginChannel.STABLE:
+                self.config.clear_global_plugin_source(self.selected_plugin)
+            elif event.value == PluginChannel.DEV_LOCAL:
+                active_path = self.config.get_plugin_source_path(self.selected_plugin)
+                if not active_path:
+                    self.app.notify(
+                        "No local development path is configured for this plugin.",
+                        severity="warning",
+                    )
+                    event.sender.set_value(PluginChannel.STABLE)
+                    return
+
+                self.config.set_global_plugin_source(
+                    self.selected_plugin,
+                    PluginChannel.DEV_LOCAL,
+                    str(active_path),
+                )
+
+            self.config.load()
+            self._load_plugins()
+            self.app.notify(
+                f"Plugin source for '{self.selected_plugin}' changed to '{event.value}'.",
+                severity="information",
+            )
+        except Exception as e:
+            logger.exception("plugin_source_switch_failed", plugin=self.selected_plugin, value=event.value)
+            self.app.notify(f"Failed to change plugin source: {e}", severity="error")
+
+    def _build_source_switch(self, value: str) -> SegmentedSwitch:
+        """Build the reusable source switch widget."""
+        return SegmentedSwitch(
+            options=[
+                SegmentedSwitchOption(value=PluginChannel.STABLE, label="Stable"),
+                SegmentedSwitchOption(value=PluginChannel.DEV_LOCAL, label="Develop"),
+            ],
+            value=value,
+            id="plugin-source-switch",
+        )
+
+    def _get_source_switch_value(
+        self,
+        active_channel: str,
+        active_path,
+        active_record: CommunityPluginRecord | None,
+    ) -> str | None:
+        """Return the switch value when source switching should be available."""
+        if active_path:
+            if active_channel == PluginChannel.DEV_LOCAL:
+                return PluginChannel.DEV_LOCAL
+            if active_record:
+                return PluginChannel.STABLE
+        return None
 
     def action_toggle_plugin(self) -> None:
         """Toggle enable/disable state of selected plugin."""
@@ -519,6 +602,45 @@ class PluginManagementScreen(BaseScreen):
                 self.app.notify("Plugin installed and loaded!", severity="information")
 
         self.app.push_screen(InstallPluginScreen(self.config), on_install_done)
+
+    def action_set_dev_source(self) -> None:
+        """Configure a local development path for the selected plugin."""
+        if not self.selected_plugin:
+            self.app.notify("Please select a plugin", severity="warning")
+            return
+
+        current_path = self.config.get_plugin_source_path(self.selected_plugin)
+
+        self.app.push_screen(
+            DevSourcePathModal(
+                plugin_name=self.selected_plugin,
+                initial_value=str(current_path) if current_path else "",
+            ),
+            self._handle_dev_source_selected,
+        )
+
+    def _handle_dev_source_selected(self, path_value: str | None) -> None:
+        """Persist a validated development source path for the selected plugin."""
+        if not path_value or not self.selected_plugin:
+            return
+
+        repo_path = Path(path_value).expanduser().resolve()
+        error = get_local_plugin_validation_error(repo_path, self.selected_plugin)
+        if error:
+            self.app.notify(error, severity="error")
+            return
+
+        self.config.set_global_plugin_source(
+            self.selected_plugin,
+            PluginChannel.STABLE,
+            str(repo_path),
+        )
+        self.config.load()
+        self._load_plugins()
+        self.app.notify(
+            f"Development path configured for '{self.selected_plugin}'.",
+            severity="information",
+        )
 
     def action_remove_plugin_from_project(self) -> None:
         """Remove the selected missing plugin from the current project's config."""
@@ -629,7 +751,7 @@ class PluginManagementScreen(BaseScreen):
             return
 
         if self.config.get_plugin_source_channel(self.selected_plugin) == PluginChannel.DEV_LOCAL:
-            self._clear_project_plugin_source(self.selected_plugin)
+            self.config.clear_global_plugin_source(self.selected_plugin)
             self.config.load()
             self._load_plugins()
             self.app.notify(f"Dev local source removed for '{self.selected_plugin}'", severity="information")
@@ -661,23 +783,6 @@ class PluginManagementScreen(BaseScreen):
         self.config.load()
         self._load_plugins()
         self.app.notify(f"Plugin '{package_name}' ({channel}) uninstalled.", severity="information")
-
-    def _clear_project_plugin_source(self, plugin_name: str) -> None:
-        """Reset a plugin source override back to stable in the project config."""
-        project_cfg_path = self.config.project_config_path
-        if not project_cfg_path or not project_cfg_path.exists():
-            return
-
-        with open(project_cfg_path, "rb") as f:
-            project_cfg_dict = tomli.load(f)
-
-        plugin_table = project_cfg_dict.setdefault("plugins", {}).setdefault(plugin_name, {})
-        source_table = plugin_table.setdefault("source", {})
-        source_table["channel"] = PluginChannel.STABLE
-        source_table.pop("path", None)
-
-        with open(project_cfg_path, "wb") as f:
-            tomli_w.dump(project_cfg_dict, f)
 
     def _remove_plugin_from_project_config(self, plugin_name: str) -> None:
         """Remove a plugin block from the current project's config."""

--- a/titan_cli/ui/tui/screens/plugin_management.py
+++ b/titan_cli/ui/tui/screens/plugin_management.py
@@ -402,7 +402,7 @@ class PluginManagementScreen(BaseScreen):
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
             details.mount(DimText(f"  Active: {source_label}"))
-            if is_community_plugin and switch_value:
+            if is_enabled and is_community_plugin and switch_value:
                 details.mount(self._build_source_switch(switch_value))
                 self._source_switch_plugin = plugin_name
             if active_channel == PluginChannel.DEV_LOCAL and active_path:
@@ -416,7 +416,7 @@ class PluginManagementScreen(BaseScreen):
             details.mount(Text(""))
             details.mount(BoldText("Source:"))
             details.mount(DimText("  Active: Development Source"))
-            if is_community_plugin and switch_value:
+            if is_enabled and is_community_plugin and switch_value:
                 details.mount(self._build_source_switch(switch_value))
                 self._source_switch_plugin = plugin_name
             details.mount(DimText(f"  Path: {active_path}"))

--- a/titan_cli/ui/tui/widgets/__init__.py
+++ b/titan_cli/ui/tui/widgets/__init__.py
@@ -19,6 +19,8 @@ from .decision_badge import DecisionBadge
 from .prompt_option_list import PromptOptionList, OptionItem
 from .styled_option_list import StyledOptionList, StyledOption
 from .wizard import StepStatus, WizardStep, StepIndicator
+from .segmented_switch import SegmentedSwitch, SegmentedSwitchOption
+from .dev_source_path_modal import DevSourcePathModal
 from .text import (
     Text,
     DimText,
@@ -52,6 +54,9 @@ __all__ = [
     "OptionItem",
     "StyledOptionList",
     "StyledOption",
+    "SegmentedSwitch",
+    "SegmentedSwitchOption",
+    "DevSourcePathModal",
     "Text",
     "DimText",
     "BoldText",

--- a/titan_cli/ui/tui/widgets/dev_source_path_modal.py
+++ b/titan_cli/ui/tui/widgets/dev_source_path_modal.py
@@ -1,0 +1,73 @@
+"""
+Development source path modal.
+"""
+
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.widgets import Input
+
+from .button import Button
+from .text import BoldPrimaryText, DimText
+
+
+class DevSourcePathModal(ModalScreen[str | None]):
+    """Simple modal for capturing a local development path."""
+
+    CSS = """
+    DevSourcePathModal {
+        align: center middle;
+    }
+
+    #dev-source-dialog {
+        width: 80;
+        height: auto;
+        border: round $primary;
+        background: $surface-lighten-1;
+        padding: 1 2;
+    }
+
+    #dev-source-dialog Input {
+        width: 100%;
+        margin-top: 1;
+    }
+
+    #dev-source-buttons {
+        width: 100%;
+        height: auto;
+        align: right middle;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, plugin_name: str, initial_value: str = "", **kwargs):
+        super().__init__(**kwargs)
+        self.plugin_name = plugin_name
+        self.initial_value = initial_value
+
+    def compose(self) -> ComposeResult:
+        with Container(id="dev-source-dialog"):
+            yield BoldPrimaryText(f"Development Source: {self.plugin_name}")
+            yield DimText("Enter the local repository path for this plugin.")
+            yield Input(
+                value=self.initial_value,
+                placeholder="/path/to/plugin-repo",
+                id="dev-source-input",
+            )
+            with Horizontal(id="dev-source-buttons"):
+                yield Button("Cancel", variant="default", id="cancel-dev-source-button")
+                yield Button("Save", variant="primary", id="save-dev-source-button")
+
+    def on_mount(self) -> None:
+        self.query_one("#dev-source-input", Input).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel-dev-source-button":
+            self.dismiss(None)
+        elif event.button.id == "save-dev-source-button":
+            value = self.query_one("#dev-source-input", Input).value.strip()
+            self.dismiss(value or None)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "dev-source-input":
+            self.dismiss(event.value.strip() or None)

--- a/titan_cli/ui/tui/widgets/segmented_switch.py
+++ b/titan_cli/ui/tui/widgets/segmented_switch.py
@@ -35,21 +35,24 @@ class SegmentedSwitch(Widget):
 
     DEFAULT_CSS = """
     SegmentedSwitch {
-        width: auto;
+        width: 30;
         height: auto;
+        margin-top: 1;
     }
 
     SegmentedSwitch > Horizontal {
-        width: auto;
+        width: 100%;
+        min-width: 30;
         height: 3;
         background: $surface-lighten-1;
         border: round $primary;
         padding: 0;
+        layout: horizontal;
     }
 
     SegmentedSwitch .segment {
-        min-width: 14;
-        width: auto;
+        width: 1fr;
+        min-width: 10;
         height: 100%;
         padding: 0 2;
         content-align: center middle;
@@ -102,6 +105,7 @@ class SegmentedSwitch(Widget):
 
         self.options = options
         self.on_change = on_change
+        self._segment_values: dict[str, str] = {}
 
         option_values = {option.value for option in options}
         initial_value = value if value in option_values else options[0].value
@@ -111,9 +115,13 @@ class SegmentedSwitch(Widget):
         """Compose the segmented switch UI."""
         with Horizontal():
             for index, option in enumerate(self.options):
-                segment = Static(option.label, classes="segment", id=f"segment-{index}")
-                segment.segment_value = option.value
-                yield segment
+                segment_id = f"segment-{index}"
+                self._segment_values[segment_id] = option.value
+                yield Static(
+                    option.label,
+                    classes="segment",
+                    id=segment_id,
+                )
 
     def on_mount(self) -> None:
         """Sync styles and focus the widget when mounted."""
@@ -127,7 +135,7 @@ class SegmentedSwitch(Widget):
 
     def on_click(self, event) -> None:
         """Handle mouse selection of a segment."""
-        segment_value = getattr(event.widget, "segment_value", None)
+        segment_value = self._segment_values.get(getattr(event.widget, "id", ""))
         if segment_value is not None:
             self._set_value(segment_value, emit=True)
             event.stop()
@@ -181,5 +189,6 @@ class SegmentedSwitch(Widget):
 
     def _refresh_segments(self) -> None:
         """Sync active CSS classes with the current value."""
-        for segment in self.query(".segment", Static):
-            segment.set_class(getattr(segment, "segment_value", None) == self.value, "-active")
+        for segment in self.query(".segment"):
+            segment_value = self._segment_values.get(segment.id or "")
+            segment.set_class(segment_value == self.value, "-active")

--- a/titan_cli/ui/tui/widgets/segmented_switch.py
+++ b/titan_cli/ui/tui/widgets/segmented_switch.py
@@ -35,14 +35,14 @@ class SegmentedSwitch(Widget):
 
     DEFAULT_CSS = """
     SegmentedSwitch {
-        width: 30;
+        width: 22;
         height: auto;
-        margin-top: 1;
+        margin-top: 0;
     }
 
     SegmentedSwitch > Horizontal {
         width: 100%;
-        min-width: 30;
+        min-width: 22;
         height: 3;
         background: $surface-lighten-1;
         border: round $primary;
@@ -52,9 +52,9 @@ class SegmentedSwitch(Widget):
 
     SegmentedSwitch .segment {
         width: 1fr;
-        min-width: 10;
+        min-width: 7;
         height: 100%;
-        padding: 0 2;
+        padding: 0 1;
         content-align: center middle;
         text-align: center;
         color: $text-muted;

--- a/titan_cli/ui/tui/widgets/segmented_switch.py
+++ b/titan_cli/ui/tui/widgets/segmented_switch.py
@@ -36,7 +36,7 @@ class SegmentedSwitch(Widget):
     DEFAULT_CSS = """
     SegmentedSwitch {
         width: 22;
-        height: auto;
+        height: 3;
         margin-top: 0;
     }
 
@@ -48,6 +48,16 @@ class SegmentedSwitch(Widget):
         border: round $primary;
         padding: 0;
         layout: horizontal;
+        align: center middle;
+    }
+
+    SegmentedSwitch.-plain > Horizontal {
+        background: transparent;
+        border: none;
+    }
+
+    SegmentedSwitch.-plain {
+        width: 22;
     }
 
     SegmentedSwitch .segment {
@@ -58,7 +68,7 @@ class SegmentedSwitch(Widget):
         content-align: center middle;
         text-align: center;
         color: $text-muted;
-        background: transparent;
+        background: $surface-lighten-1;
     }
 
     SegmentedSwitch .segment.-active {
@@ -67,12 +77,27 @@ class SegmentedSwitch(Widget):
         text-style: bold;
     }
 
+    SegmentedSwitch.-plain .segment {
+        width: 1fr;
+        min-width: 7;
+        background: $panel-lighten-1;
+        color: $text;
+    }
+
+    SegmentedSwitch.-plain .segment.-active {
+        background: $primary;
+    }
+
     SegmentedSwitch:focus > Horizontal {
         border: round $accent;
     }
 
     SegmentedSwitch:focus .segment.-active {
         background: $accent;
+    }
+
+    SegmentedSwitch.-plain:focus > Horizontal {
+        border: none;
     }
     """
 
@@ -89,6 +114,7 @@ class SegmentedSwitch(Widget):
         options: list[SegmentedSwitchOption],
         value: Optional[str] = None,
         on_change: Optional[Callable[[str], None]] = None,
+        boxed: bool = True,
         **kwargs,
     ) -> None:
         """
@@ -106,10 +132,14 @@ class SegmentedSwitch(Widget):
         self.options = options
         self.on_change = on_change
         self._segment_values: dict[str, str] = {}
+        self.boxed = boxed
 
         option_values = {option.value for option in options}
         initial_value = value if value in option_values else options[0].value
         self.value = initial_value
+
+        if not boxed:
+            self.add_class("-plain")
 
     def compose(self) -> ComposeResult:
         """Compose the segmented switch UI."""

--- a/titan_cli/ui/tui/widgets/segmented_switch.py
+++ b/titan_cli/ui/tui/widgets/segmented_switch.py
@@ -1,0 +1,185 @@
+"""
+Segmented Switch Widget
+
+Reusable two-or-more option segmented switch for compact source selection.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+@dataclass(frozen=True)
+class SegmentedSwitchOption:
+    """Data model for a segmented switch option."""
+
+    value: str
+    label: str
+
+
+class SegmentedSwitch(Widget):
+    """
+    Reusable segmented switch with keyboard and mouse interaction.
+
+    Emits a ``Changed`` message when the selected option changes.
+    """
+
+    can_focus = True
+    value: reactive[str] = reactive("")
+
+    DEFAULT_CSS = """
+    SegmentedSwitch {
+        width: auto;
+        height: auto;
+    }
+
+    SegmentedSwitch > Horizontal {
+        width: auto;
+        height: 3;
+        background: $surface-lighten-1;
+        border: round $primary;
+        padding: 0;
+    }
+
+    SegmentedSwitch .segment {
+        min-width: 14;
+        width: auto;
+        height: 100%;
+        padding: 0 2;
+        content-align: center middle;
+        text-align: center;
+        color: $text-muted;
+        background: transparent;
+    }
+
+    SegmentedSwitch .segment.-active {
+        color: $text;
+        background: $primary;
+        text-style: bold;
+    }
+
+    SegmentedSwitch:focus > Horizontal {
+        border: round $accent;
+    }
+
+    SegmentedSwitch:focus .segment.-active {
+        background: $accent;
+    }
+    """
+
+    class Changed(Message):
+        """Message sent when the selected value changes."""
+
+        def __init__(self, sender: Widget, value: str):
+            super().__init__()
+            self.sender = sender
+            self.value = value
+
+    def __init__(
+        self,
+        options: list[SegmentedSwitchOption],
+        value: Optional[str] = None,
+        on_change: Optional[Callable[[str], None]] = None,
+        **kwargs,
+    ) -> None:
+        """
+        Initialize the segmented switch.
+
+        Args:
+            options: Ordered list of switch options.
+            value: Initially selected option value. Defaults to the first option.
+            on_change: Optional callback invoked after a user-driven change.
+        """
+        super().__init__(**kwargs)
+        if not options:
+            raise ValueError("SegmentedSwitch requires at least one option")
+
+        self.options = options
+        self.on_change = on_change
+
+        option_values = {option.value for option in options}
+        initial_value = value if value in option_values else options[0].value
+        self.value = initial_value
+
+    def compose(self) -> ComposeResult:
+        """Compose the segmented switch UI."""
+        with Horizontal():
+            for index, option in enumerate(self.options):
+                segment = Static(option.label, classes="segment", id=f"segment-{index}")
+                segment.segment_value = option.value
+                yield segment
+
+    def on_mount(self) -> None:
+        """Sync styles and focus the widget when mounted."""
+        self._refresh_segments()
+        self.focus()
+
+    def watch_value(self, _: str) -> None:
+        """Refresh segment styles when the selected value changes."""
+        if self.is_mounted:
+            self._refresh_segments()
+
+    def on_click(self, event) -> None:
+        """Handle mouse selection of a segment."""
+        segment_value = getattr(event.widget, "segment_value", None)
+        if segment_value is not None:
+            self._set_value(segment_value, emit=True)
+            event.stop()
+
+    def on_key(self, event) -> None:
+        """Handle keyboard navigation and selection."""
+        if event.key in {"left", "up"}:
+            self._move_selection(-1)
+            event.stop()
+        elif event.key in {"right", "down"}:
+            self._move_selection(1)
+            event.stop()
+        elif event.key == "home":
+            self._set_value(self.options[0].value, emit=True)
+            event.stop()
+        elif event.key == "end":
+            self._set_value(self.options[-1].value, emit=True)
+            event.stop()
+
+    def set_value(self, value: str) -> None:
+        """Update the switch value without emitting a change event."""
+        self._set_value(value, emit=False)
+
+    def _move_selection(self, step: int) -> None:
+        """Move the active segment left or right."""
+        current_index = self._get_index(self.value)
+        next_index = max(0, min(len(self.options) - 1, current_index + step))
+        self._set_value(self.options[next_index].value, emit=True)
+
+    def _set_value(self, value: str, emit: bool) -> None:
+        """Update the selected value and optionally emit a change event."""
+        if value == self.value:
+            return
+
+        self.value = value
+        if emit:
+            self._emit_changed()
+
+    def _emit_changed(self) -> None:
+        """Emit the changed message and invoke the callback."""
+        if self.on_change:
+            self.on_change(self.value)
+        self.post_message(self.Changed(self, self.value))
+
+    def _get_index(self, value: str) -> int:
+        """Return the index for a given option value."""
+        for index, option in enumerate(self.options):
+            if option.value == value:
+                return index
+        return 0
+
+    def _refresh_segments(self) -> None:
+        """Sync active CSS classes with the current value."""
+        for segment in self.query(".segment", Static):
+            segment.set_class(getattr(segment, "segment_value", None) == self.value, "-active")


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->

Implements a global plugin source override mechanism that allows users to configure plugin sources at the user-level (`~/.titan/config.toml`) with precedence over project-level settings. This enables developers to use local plugin versions across all projects without modifying each project's configuration, while ensuring that global source overrides never implicitly enable plugins in projects.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added global plugin source override system with user-local precedence over project-level source metadata
- Implemented `set_global_plugin_source()` and `clear_global_plugin_source()` methods to manage user-level plugin sources
- Fixed critical bug where global plugin source overrides would implicitly enable plugins in projects that hadn't explicitly enabled them
- Added package root tracking and cleanup for dev_local plugins to properly manage Poetry plugin entry points
- Enhanced `SegmentedSwitch` widget with plain/unboxed variant styling for cleaner UI presentation
- Refactored plugin source switch layout with improved refresh behavior and clearer UI labels
- Added Poetry plugin entry points support (`[tool.poetry.plugins."titan.plugins"]`) for better dev plugin management

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [x] All tests passing (`make test`)
- [x] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

Added comprehensive test coverage for the global plugin source override mechanism:
- `test_get_plugin_source_prefers_global_override_over_project` — verifies global source takes precedence
- `test_set_global_plugin_source_writes_user_config` — validates global config writing without enabling plugins
- `test_clear_global_plugin_source_removes_only_source_block` — ensures other plugin settings are preserved
- `test_save_global_config_preserves_existing_plugin_source` — prevents accidental override erasure
- `test_global_source_override_does_not_enable_plugin_in_other_projects` — critical test ensuring source-only overrides don't enable plugins
- `test_project_must_explicitly_enable_plugin` — validates explicit enable requirement
- Local plugin source validation tests with improved UI feedback

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed