### PR TITLE
feat: Add support for pushing and checking remote tag existence

### DIFF
--- a/plugins/titan-plugin-git/tests/services/test_remote_service.py
+++ b/plugins/titan-plugin-git/tests/services/test_remote_service.py
@@ -69,6 +69,29 @@ class TestRemoteServicePush:
 
         assert isinstance(result, ClientError)
         assert result.error_code == "PUSH_ERROR"
+
+
+@pytest.mark.unit
+class TestRemoteServicePushTag:
+    """Test RemoteService.push_tag()"""
+
+    def test_push_tag_basic(self, service, mock_git_network):
+        """Test push a specific tag to remote"""
+        mock_git_network.run_command.return_value = ""
+
+        result = service.push_tag("v1.0.0", remote="origin")
+
+        assert isinstance(result, ClientSuccess)
+        mock_git_network.run_command.assert_called_once_with(["git", "push", "origin", "v1.0.0"])
+
+    def test_push_tag_error_returns_client_error(self, service, mock_git_network):
+        """Test git error returns ClientError"""
+        mock_git_network.run_command.side_effect = GitCommandError("rejected")
+
+        result = service.push_tag("v1.0.0", remote="origin")
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "PUSH_ERROR"
         assert "rejected" in result.error_message
 
 

--- a/plugins/titan-plugin-git/tests/services/test_tag_service.py
+++ b/plugins/titan-plugin-git/tests/services/test_tag_service.py
@@ -145,3 +145,39 @@ class TestTagServiceListTags:
 
         assert isinstance(result, ClientError)
         assert result.error_code == "TAG_LIST_ERROR"
+
+
+@pytest.mark.unit
+class TestTagServiceRemoteTagExists:
+    """Test TagService.remote_tag_exists()"""
+
+    def test_remote_tag_exists_returns_true(self, service, mock_git_network):
+        """Test returns True when ls-remote returns a tag"""
+        mock_git_network.run_command.return_value = "abc123\trefs/tags/v1.0.0\n"
+
+        result = service.remote_tag_exists("v1.0.0", remote="origin")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data is True
+        mock_git_network.run_command.assert_called_once_with(
+            ["git", "ls-remote", "--tags", "origin", "refs/tags/v1.0.0"],
+            check=False,
+        )
+
+    def test_remote_tag_exists_returns_false(self, service, mock_git_network):
+        """Test returns False when ls-remote output is empty"""
+        mock_git_network.run_command.return_value = ""
+
+        result = service.remote_tag_exists("v9.9.9", remote="origin")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data is False
+
+    def test_remote_tag_exists_error_returns_client_error(self, service, mock_git_network):
+        """Test git error returns ClientError"""
+        mock_git_network.run_command.side_effect = GitCommandError("remote failure")
+
+        result = service.remote_tag_exists("v1.0.0", remote="origin")
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "TAG_CHECK_ERROR"

--- a/plugins/titan-plugin-git/tests/unit/test_git_client.py
+++ b/plugins/titan-plugin-git/tests/unit/test_git_client.py
@@ -340,3 +340,33 @@ class TestGitClientCommitQueryDelegation:
         assert isinstance(result, ClientSuccess)
         assert result.data == ["feat: A", "fix: B"]
         mock_services['commit'].get_commits_between_refs.assert_called_once_with("0.4.0", "HEAD")
+
+
+@pytest.mark.unit
+class TestGitClientTagAndRemoteDelegation:
+    """Test that GitClient delegates tag and remote helpers correctly"""
+
+    def test_remote_tag_exists_delegates(self, mock_services):
+        mock_services['tag'].remote_tag_exists.return_value = ClientSuccess(
+            data=True,
+            message="Tag exists on origin"
+        )
+
+        client = GitClient()
+        result = client.remote_tag_exists("0.4.0", "origin")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data is True
+        mock_services['tag'].remote_tag_exists.assert_called_once_with("0.4.0", "origin")
+
+    def test_push_tag_delegates(self, mock_services):
+        mock_services['remote'].push_tag.return_value = ClientSuccess(
+            data=None,
+            message="Pushed tag"
+        )
+
+        client = GitClient()
+        result = client.push_tag("0.4.0", "origin")
+
+        assert isinstance(result, ClientSuccess)
+        mock_services['remote'].push_tag.assert_called_once_with("0.4.0", "origin")

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
@@ -359,6 +359,10 @@ class GitClient:
         """Push to remote."""
         return self.remote_service.push(remote, branch, set_upstream, tags)
 
+    def push_tag(self, tag_name: str, remote: str = "origin") -> ClientResult[None]:
+        """Push a specific tag to remote."""
+        return self.remote_service.push_tag(tag_name, remote)
+
     def pull(
         self, remote: str = "origin", branch: Optional[str] = None
     ) -> ClientResult[None]:
@@ -411,6 +415,10 @@ class GitClient:
     def tag_exists(self, tag_name: str) -> ClientResult[bool]:
         """Check if a tag exists locally."""
         return self.tag_service.tag_exists(tag_name)
+
+    def remote_tag_exists(self, tag_name: str, remote: str = "origin") -> ClientResult[bool]:
+        """Check if a tag exists on a remote."""
+        return self.tag_service.remote_tag_exists(tag_name, remote)
 
     def list_tags(self) -> ClientResult[List[UIGitTag]]:
         """List all tags in the repository."""

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/services/remote_service.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/services/remote_service.py
@@ -72,6 +72,24 @@ class RemoteService:
             return ClientError(error_message=str(e), error_code="PUSH_ERROR")
 
     @log_client_operation()
+    def push_tag(self, tag_name: str, remote: str = "origin") -> ClientResult[None]:
+        """
+        Push a specific tag to remote.
+
+        Args:
+            tag_name: Tag name to push
+            remote: Remote name
+
+        Returns:
+            ClientResult[None]
+        """
+        try:
+            self.git.run_command(["git", "push", remote, tag_name])
+            return ClientSuccess(data=None, message=f"Pushed tag {tag_name} to {remote}")
+        except GitCommandError as e:
+            return ClientError(error_message=str(e), error_code="PUSH_ERROR")
+
+    @log_client_operation()
     def pull(
         self, remote: str = "origin", branch: Optional[str] = None
     ) -> ClientResult[None]:

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/services/tag_service.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/services/tag_service.py
@@ -94,6 +94,31 @@ class TagService:
             return ClientError(error_message=str(e), error_code="TAG_CHECK_ERROR")
 
     @log_client_operation()
+    def remote_tag_exists(self, tag_name: str, remote: str = "origin") -> ClientResult[bool]:
+        """
+        Check if a tag exists on a remote.
+
+        Args:
+            tag_name: Name of the tag to check
+            remote: Remote name
+
+        Returns:
+            ClientResult[bool] with True if tag exists on the remote
+        """
+        try:
+            output = self.git.run_command(
+                ["git", "ls-remote", "--tags", remote, f"refs/tags/{tag_name}"],
+                check=False,
+            )
+            exists = bool(output.strip())
+            return ClientSuccess(
+                data=exists,
+                message=f"Tag '{tag_name}' {'exists' if exists else 'does not exist'} on {remote}",
+            )
+        except GitCommandError as e:
+            return ClientError(error_message=str(e), error_code="TAG_CHECK_ERROR")
+
+    @log_client_operation()
     def list_tags(self) -> ClientResult[List[UIGitTag]]:
         """
         List all tags in the repository.


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR adds functionality to push specific tags to remote repositories and check for tag existence on remote repositories. It extends the GitClient with new methods for tag management and enhances the underlying services to handle remote tag operations.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `push_tag()` method to GitClient and RemoteService for pushing individual tags to remote repositories
- Implemented `remote_tag_exists()` method in TagService and GitClient to check if tags exist on remote repositories
- Added comprehensive unit tests for both new tag operations including success and error cases
- Updated client delegation tests to ensure proper method forwarding

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
Unit tests cover:
- Successful tag push operations with proper git command execution
- Error handling for tag push failures
- Remote tag existence checks returning true/false based on git output
- Error handling for remote tag check failures
- Client method delegation to underlying services

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed