### PR TITLE
feat: Add Jira version management and GitHub PR workflow steps

### DIFF
--- a/docs/plugins/jira-plugin.md
+++ b/docs/plugins/jira-plugin.md
@@ -296,6 +296,70 @@ client.list_project_versions(project_key="APP")
 
 - `project_key`: Optional. Project key. Uses the configured default project when omitted.
 
+### Create a version
+
+Creates a Jira version in a project.
+
+**Call:**
+
+```python
+client.create_version(
+    name="25.45",
+    project_key="APP",
+    description="Weekly mobile release",
+    release_date="2026-04-30",
+)
+```
+
+**Parameters:**
+
+- `name`: Required. Version name.
+- `project_key`: Optional. Project key. Uses the configured default project when omitted.
+- `description`: Optional. Version description.
+- `release_date`: Optional. Jira release date in `YYYY-MM-DD` format.
+
+### Ensure a version exists
+
+Returns an existing version by name or creates it if missing.
+
+**Call:**
+
+```python
+client.ensure_version_exists(
+    name="25.45",
+    project_key="APP",
+    description="Weekly mobile release",
+)
+```
+
+**Parameters:**
+
+- `name`: Required. Version name.
+- `project_key`: Optional. Project key. Uses the configured default project when omitted.
+- `description`: Optional. Description to use if the version must be created.
+- `release_date`: Optional. Release date to use if the version must be created.
+
+### Assign a fixVersion
+
+Assigns a Jira fixVersion to an issue, by version ID or version name.
+
+**Call:**
+
+```python
+client.assign_fix_version(
+    issue_key="APP-123",
+    version_name="25.45",
+    project_key="APP",
+)
+```
+
+**Parameters:**
+
+- `issue_key`: Required. Issue key.
+- `version_id`: Optional. Jira version ID.
+- `version_name`: Optional. Version name. Required when `version_id` is not provided.
+- `project_key`: Optional. Project key used to resolve `version_name`. Uses the configured default project when omitted.
+
 ### Get priorities
 
 Returns the priorities available in Jira.

--- a/plugins/titan-plugin-github/tests/unit/test_pull_request_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pull_request_steps.py
@@ -1,0 +1,149 @@
+from unittest.mock import Mock
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import Error, Success, WorkflowContext
+from titan_plugin_github.models.view import UIPRMergeResult
+from titan_plugin_github.steps.pull_request_steps import (
+    get_pull_request_step,
+    merge_pull_request_step,
+    verify_pull_request_state_step,
+)
+
+
+class MockTextual:
+    def __init__(self):
+        self.begin_step = Mock()
+        self.end_step = Mock()
+        self.error_text = Mock()
+        self.success_text = Mock()
+        self.warning_text = Mock()
+        self.dim_text = Mock()
+
+    def loading(self, _message):
+        class _Loader:
+            def __enter__(self_inner):
+                return None
+
+            def __exit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _Loader()
+
+
+def make_context(mock_github_client=None, **data):
+    ctx = WorkflowContext(secrets=Mock(), textual=MockTextual(), github=mock_github_client)
+    ctx.data.update(data)
+    return ctx
+
+
+def test_get_pull_request_step_success(sample_ui_pr):
+    github = Mock()
+    github.get_pull_request.return_value = ClientSuccess(data=sample_ui_pr, message="ok")
+    ctx = make_context(github, pr_number=123)
+
+    result = get_pull_request_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"pr_info": sample_ui_pr}
+    github.get_pull_request.assert_called_once_with(123)
+    ctx.textual.end_step.assert_called_once_with("success")
+
+
+def test_get_pull_request_step_errors_without_pr_number():
+    ctx = make_context(Mock())
+
+    result = get_pull_request_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "No PR number in context"
+    ctx.textual.end_step.assert_called_once_with("error")
+
+
+def test_get_pull_request_step_client_error():
+    github = Mock()
+    github.get_pull_request.return_value = ClientError(error_message="boom")
+    ctx = make_context(github, pr_number=123)
+
+    result = get_pull_request_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "Failed to fetch PR: boom"
+    ctx.textual.end_step.assert_called_once_with("error")
+
+
+def test_merge_pull_request_step_success():
+    github = Mock()
+    merge_result = UIPRMergeResult(
+        merged=True,
+        status_icon="✅",
+        sha_short="abc123d",
+        message="Successfully merged",
+    )
+    github.merge_pr.return_value = ClientSuccess(data=merge_result, message="ok")
+    ctx = make_context(github, pr_number=123, merge_method="squash")
+
+    result = merge_pull_request_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"merge_result": merge_result}
+    github.merge_pr.assert_called_once_with(
+        123,
+        merge_method="squash",
+        commit_title=None,
+        commit_message=None,
+    )
+    ctx.textual.end_step.assert_called_once_with("success")
+
+
+def test_merge_pull_request_step_treats_unsuccessful_merge_as_error():
+    github = Mock()
+    merge_result = UIPRMergeResult(
+        merged=False,
+        status_icon="❌",
+        sha_short="",
+        message="Merge failed",
+    )
+    github.merge_pr.return_value = ClientSuccess(data=merge_result, message="failed")
+    ctx = make_context(github, pr_number=123)
+
+    result = merge_pull_request_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "Failed to merge PR #123: Merge failed"
+    ctx.textual.end_step.assert_called_once_with("error")
+
+
+def test_verify_pull_request_state_step_success(sample_ui_pr):
+    github = Mock()
+    merged_pr = sample_ui_pr
+    merged_pr.state = "MERGED"
+    github.get_pull_request.return_value = ClientSuccess(data=merged_pr, message="ok")
+    ctx = make_context(github, pr_number=123, expected_state="merged")
+
+    result = verify_pull_request_state_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"verified_pr_info": merged_pr}
+    ctx.textual.end_step.assert_called_once_with("success")
+
+
+def test_verify_pull_request_state_step_errors_on_mismatch(sample_ui_pr):
+    github = Mock()
+    github.get_pull_request.return_value = ClientSuccess(data=sample_ui_pr, message="ok")
+    ctx = make_context(github, pr_number=123, expected_state="MERGED")
+
+    result = verify_pull_request_state_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "PR #123 state mismatch: expected MERGED, got OPEN"
+    ctx.textual.end_step.assert_called_once_with("error")
+
+
+def test_verify_pull_request_state_step_requires_expected_state():
+    ctx = make_context(Mock(), pr_number=123)
+
+    result = verify_pull_request_state_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "No expected PR state in context"
+    ctx.textual.end_step.assert_called_once_with("error")

--- a/plugins/titan-plugin-github/titan_plugin_github/plugin.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/plugin.py
@@ -136,6 +136,11 @@ class GitHubPlugin(TitanPlugin):
         from .steps.ai_pr_step import ai_suggest_pr_description_step
         from .steps.issue_steps import ai_suggest_issue_title_and_body_step, create_issue_steps
         from .steps.preview_step import preview_and_confirm_issue_step
+        from .steps.pull_request_steps import (
+            get_pull_request_step,
+            merge_pull_request_step,
+            verify_pull_request_state_step,
+        )
         from .steps.pr_review_steps import (
             select_pr_for_review_step,
             fetch_pending_comments_step,
@@ -184,6 +189,9 @@ class GitHubPlugin(TitanPlugin):
             "ai_suggest_issue_title_and_body": ai_suggest_issue_title_and_body_step,
             "create_issue": create_issue_steps,
             "preview_and_confirm_issue": preview_and_confirm_issue_step,
+            "get_pull_request": get_pull_request_step,
+            "merge_pull_request": merge_pull_request_step,
+            "verify_pull_request_state": verify_pull_request_state_step,
             "select_pr_for_review": select_pr_for_review_step,
             "fetch_pending_comments": fetch_pending_comments_step,
             "check_clean_state": check_clean_state_step,

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/pull_request_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/pull_request_steps.py
@@ -1,0 +1,150 @@
+"""Reusable workflow steps for GitHub pull request operations."""
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
+
+from ..messages import msg
+
+
+def get_pull_request_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Fetch a pull request and store it in workflow context."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Fetch Pull Request")
+
+    if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
+        ctx.textual.end_step("error")
+        return Error("GitHub client not available")
+
+    pr_number = ctx.get("pr_number")
+    if not pr_number:
+        ctx.textual.error_text("No PR number in context")
+        ctx.textual.end_step("error")
+        return Error("No PR number in context")
+
+    with ctx.textual.loading(f"Fetching PR #{pr_number}..."):
+        result = ctx.github.get_pull_request(int(pr_number))
+
+    match result:
+        case ClientSuccess(data=pr_info):
+            ctx.textual.success_text(f"PR #{pr_info.number}: {pr_info.title}")
+            ctx.textual.end_step("success")
+            return Success(
+                f"Fetched PR #{pr_info.number}",
+                metadata={"pr_info": pr_info},
+            )
+        case ClientError(error_message=err):
+            ctx.textual.error_text(f"Failed to fetch PR: {err}")
+            ctx.textual.end_step("error")
+            return Error(f"Failed to fetch PR: {err}")
+
+
+def merge_pull_request_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Merge a pull request using the configured GitHub client."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Merge Pull Request")
+
+    if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
+        ctx.textual.end_step("error")
+        return Error("GitHub client not available")
+
+    pr_number = ctx.get("pr_number")
+    if not pr_number:
+        ctx.textual.error_text("No PR number in context")
+        ctx.textual.end_step("error")
+        return Error("No PR number in context")
+
+    merge_method = ctx.get("merge_method", "squash")
+    commit_title = ctx.get("commit_title")
+    commit_message = ctx.get("commit_message")
+
+    with ctx.textual.loading(f"Merging PR #{pr_number} with {merge_method}..."):
+        result = ctx.github.merge_pr(
+            int(pr_number),
+            merge_method=merge_method,
+            commit_title=commit_title,
+            commit_message=commit_message,
+        )
+
+    match result:
+        case ClientSuccess(data=merge_result):
+            if not merge_result.merged:
+                ctx.textual.error_text(f"Failed to merge PR #{pr_number}: {merge_result.message}")
+                ctx.textual.end_step("error")
+                return Error(f"Failed to merge PR #{pr_number}: {merge_result.message}")
+
+            ctx.textual.success_text(msg.GitHub.PR_MERGED.format(number=pr_number))
+            ctx.textual.end_step("success")
+            return Success(
+                f"Merged PR #{pr_number}",
+                metadata={"merge_result": merge_result},
+            )
+        case ClientError(error_message=err):
+            ctx.textual.error_text(f"Failed to merge PR: {err}")
+            ctx.textual.end_step("error")
+            return Error(f"Failed to merge PR: {err}")
+
+
+def verify_pull_request_state_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Verify a pull request is currently in the expected state."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Verify Pull Request State")
+
+    if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
+        ctx.textual.end_step("error")
+        return Error("GitHub client not available")
+
+    pr_number = ctx.get("pr_number")
+    if not pr_number:
+        ctx.textual.error_text("No PR number in context")
+        ctx.textual.end_step("error")
+        return Error("No PR number in context")
+
+    expected_state = ctx.get("expected_state")
+    if not expected_state:
+        ctx.textual.error_text("No expected PR state in context")
+        ctx.textual.end_step("error")
+        return Error("No expected PR state in context")
+
+    expected_state = str(expected_state).upper()
+
+    with ctx.textual.loading(f"Verifying PR #{pr_number} state..."):
+        result = ctx.github.get_pull_request(int(pr_number))
+
+    match result:
+        case ClientSuccess(data=pr_info):
+            actual_state = str(pr_info.state).upper()
+            if actual_state != expected_state:
+                ctx.textual.error_text(
+                    f"PR #{pr_number} is {actual_state}, expected {expected_state}"
+                )
+                ctx.textual.end_step("error")
+                return Error(
+                    f"PR #{pr_number} state mismatch: expected {expected_state}, got {actual_state}"
+                )
+
+            ctx.textual.success_text(f"PR #{pr_number} is {actual_state}")
+            ctx.textual.end_step("success")
+            return Success(
+                f"Verified PR #{pr_number} is {actual_state}",
+                metadata={"verified_pr_info": pr_info},
+            )
+        case ClientError(error_message=err):
+            ctx.textual.error_text(f"Failed to verify PR state: {err}")
+            ctx.textual.end_step("error")
+            return Error(f"Failed to verify PR state: {err}")
+
+
+__all__ = [
+    "get_pull_request_step",
+    "merge_pull_request_step",
+    "verify_pull_request_state_step",
+]

--- a/plugins/titan-plugin-jira/tests/unit/test_issue_management_operations.py
+++ b/plugins/titan-plugin-jira/tests/unit/test_issue_management_operations.py
@@ -1,0 +1,82 @@
+from titan_plugin_jira.models import UIJiraIssue, UIJiraTransition, UIJiraVersion
+from titan_plugin_jira.operations import (
+    find_transition_by_name_contains,
+    find_transition_by_target_status,
+    find_version_by_name,
+    issue_has_fix_version,
+)
+
+
+def make_issue(*, fix_versions=None):
+    return UIJiraIssue(
+        key="TEST-1",
+        id="1",
+        summary="Test",
+        description="Desc",
+        status="To Do",
+        status_icon="🟡",
+        status_category="To Do",
+        issue_type="Task",
+        issue_type_icon="✅",
+        assignee="Unassigned",
+        assignee_email=None,
+        reporter="Reporter",
+        priority="Medium",
+        priority_icon="🟡",
+        formatted_created_at="01/01/2025 10:00:00",
+        formatted_updated_at="01/01/2025 10:00:00",
+        labels=[],
+        components=[],
+        fix_versions=fix_versions or [],
+        is_subtask=False,
+        parent_key=None,
+        subtask_count=0,
+    )
+
+
+def test_find_transition_by_target_status_matches_case_insensitively():
+    transitions = [
+        UIJiraTransition(id="1", name="Move to QA", to_status="QA", to_status_icon="🟢"),
+        UIJiraTransition(id="2", name="Done", to_status="Done", to_status_icon="✅"),
+    ]
+
+    result = find_transition_by_target_status(transitions, "qa")
+
+    assert result is not None
+    assert result.id == "1"
+
+
+def test_find_transition_by_name_contains_returns_matching_transition():
+    transitions = [
+        UIJiraTransition(id="1", name="Move to QA", to_status="QA", to_status_icon="🟢"),
+        UIJiraTransition(id="2", name="Done", to_status="Done", to_status_icon="✅"),
+    ]
+
+    result = find_transition_by_name_contains(transitions, "qa")
+
+    assert result is not None
+    assert result.to_status == "QA"
+
+
+def test_find_version_by_name_returns_exact_match():
+    versions = [
+        UIJiraVersion(id="1", name="1.0.0", description="", released=False, release_date="Not set"),
+        UIJiraVersion(id="2", name="1.1.0", description="", released=False, release_date="Not set"),
+    ]
+
+    result = find_version_by_name(versions, "1.1.0")
+
+    assert result is not None
+    assert result.id == "2"
+
+
+def test_issue_has_fix_version_returns_true_when_present():
+    issue = make_issue(fix_versions=["1.0.0", "1.1.0"])
+
+    assert issue_has_fix_version(issue, "1.1.0") is True
+
+
+def test_issue_has_fix_version_returns_false_when_missing():
+    issue = make_issue(fix_versions=["1.0.0"])
+
+    assert issue_has_fix_version(issue, "2.0.0") is False

--- a/plugins/titan-plugin-jira/tests/unit/test_issue_management_steps.py
+++ b/plugins/titan-plugin-jira/tests/unit/test_issue_management_steps.py
@@ -1,0 +1,139 @@
+from unittest.mock import Mock
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import Error, Success, WorkflowContext
+from titan_plugin_jira.models import UIJiraTransition, UIJiraVersion
+from titan_plugin_jira.steps.issue_management_steps import (
+    assign_fix_version_step,
+    create_version_step,
+    ensure_version_exists_step,
+    get_transitions_step,
+    transition_issue_step,
+    verify_issue_has_fix_version_step,
+    verify_issue_state_step,
+)
+
+
+class MockTextual:
+    def __init__(self):
+        self.begin_step = Mock()
+        self.end_step = Mock()
+        self.error_text = Mock()
+        self.success_text = Mock()
+
+    def loading(self, _message):
+        class Loader:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        return Loader()
+
+
+def make_context(mock_jira=None, **data):
+    ctx = WorkflowContext(secrets=Mock(), textual=MockTextual(), jira=mock_jira)
+    ctx.data.update(data)
+    return ctx
+
+
+def test_get_transitions_step_success():
+    jira = Mock()
+    transitions = [UIJiraTransition(id="1", name="Move to QA", to_status="QA", to_status_icon="🟢")]
+    jira.get_transitions.return_value = ClientSuccess(data=transitions, message="ok")
+    ctx = make_context(jira, jira_issue_key="TEST-1")
+
+    result = get_transitions_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"jira_transitions": transitions}
+
+
+def test_transition_issue_step_success():
+    jira = Mock()
+    jira.transition_issue.return_value = ClientSuccess(data=None, message="ok")
+    ctx = make_context(jira, jira_issue_key="TEST-1", target_status="QA")
+
+    result = transition_issue_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"transition_target_status": "QA"}
+
+
+def test_verify_issue_state_step_mismatch_returns_error(sample_ui_issue):
+    jira = Mock()
+    jira.get_issue.return_value = ClientSuccess(data=sample_ui_issue, message="ok")
+    ctx = make_context(jira, jira_issue_key="TEST-123", expected_status="Done")
+
+    result = verify_issue_state_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "expected 'Done'" in result.message
+
+
+def test_create_version_step_success():
+    jira = Mock()
+    version = UIJiraVersion(id="10", name="1.0.0", description="", released=False, release_date="Not set")
+    jira.create_version.return_value = ClientSuccess(data=version, message="ok")
+    ctx = make_context(jira, project_key="TEST", version_name="1.0.0")
+
+    result = create_version_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"version": version, "version_id": "10", "version_name": "1.0.0"}
+
+
+def test_ensure_version_exists_step_success():
+    jira = Mock()
+    version = UIJiraVersion(id="10", name="1.0.0", description="", released=False, release_date="Not set")
+    jira.ensure_version_exists.return_value = ClientSuccess(data=version, message="ok")
+    ctx = make_context(jira, project_key="TEST", version_name="1.0.0")
+
+    result = ensure_version_exists_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"version": version, "version_id": "10", "version_name": "1.0.0"}
+
+
+def test_assign_fix_version_step_success():
+    jira = Mock()
+    jira.assign_fix_version.return_value = ClientSuccess(data=None, message="ok")
+    ctx = make_context(jira, jira_issue_key="TEST-1", version_name="1.0.0", project_key="TEST")
+
+    result = assign_fix_version_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"assigned_fix_version": "1.0.0"}
+
+
+def test_verify_issue_has_fix_version_step_success(sample_ui_issue):
+    jira = Mock()
+    sample_ui_issue.fix_versions = ["1.0.0"]
+    jira.get_issue.return_value = ClientSuccess(data=sample_ui_issue, message="ok")
+    ctx = make_context(jira, jira_issue_key="TEST-123", version_name="1.0.0")
+
+    result = verify_issue_has_fix_version_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata == {"verified_jira_issue": sample_ui_issue}
+
+
+def test_verify_issue_has_fix_version_step_missing_version_returns_error(sample_ui_issue):
+    jira = Mock()
+    jira.get_issue.return_value = ClientSuccess(data=sample_ui_issue, message="ok")
+    ctx = make_context(jira, jira_issue_key="TEST-123", version_name="2.0.0")
+
+    result = verify_issue_has_fix_version_step(ctx)
+
+    assert isinstance(result, Error)
+
+
+def test_get_transitions_step_client_error():
+    jira = Mock()
+    jira.get_transitions.return_value = ClientError(error_message="boom")
+    ctx = make_context(jira, jira_issue_key="TEST-1")
+
+    result = get_transitions_step(ctx)
+
+    assert isinstance(result, Error)

--- a/plugins/titan-plugin-jira/tests/unit/test_jira_client.py
+++ b/plugins/titan-plugin-jira/tests/unit/test_jira_client.py
@@ -279,6 +279,57 @@ def test_list_project_versions_no_default_key():
     assert result.error_code == "MISSING_PROJECT_KEY"
 
 
+def test_create_version_delegates_to_metadata_service(jira_client):
+    """Test that create_version delegates to MetadataService."""
+    jira_client._metadata_service.create_version = Mock(
+        return_value=ClientSuccess(data=Mock(id="1", name="1.0.0"), message="Created")
+    )
+
+    result = jira_client.create_version("1.0.0")
+
+    assert isinstance(result, ClientSuccess)
+    jira_client._metadata_service.create_version.assert_called_once_with(
+        project_key="TEST",
+        name="1.0.0",
+        description=None,
+        release_date=None,
+    )
+
+
+def test_ensure_version_exists_delegates_to_metadata_service(jira_client):
+    """Test that ensure_version_exists delegates to MetadataService."""
+    jira_client._metadata_service.ensure_version_exists = Mock(
+        return_value=ClientSuccess(data=Mock(id="1", name="1.0.0"), message="Ready")
+    )
+
+    result = jira_client.ensure_version_exists("1.0.0")
+
+    assert isinstance(result, ClientSuccess)
+    jira_client._metadata_service.ensure_version_exists.assert_called_once_with(
+        project_key="TEST",
+        name="1.0.0",
+        description=None,
+        release_date=None,
+    )
+
+
+def test_assign_fix_version_delegates_to_issue_service(jira_client):
+    """Test that assign_fix_version delegates to IssueService."""
+    jira_client._issue_service.assign_fix_version_reference = Mock(
+        return_value=ClientSuccess(data=None, message="Assigned")
+    )
+
+    result = jira_client.assign_fix_version("TEST-123", version_name="1.0.0")
+
+    assert isinstance(result, ClientSuccess)
+    jira_client._issue_service.assign_fix_version_reference.assert_called_once_with(
+        issue_key="TEST-123",
+        project_key="TEST",
+        version_id=None,
+        version_name="1.0.0",
+    )
+
+
 def test_get_comments_delegates(jira_client):
     """Test that get_comments delegates to CommentService"""
     jira_client._comment_service.get_comments = Mock(

--- a/plugins/titan-plugin-jira/titan_plugin_jira/clients/jira_client.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/clients/jira_client.py
@@ -360,6 +360,65 @@ class JiraClient:
 
         return self._metadata_service.list_project_versions(key)
 
+    def create_version(
+        self,
+        name: str,
+        project_key: Optional[str] = None,
+        description: Optional[str] = None,
+        release_date: Optional[str] = None,
+    ) -> ClientResult[UIJiraVersion]:
+        """Create a version in the provided or default Jira project."""
+        key = project_key or self.project_key
+        if not key:
+            return ClientError(
+                error_message="Project key not provided",
+                error_code="MISSING_PROJECT_KEY"
+            )
+
+        return self._metadata_service.create_version(
+            project_key=key,
+            name=name,
+            description=description,
+            release_date=release_date,
+        )
+
+    def ensure_version_exists(
+        self,
+        name: str,
+        project_key: Optional[str] = None,
+        description: Optional[str] = None,
+        release_date: Optional[str] = None,
+    ) -> ClientResult[UIJiraVersion]:
+        """Return an existing version by name or create it if missing."""
+        key = project_key or self.project_key
+        if not key:
+            return ClientError(
+                error_message="Project key not provided",
+                error_code="MISSING_PROJECT_KEY"
+            )
+
+        return self._metadata_service.ensure_version_exists(
+            project_key=key,
+            name=name,
+            description=description,
+            release_date=release_date,
+        )
+
+    def assign_fix_version(
+        self,
+        issue_key: str,
+        version_id: Optional[str] = None,
+        version_name: Optional[str] = None,
+        project_key: Optional[str] = None,
+    ) -> ClientResult[None]:
+        """Assign a fixVersion to an issue by version ID or version name."""
+        return self._issue_service.assign_fix_version_reference(
+            issue_key=issue_key,
+            project_key=project_key or self.project_key,
+            version_id=version_id,
+            version_name=version_name,
+        )
+
     def get_priorities(self) -> ClientResult[List[UIPriority]]:
         """
         Get all available priorities in Jira.

--- a/plugins/titan-plugin-jira/titan_plugin_jira/clients/services/issue_service.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/clients/services/issue_service.py
@@ -362,6 +362,93 @@ class IssueService:
                 error_code="CREATE_SUBTASK_ERROR"
             )
 
+    @log_client_operation()
+    def assign_fix_version(
+        self,
+        issue_key: str,
+        version_id: str,
+    ) -> ClientResult[None]:
+        """Assign a fixVersion to an issue using a Jira version ID."""
+        try:
+            payload = {
+                "update": {
+                    "fixVersions": [
+                        {
+                            "add": {"id": version_id}
+                        }
+                    ]
+                }
+            }
+
+            self.network.make_request("PUT", f"issue/{issue_key}", json=payload)
+
+            return ClientSuccess(
+                data=None,
+                message=f"Assigned fixVersion {version_id} to {issue_key}",
+            )
+
+        except JiraAPIError as e:
+            return ClientError(
+                error_message=f"Failed to assign fixVersion {version_id} to {issue_key}: {e.message}",
+                error_code="ASSIGN_FIX_VERSION_ERROR",
+            )
+
+    @log_client_operation()
+    def assign_fix_version_by_name(
+        self,
+        issue_key: str,
+        project_key: str,
+        version_name: str,
+    ) -> ClientResult[None]:
+        """Assign a fixVersion to an issue by resolving a project version name."""
+        if not self.metadata_service:
+            return ClientError(
+                error_message="MetadataService not available",
+                error_code="SERVICE_NOT_AVAILABLE"
+            )
+
+        versions_result = self.metadata_service.list_project_versions(project_key)
+        match versions_result:
+            case ClientSuccess(data=versions):
+                matching_version = next(
+                    (version for version in versions if version.name == version_name),
+                    None,
+                )
+                if not matching_version:
+                    return ClientError(
+                        error_message=f"Version '{version_name}' not found in project {project_key}",
+                        error_code="VERSION_NOT_FOUND"
+                    )
+                return self.assign_fix_version(issue_key, matching_version.id)
+            case ClientError() as error:
+                return error
+
+    @log_client_operation()
+    def assign_fix_version_reference(
+        self,
+        issue_key: str,
+        project_key: str | None = None,
+        version_id: str | None = None,
+        version_name: str | None = None,
+    ) -> ClientResult[None]:
+        """Assign a fixVersion to an issue by version ID or version name."""
+        if version_id:
+            return self.assign_fix_version(issue_key, version_id)
+
+        if not version_name:
+            return ClientError(
+                error_message="Either version_id or version_name is required",
+                error_code="MISSING_VERSION_REFERENCE"
+            )
+
+        if not project_key:
+            return ClientError(
+                error_message="Project key not provided",
+                error_code="MISSING_PROJECT_KEY"
+            )
+
+        return self.assign_fix_version_by_name(issue_key, project_key, version_name)
+
     def _convert_text_to_adf(self, text: str) -> dict:
         """
         Convert plain text to Atlassian Document Format (ADF).

--- a/plugins/titan-plugin-jira/titan_plugin_jira/clients/services/metadata_service.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/clients/services/metadata_service.py
@@ -224,6 +224,76 @@ class MetadataService:
                 error_code="LIST_VERSIONS_ERROR",
             )
 
+    @log_client_operation()
+    def create_version(
+        self,
+        project_key: str,
+        name: str,
+        description: str | None = None,
+        release_date: str | None = None,
+    ) -> ClientResult[UIJiraVersion]:
+        """Create a Jira version for a project."""
+        try:
+            payload = {
+                "project": project_key,
+                "name": name,
+            }
+
+            if description:
+                payload["description"] = description
+            if release_date:
+                payload["releaseDate"] = release_date
+
+            data = self.network.make_request("POST", "version", json=payload)
+
+            network_version = NetworkJiraVersion(
+                id=data.get("id", ""),
+                name=data.get("name", name),
+                description=data.get("description"),
+                released=data.get("released", False),
+                releaseDate=data.get("releaseDate"),
+            )
+
+            return ClientSuccess(
+                data=from_network_version(network_version),
+                message=f"Version {name} created",
+            )
+
+        except JiraAPIError as e:
+            return ClientError(
+                error_message=f"Failed to create version {name} in {project_key}: {e.message}",
+                error_code="CREATE_VERSION_ERROR",
+            )
+
+    @log_client_operation()
+    def ensure_version_exists(
+        self,
+        project_key: str,
+        name: str,
+        description: str | None = None,
+        release_date: str | None = None,
+    ) -> ClientResult[UIJiraVersion]:
+        """Return an existing version by name or create it if missing."""
+        versions_result = self.list_project_versions(project_key)
+
+        match versions_result:
+            case ClientSuccess(data=versions):
+                existing_version = next((version for version in versions if version.name == name), None)
+                if existing_version:
+                    return ClientSuccess(
+                        data=existing_version,
+                        message=f"Version {name} already exists",
+                    )
+            case ClientError() as error:
+                return error
+
+        return self.create_version(
+            project_key=project_key,
+            name=name,
+            description=description,
+            release_date=release_date,
+        )
+
     def get_priorities(self) -> ClientResult[List[UIPriority]]:
         """
         Get all available priorities in Jira.

--- a/plugins/titan-plugin-jira/titan_plugin_jira/messages.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/messages.py
@@ -48,6 +48,29 @@ class Messages:
             GET_FAILED: str = "Failed to get JIRA issue: {e}"
             ISSUE_NOT_FOUND: str = "JIRA issue not found: {issue_key}"
 
+        class Versions:
+            """Version management step messages"""
+            LIST_PROJECT_REQUIRED: str = "project_key is required. Provide it in workflow params or configure default_project in JIRA plugin."
+            VERSION_NAME_REQUIRED: str = "version_name is required"
+            CREATE_SUCCESS: str = "Created JIRA version: {version_name}"
+            CREATE_FAILED: str = "Failed to create JIRA version: {e}"
+            ENSURE_SUCCESS: str = "Version available: {version_name}"
+            ASSIGN_SUCCESS: str = "Assigned fix version '{version_name}' to {issue_key}"
+            ASSIGN_FAILED: str = "Failed to assign fix version: {e}"
+            VERIFY_SUCCESS: str = "Issue {issue_key} has fix version '{version_name}'"
+            VERIFY_FAILED: str = "Issue {issue_key} does not have fix version '{version_name}'"
+
+        class Transitions:
+            """Transition workflow step messages"""
+            ISSUE_KEY_REQUIRED: str = "JIRA issue key is required"
+            TARGET_STATUS_REQUIRED: str = "target_status is required"
+            GET_SUCCESS: str = "Retrieved {count} transition(s) for {issue_key}"
+            GET_FAILED: str = "Failed to get transitions: {e}"
+            TRANSITION_SUCCESS: str = "Updated JIRA issue {issue_key} to {status}"
+            TRANSITION_FAILED: str = "Failed to transition JIRA issue: {e}"
+            VERIFY_SUCCESS: str = "Issue {issue_key} is in status '{status}'"
+            VERIFY_FAILED: str = "Issue {issue_key} is '{actual_status}', expected '{expected_status}'"
+
         class CreateIssue:
             """Create issue step messages"""
             CREATING_ISSUE: str = "Creating JIRA issue: {summary}"

--- a/plugins/titan-plugin-jira/titan_plugin_jira/operations/__init__.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/operations/__init__.py
@@ -29,6 +29,13 @@ from .issue_operations import (
     transition_issue_to_ready_for_dev,
 )
 
+from .issue_management_operations import (
+    find_transition_by_target_status,
+    find_transition_by_name_contains,
+    find_version_by_name,
+    issue_has_fix_version,
+)
+
 __all__ = [
     # JQL operations
     "substitute_jql_variables",
@@ -44,4 +51,9 @@ __all__ = [
     # Issue operations
     "find_ready_to_dev_transition",
     "transition_issue_to_ready_for_dev",
+    # Workflow operations
+    "find_transition_by_target_status",
+    "find_transition_by_name_contains",
+    "find_version_by_name",
+    "issue_has_fix_version",
 ]

--- a/plugins/titan-plugin-jira/titan_plugin_jira/operations/issue_management_operations.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/operations/issue_management_operations.py
@@ -1,0 +1,33 @@
+"""Pure operations for reusable Jira issue management capabilities."""
+
+from titan_plugin_jira.models import UIJiraIssue, UIJiraTransition, UIJiraVersion
+
+
+def find_transition_by_target_status(
+    transitions: list[UIJiraTransition], target_status: str
+) -> UIJiraTransition | None:
+    """Return the transition whose target status matches the requested status."""
+    target = target_status.strip().lower()
+    return next((t for t in transitions if t.to_status.strip().lower() == target), None)
+
+
+def find_transition_by_name_contains(
+    transitions: list[UIJiraTransition], needle: str
+) -> UIJiraTransition | None:
+    """Return the first transition whose name contains the provided text."""
+    normalized = needle.strip().lower()
+    return next((t for t in transitions if normalized in t.name.strip().lower()), None)
+
+
+def find_version_by_name(
+    versions: list[UIJiraVersion], version_name: str
+) -> UIJiraVersion | None:
+    """Return the Jira version with the exact requested name."""
+    target = version_name.strip()
+    return next((v for v in versions if v.name == target), None)
+
+
+def issue_has_fix_version(issue: UIJiraIssue, version_name: str) -> bool:
+    """Check whether a Jira issue already contains the requested fixVersion."""
+    target = version_name.strip()
+    return target in issue.fix_versions

--- a/plugins/titan-plugin-jira/titan_plugin_jira/plugin.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/plugin.py
@@ -263,6 +263,15 @@ class JiraPlugin(TitanPlugin):
         from .steps.get_issue_step import get_issue_step
         from .steps.ai_analyze_issue_step import ai_analyze_issue_requirements_step
         from .steps.list_versions_step import list_versions_step
+        from .steps.issue_management_steps import (
+            get_transitions_step,
+            transition_issue_step,
+            verify_issue_state_step,
+            create_version_step,
+            ensure_version_exists_step,
+            assign_fix_version_step,
+            verify_issue_has_fix_version_step,
+        )
 
         # Generic Issue Creation Workflow steps
         from .steps.prompt_issue_description_step import prompt_issue_description
@@ -281,6 +290,13 @@ class JiraPlugin(TitanPlugin):
             "get_issue": get_issue_step,
             "ai_analyze_issue_requirements": ai_analyze_issue_requirements_step,
             "list_versions": list_versions_step,
+            "get_transitions": get_transitions_step,
+            "transition_issue": transition_issue_step,
+            "verify_issue_state": verify_issue_state_step,
+            "create_version": create_version_step,
+            "ensure_version_exists": ensure_version_exists_step,
+            "assign_fix_version": assign_fix_version_step,
+            "verify_issue_has_fix_version": verify_issue_has_fix_version_step,
 
             # Generic Issue Creation Workflow steps
             "prompt_issue_description": prompt_issue_description,

--- a/plugins/titan-plugin-jira/titan_plugin_jira/steps/issue_management_steps.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/steps/issue_management_steps.py
@@ -1,0 +1,357 @@
+"""Reusable Jira steps for issue state and version management."""
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
+
+from ..messages import msg
+from ..operations import issue_has_fix_version
+
+
+def get_transitions_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Fetch available transitions for a Jira issue."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Get Jira Transitions")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    issue_key = ctx.get("jira_issue_key")
+    if not issue_key:
+        ctx.textual.error_text(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+
+    with ctx.textual.loading(f"Fetching transitions for {issue_key}..."):
+        result = ctx.jira.get_transitions(issue_key)
+
+    match result:
+        case ClientSuccess(data=transitions):
+            success_msg = msg.Steps.Transitions.GET_SUCCESS.format(
+                count=len(transitions), issue_key=issue_key
+            )
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(success_msg, metadata={"jira_transitions": transitions})
+        case ClientError(error_message=err):
+            error_msg = msg.Steps.Transitions.GET_FAILED.format(e=err)
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+def transition_issue_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Transition a Jira issue to a target status."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Transition Jira Issue")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    issue_key = ctx.get("jira_issue_key")
+    target_status = ctx.get("target_status")
+    comment = ctx.get("transition_comment")
+
+    if not issue_key:
+        ctx.textual.error_text(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+    if not target_status:
+        ctx.textual.error_text(msg.Steps.Transitions.TARGET_STATUS_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.TARGET_STATUS_REQUIRED)
+
+    with ctx.textual.loading(f"Transitioning {issue_key} to {target_status}..."):
+        result = ctx.jira.transition_issue(issue_key, target_status, comment)
+
+    match result:
+        case ClientSuccess():
+            success_msg = msg.Steps.Transitions.TRANSITION_SUCCESS.format(
+                issue_key=issue_key, status=target_status
+            )
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(success_msg, metadata={"transition_target_status": target_status})
+        case ClientError(error_message=err):
+            error_msg = msg.Steps.Transitions.TRANSITION_FAILED.format(e=err)
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+def verify_issue_state_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Verify that a Jira issue is currently in the expected status."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Verify Jira Issue State")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    issue_key = ctx.get("jira_issue_key")
+    expected_status = ctx.get("expected_status")
+
+    if not issue_key:
+        ctx.textual.error_text(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+    if not expected_status:
+        ctx.textual.error_text(msg.Steps.Transitions.TARGET_STATUS_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.TARGET_STATUS_REQUIRED)
+
+    with ctx.textual.loading(f"Verifying status for {issue_key}..."):
+        result = ctx.jira.get_issue(issue_key)
+
+    match result:
+        case ClientSuccess(data=issue):
+            if issue.status.lower() != str(expected_status).lower():
+                error_msg = msg.Steps.Transitions.VERIFY_FAILED.format(
+                    issue_key=issue_key,
+                    actual_status=issue.status,
+                    expected_status=expected_status,
+                )
+                ctx.textual.error_text(error_msg)
+                ctx.textual.end_step("error")
+                return Error(error_msg)
+
+            success_msg = msg.Steps.Transitions.VERIFY_SUCCESS.format(
+                issue_key=issue_key,
+                status=issue.status,
+            )
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(success_msg, metadata={"verified_jira_issue": issue})
+        case ClientError(error_message=err):
+            error_msg = msg.Steps.GetIssue.GET_FAILED.format(e=err)
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+def create_version_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Create a Jira version."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Create Jira Version")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    version_name = ctx.get("version_name")
+    project_key = ctx.get("project_key")
+    description = ctx.get("version_description")
+    release_date = ctx.get("release_date")
+
+    if not version_name:
+        ctx.textual.error_text(msg.Steps.Versions.VERSION_NAME_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Versions.VERSION_NAME_REQUIRED)
+
+    with ctx.textual.loading(f"Creating version {version_name}..."):
+        result = ctx.jira.create_version(
+            name=version_name,
+            project_key=project_key,
+            description=description,
+            release_date=release_date,
+        )
+
+    match result:
+        case ClientSuccess(data=version):
+            success_msg = msg.Steps.Versions.CREATE_SUCCESS.format(version_name=version.name)
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(
+                success_msg,
+                metadata={
+                    "version": version,
+                    "version_id": version.id,
+                    "version_name": version.name,
+                },
+            )
+        case ClientError(error_message=err, error_code=code):
+            error_msg = msg.Steps.Versions.CREATE_FAILED.format(e=err)
+            if code == "MISSING_PROJECT_KEY":
+                error_msg = msg.Steps.Versions.LIST_PROJECT_REQUIRED
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+def ensure_version_exists_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Ensure a Jira version exists, creating it if missing."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Ensure Jira Version Exists")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    version_name = ctx.get("version_name")
+    project_key = ctx.get("project_key")
+    description = ctx.get("version_description")
+    release_date = ctx.get("release_date")
+
+    if not version_name:
+        ctx.textual.error_text(msg.Steps.Versions.VERSION_NAME_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Versions.VERSION_NAME_REQUIRED)
+
+    with ctx.textual.loading(f"Ensuring version {version_name} exists..."):
+        result = ctx.jira.ensure_version_exists(
+            name=version_name,
+            project_key=project_key,
+            description=description,
+            release_date=release_date,
+        )
+
+    match result:
+        case ClientSuccess(data=version):
+            success_msg = msg.Steps.Versions.ENSURE_SUCCESS.format(version_name=version.name)
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(
+                success_msg,
+                metadata={
+                    "version": version,
+                    "version_id": version.id,
+                    "version_name": version.name,
+                },
+            )
+        case ClientError(error_message=err, error_code=code):
+            error_msg = msg.Steps.Versions.CREATE_FAILED.format(e=err)
+            if code == "MISSING_PROJECT_KEY":
+                error_msg = msg.Steps.Versions.LIST_PROJECT_REQUIRED
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+def assign_fix_version_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Assign a fixVersion to a Jira issue."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Assign Jira Fix Version")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    issue_key = ctx.get("jira_issue_key")
+    version_id = ctx.get("version_id")
+    version_name = ctx.get("version_name")
+    project_key = ctx.get("project_key")
+
+    if not issue_key:
+        ctx.textual.error_text(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+    if not version_id and not version_name:
+        ctx.textual.error_text("version_id or version_name is required")
+        ctx.textual.end_step("error")
+        return Error("version_id or version_name is required")
+
+    with ctx.textual.loading(f"Assigning fix version to {issue_key}..."):
+        result = ctx.jira.assign_fix_version(
+            issue_key=issue_key,
+            version_id=version_id,
+            version_name=version_name,
+            project_key=project_key,
+        )
+
+    match result:
+        case ClientSuccess():
+            resolved_name = version_name or version_id
+            success_msg = msg.Steps.Versions.ASSIGN_SUCCESS.format(
+                version_name=resolved_name,
+                issue_key=issue_key,
+            )
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(success_msg, metadata={"assigned_fix_version": resolved_name})
+        case ClientError(error_message=err):
+            error_msg = msg.Steps.Versions.ASSIGN_FAILED.format(e=err)
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+def verify_issue_has_fix_version_step(ctx: WorkflowContext) -> WorkflowResult:
+    """Verify a Jira issue has the expected fixVersion."""
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Verify Jira Fix Version")
+
+    if not ctx.jira:
+        ctx.textual.error_text(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+        ctx.textual.end_step("error")
+        return Error(msg.Plugin.CLIENT_NOT_AVAILABLE_IN_CONTEXT)
+
+    issue_key = ctx.get("jira_issue_key")
+    version_name = ctx.get("expected_fix_version") or ctx.get("version_name")
+
+    if not issue_key:
+        ctx.textual.error_text(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
+    if not version_name:
+        ctx.textual.error_text(msg.Steps.Versions.VERSION_NAME_REQUIRED)
+        ctx.textual.end_step("error")
+        return Error(msg.Steps.Versions.VERSION_NAME_REQUIRED)
+
+    with ctx.textual.loading(f"Verifying fix version on {issue_key}..."):
+        result = ctx.jira.get_issue(issue_key)
+
+    match result:
+        case ClientSuccess(data=issue):
+            if not issue_has_fix_version(issue, version_name):
+                error_msg = msg.Steps.Versions.VERIFY_FAILED.format(
+                    issue_key=issue_key,
+                    version_name=version_name,
+                )
+                ctx.textual.error_text(error_msg)
+                ctx.textual.end_step("error")
+                return Error(error_msg)
+
+            success_msg = msg.Steps.Versions.VERIFY_SUCCESS.format(
+                issue_key=issue_key,
+                version_name=version_name,
+            )
+            ctx.textual.success_text(success_msg)
+            ctx.textual.end_step("success")
+            return Success(success_msg, metadata={"verified_jira_issue": issue})
+        case ClientError(error_message=err):
+            error_msg = msg.Steps.GetIssue.GET_FAILED.format(e=err)
+            ctx.textual.error_text(error_msg)
+            ctx.textual.end_step("error")
+            return Error(error_msg)
+
+
+__all__ = [
+    "get_transitions_step",
+    "transition_issue_step",
+    "verify_issue_state_step",
+    "create_version_step",
+    "ensure_version_exists_step",
+    "assign_fix_version_step",
+    "verify_issue_has_fix_version_step",
+]


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR introduces new reusable workflow steps for Jira version management and GitHub pull request operations. It adds capabilities to create and manage Jira versions, assign fixVersions to issues, and provides steps for fetching, merging, and verifying GitHub pull request states.

## 🔧 Changes Made
- Added Jira client methods for version management: `create_version`, `ensure_version_exists`, and `assign_fix_version`
- Implemented GitHub pull request workflow steps: `get_pull_request_step`, `merge_pull_request_step`, and `verify_pull_request_state_step`
- Extended GitHub plugin to register the new pull request workflow steps
- Added comprehensive unit tests for all new GitHub PR steps covering success and error cases
- Updated Jira plugin documentation with detailed examples for version management functions

## 🧪 Testing
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

New unit tests cover:
- Successful PR fetching with proper metadata capture
- Error handling for missing PR numbers and client errors
- PR merge operations with different merge methods
- Verification of PR states with success and mismatch cases
- Proper contextual error messaging and UI state management

## 📊 Logs
- [ ] No new log events

## ✅ Checklist
- [x] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)