### PR TITLE
fix: Allow project config to use modern schema without being rewritten

### DIFF
--- a/plugins/titan-plugin-github/tests/unit/test_gh_network.py
+++ b/plugins/titan-plugin-github/tests/unit/test_gh_network.py
@@ -125,6 +125,31 @@ def test_run_command_api_error(gh_network):
         assert "pull request not found" in str(exc_info.value).lower()
 
 
+def test_run_command_api_error_logs_with_custom_logger(gh_network):
+    """API failures should be logged via the custom structured logger."""
+    gh_network._logger = Mock()
+
+    with patch('titan_plugin_github.clients.network.gh_network.subprocess.run') as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "pr", "create", "--body", "secret body"],
+            stderr="GraphQL: Something went wrong",
+        )
+
+        with pytest.raises(GitHubAPIError):
+            gh_network.run_command(["pr", "create", "--body", "secret body"])
+
+    gh_network._logger.error.assert_called_once()
+    event_name = gh_network._logger.error.call_args.args[0]
+    event_fields = gh_network._logger.error.call_args.kwargs
+
+    assert event_name == "gh_command_failed"
+    assert event_fields["subcommand"] == "pr"
+    assert event_fields["action"] == "create"
+    assert event_fields["exit_code"] == 1
+    assert isinstance(event_fields["duration"], float)
+
+
 def test_run_command_cli_not_found(gh_network):
     """Test command execution when gh CLI is not installed"""
     with patch('titan_plugin_github.clients.network.gh_network.subprocess.run') as mock_run:

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/network/gh_network.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/network/gh_network.py
@@ -99,7 +99,7 @@ class GHNetwork:
             )
             return result.stdout.strip()
         except subprocess.CalledProcessError as e:
-            self._logger.debug(
+            self._logger.error(
                 "gh_command_failed",
                 subcommand=subcommand,
                 action=action,
@@ -107,7 +107,7 @@ class GHNetwork:
                 exit_code=e.returncode,
             )
             error_msg = e.stderr.strip() if e.stderr else str(e)
-            raise GitHubAPIError(msg.GitHub.API_ERROR.format(error_msg=error_msg))
+            raise GitHubAPIError(msg.GitHub.API_ERROR.format(error_msg=error_msg)) from e
         except FileNotFoundError:
             raise GitHubError(msg.GitHub.CLI_NOT_FOUND)
         except Exception as e:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -413,6 +413,43 @@ def test_load_does_not_rewrite_legacy_project_config(
     assert loaded_project == legacy_project_data
 
 
+def test_load_accepts_already_migrated_project_config(
+    tmp_path: Path, monkeypatch, mocker
+):
+    mocker.patch("titan_cli.core.config.PluginRegistry")
+
+    global_config_path = tmp_path / "home" / ".titan" / "config.toml"
+    global_config_path.parent.mkdir(parents=True)
+    with open(global_config_path, "wb") as f:
+        tomli_w.dump({"config_version": "1.0"}, f)
+
+    project_root = tmp_path / "project"
+    project_config_path = project_root / ".titan" / "config.toml"
+    project_config_path.parent.mkdir(parents=True)
+    project_config_data = {
+        "config_version": "1.0",
+        "project": {"name": "demo-project"},
+    }
+    with open(project_config_path, "wb") as f:
+        tomli_w.dump(project_config_data, f)
+
+    monkeypatch.setattr(TitanConfig, "GLOBAL_CONFIG", global_config_path)
+    monkeypatch.setattr(
+        TitanConfig,
+        "_find_project_config",
+        lambda self, path: project_config_path,
+    )
+    monkeypatch.setattr("titan_cli.core.config.find_project_root", lambda: project_root)
+
+    config = TitanConfig()
+
+    with open(project_config_path, "rb") as f:
+        loaded_project = tomli.load(f)
+
+    assert config.config.project.name == "demo-project"
+    assert loaded_project == project_config_data
+
+
 def test_config_finds_titan_at_git_root_not_subdir(tmp_path: Path, monkeypatch, mocker):
     """
     When running from /monorepo/app with .titan only at /monorepo,

--- a/titan_cli/core/config.py
+++ b/titan_cli/core/config.py
@@ -18,10 +18,7 @@ class TitanConfig:
 
     GLOBAL_CONFIG = Path.home() / ".titan" / "config.toml"
     global_migration_manager = MigrationManager()
-    project_migration_manager = MigrationManager(
-        migrations=[],
-        target_version="legacy",
-    )
+    project_migration_manager = MigrationManager()
 
     def __init__(
         self,
@@ -69,10 +66,7 @@ class TitanConfig:
         self.project_config_path = self._find_project_config(project_root)
 
         # Load project config if it exists
-        self.project_config = self._load_and_migrate_toml(
-            self.project_config_path,
-            migration_manager=self.project_migration_manager,
-        )
+        self.project_config = self._load_toml(self.project_config_path)
 
         # Merge and validate final config
         merged = self._merge_configs(self.global_config, self.project_config)
@@ -133,6 +127,7 @@ class TitanConfig:
         self,
         path: Optional[Path],
         migration_manager: MigrationManager,
+        write_on_migration: bool = True,
     ) -> dict:
         """Load TOML and normalize it to the current config schema."""
         raw_config = self._load_toml(path)
@@ -148,7 +143,7 @@ class TitanConfig:
                 to_version=migration_result.final_version,
                 steps=migration_result.applied_steps,
             )
-            if path is not None:
+            if write_on_migration and path is not None:
                 self._write_toml(path, migration_result.data)
 
         return migration_result.data


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This pull request addresses an issue where project-level `config.toml` files that were already using the modern schema were being unnecessarily rewritten during initialization. The previous logic incorrectly attempted to run a migration on these files. This change ensures that up-to-date configuration files are loaded without being modified on disk.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Modified `TitanConfig.__init__` to load the project configuration directly without forcing a migration.
- Removed the legacy-specific configuration from the `project_migration_manager`.
- Added a new unit test to verify that a modern project config is loaded correctly and is not rewritten.

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
A new test, `test_load_accepts_already_migrated_project_config`, was added. It creates a project configuration file that is already in the modern format and asserts that the `TitanConfig` class can load it successfully without altering the original file on disk.

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed