### PR TITLE
feat: Add method to retrieve commits between two git references

### DIFF
--- a/plugins/titan-plugin-git/tests/services/test_commit_service.py
+++ b/plugins/titan-plugin-git/tests/services/test_commit_service.py
@@ -197,6 +197,52 @@ class TestCommitServiceCountCommitsAhead:
 
 
 @pytest.mark.unit
+class TestCommitServiceGetCommitsBetweenRefs:
+    """Test CommitService.get_commits_between_refs()"""
+
+    def test_returns_commit_list(self, service, mock_git_network):
+        """Test parses multi-line log output into list"""
+        mock_git_network.run_command.return_value = "feat: A\nfix: B\nchore: C"
+
+        result = service.get_commits_between_refs("0.4.0", "HEAD")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data == ["feat: A", "fix: B", "chore: C"]
+        mock_git_network.run_command.assert_called_once_with(
+            ["git", "log", "0.4.0..HEAD", "--pretty=format:%s"]
+        )
+
+    def test_uses_head_by_default(self, service, mock_git_network):
+        """Test default head_ref is HEAD"""
+        mock_git_network.run_command.return_value = ""
+
+        result = service.get_commits_between_refs("0.4.0")
+
+        assert isinstance(result, ClientSuccess)
+        mock_git_network.run_command.assert_called_once_with(
+            ["git", "log", "0.4.0..HEAD", "--pretty=format:%s"]
+        )
+
+    def test_empty_output_returns_empty_list(self, service, mock_git_network):
+        """Test empty output returns empty list"""
+        mock_git_network.run_command.return_value = ""
+
+        result = service.get_commits_between_refs("0.4.0", "master")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data == []
+
+    def test_error_returns_client_error(self, service, mock_git_network):
+        """Test git error returns ClientError"""
+        mock_git_network.run_command.side_effect = GitCommandError("unknown revision")
+
+        result = service.get_commits_between_refs("bad-ref", "HEAD")
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "COMMIT_ERROR"
+
+
+@pytest.mark.unit
 class TestCommitServiceCountUnpushedCommits:
     """Test CommitService.count_unpushed_commits()"""
 

--- a/plugins/titan-plugin-git/tests/unit/test_git_client.py
+++ b/plugins/titan-plugin-git/tests/unit/test_git_client.py
@@ -321,3 +321,22 @@ class TestGitClientWorktreeDelegation:
 
         assert isinstance(result, ClientError)
         assert result.error_code == "WORKTREE_COMMIT_ERROR"
+
+
+@pytest.mark.unit
+class TestGitClientCommitQueryDelegation:
+    """Test that GitClient delegates commit query methods to CommitService"""
+
+    def test_get_commits_between_refs_delegates(self, mock_services):
+        """Test get_commits_between_refs delegates to CommitService"""
+        mock_services['commit'].get_commits_between_refs.return_value = ClientSuccess(
+            data=["feat: A", "fix: B"],
+            message="Found 2 commits"
+        )
+
+        client = GitClient()
+        result = client.get_commits_between_refs("0.4.0", "HEAD")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data == ["feat: A", "fix: B"]
+        mock_services['commit'].get_commits_between_refs.assert_called_once_with("0.4.0", "HEAD")

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
@@ -267,6 +267,12 @@ class GitClient:
         """Get list of commits in head_branch that are not in base_branch."""
         return self.commit_service.get_branch_commits(base_branch, head_branch)
 
+    def get_commits_between_refs(
+        self, base_ref: str, head_ref: str = "HEAD"
+    ) -> ClientResult[List[str]]:
+        """Get list of commits reachable from head_ref but not base_ref."""
+        return self.commit_service.get_commits_between_refs(base_ref, head_ref)
+
     def count_commits_ahead(self, base_branch: str = "develop") -> ClientResult[int]:
         """Count how many commits current branch is ahead of base branch."""
         return self.commit_service.count_commits_ahead(base_branch)

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/services/commit_service.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/services/commit_service.py
@@ -226,6 +226,37 @@ class CommitService:
             return ClientError(error_message=str(e), error_code="COMMIT_ERROR")
 
     @log_client_operation()
+    def get_commits_between_refs(
+        self, base_ref: str, head_ref: str = "HEAD"
+    ) -> ClientResult[List[str]]:
+        """
+        Get list of commit subjects reachable from head_ref but not base_ref.
+
+        Args:
+            base_ref: Base git reference (tag, branch, or commit SHA)
+            head_ref: Head git reference (default: HEAD)
+
+        Returns:
+            ClientResult[List[str]] with commit messages
+        """
+        try:
+            output = self.git.run_command([
+                "git", "log", f"{base_ref}..{head_ref}", "--pretty=format:%s"
+            ])
+
+            if not output:
+                return ClientSuccess(data=[], message="No commits found")
+
+            commits = [line.strip() for line in output.split("\n") if line.strip()]
+            return ClientSuccess(
+                data=commits,
+                message=f"Found {len(commits)} commits between {base_ref} and {head_ref}",
+            )
+
+        except GitCommandError as e:
+            return ClientError(error_message=str(e), error_code="COMMIT_ERROR")
+
+    @log_client_operation()
     def count_commits_ahead(self, base_branch: str = "develop") -> ClientResult[int]:
         """
         Count how many commits current branch is ahead of base branch.


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR adds a new method to retrieve the list of commit subjects between two git references. It enhances the `GitClient` and `CommitService` to support querying commits via `git log <base_ref>..<head_ref>`, which is particularly useful for generating changelogs, summarizing branch differences, or analyzing release diffs.

## 🔧 Changes Made
- Added `get_commits_between_refs` method to `CommitService` to execute and parse `git log` output.
- Added corresponding delegation method `get_commits_between_refs` to `GitClient`.
- Implemented robust error handling to return `ClientError` on git command failures and `ClientSuccess` with an empty list when no commits are found.
- Applied existing `@log_client_operation()` decorator for standard observability.

## 🧪 Testing
- [x] Unit tests added/updated (`poetry run pytest`)
- [x] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

Added unit tests in `test_commit_service.py` covering multi-line log output parsing, default `HEAD` reference usage, empty outputs, and `GitCommandError` handling. Added a delegation test in `test_git_client.py` to ensure `GitClient` properly routes the call to `CommitService`.

## 📊 Logs
- [x] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [ ] Documentation updated if needed