### PR TITLE
docs: Add plugins section to documentation index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,12 @@ On first run, Titan guides you through setting up global preferences and enablin
 
     [→ Workflow Concepts](concepts/workflows.md)
 
+- **Explore built-in plugins**
+
+    Browse the capabilities of the official Git, GitHub, and Jira plugins.
+
+    [→ Plugins](plugins/overview.md)
+
 - **Build your own workflow**
 
     Hands-on tutorial: extend a built-in workflow with a custom step.


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR adds a new "Explore built-in plugins" section to the documentation index, providing users with easy access to information about the official Git, GitHub, and Jira plugins.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added plugins section with description and link to the documentation index
- Included reference to official Git, GitHub, and Jira plugins

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)

```