### PR TITLE
fix: Ensure autoupdate correctly reports when version does not change after pipx upgrade

### DIFF
--- a/tests/core/test_autoupdate.py
+++ b/tests/core/test_autoupdate.py
@@ -5,19 +5,48 @@ from titan_cli.utils import autoupdate
 
 def test_update_core_prefers_runtime_version_after_pipx_upgrade(mocker):
     """Report the version from the updated runtime when pipx upgrade succeeds."""
+    newer_version = "999.0.0"
     mock_run = mocker.patch("titan_cli.utils.autoupdate.subprocess.run")
     mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
     mocker.patch(
         "titan_cli.utils.autoupdate._get_installed_version_runtime",
-        return_value="0.3.0",
+        return_value=newer_version,
     )
     mocker.patch(
         "titan_cli.utils.autoupdate._get_installed_version_pipx",
-        return_value="0.2.0",
+        return_value=autoupdate.__version__,
     )
 
     result = autoupdate.update_core()
 
     assert result["success"] is True
     assert result["method"] == "pipx"
-    assert result["installed_version"] == "0.3.0"
+    assert result["installed_version"] == newer_version
+
+
+def test_update_core_fails_when_version_does_not_change_after_pipx_upgrade(mocker):
+    """Avoid reporting success when pipx leaves Titan on the current version."""
+    mock_run = mocker.patch("titan_cli.utils.autoupdate.subprocess.run")
+    mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+    mocker.patch(
+        "titan_cli.utils.autoupdate._get_installed_version_runtime",
+        return_value=autoupdate.__version__,
+    )
+    mocker.patch(
+        "titan_cli.utils.autoupdate._get_installed_version_pipx",
+        return_value=None,
+    )
+
+    result = autoupdate.update_core()
+
+    assert result["success"] is False
+    assert result["installed_version"] is None
+    assert result["error"] == (
+        f"Installed version remains at {autoupdate.__version__}; update did not apply"
+    )
+
+
+def test_is_newer_installed_version_requires_higher_semver():
+    """Only a strictly newer installed version should count as a successful update."""
+    assert autoupdate._is_newer_installed_version("999.0.0") is True
+    assert autoupdate._is_newer_installed_version(autoupdate.__version__) is False

--- a/titan_cli/utils/autoupdate.py
+++ b/titan_cli/utils/autoupdate.py
@@ -6,6 +6,8 @@ import subprocess
 from typing import Dict, Optional
 from pathlib import Path
 
+from packaging import version
+
 from titan_cli import __version__
 
 
@@ -137,10 +139,14 @@ def update_core() -> Dict[str, any]:
 
         if proc.returncode == 0:
             installed_version = _get_installed_version_runtime() or _get_installed_version_pipx()
-            if installed_version:
+            if installed_version and _is_newer_installed_version(installed_version):
                 result["success"] = True
                 result["method"] = "pipx"
                 result["installed_version"] = installed_version
+            elif installed_version:
+                result["error"] = (
+                    f"Installed version remains at {installed_version}; update did not apply"
+                )
             else:
                 result["error"] = "Could not verify installed version"
             return result
@@ -162,10 +168,14 @@ def update_core() -> Dict[str, any]:
 
         if proc.returncode == 0:
             installed_version = _get_installed_version_runtime() or _get_installed_version_pip()
-            if installed_version:
+            if installed_version and _is_newer_installed_version(installed_version):
                 result["success"] = True
                 result["method"] = "pip"
                 result["installed_version"] = installed_version
+            elif installed_version:
+                result["error"] = (
+                    f"Installed version remains at {installed_version}; update did not apply"
+                )
             else:
                 result["error"] = "Could not verify installed version"
         else:
@@ -285,6 +295,14 @@ def _get_installed_version_pip() -> Optional[str]:
     except Exception:
         pass
     return None
+
+
+def _is_newer_installed_version(installed_version: str) -> bool:
+    """Return True when the installed version is newer than the running one."""
+    try:
+        return version.parse(installed_version) > version.parse(__version__)
+    except Exception:
+        return installed_version != __version__
 
 
 def get_update_message(update_info: Dict[str, any]) -> Optional[str]:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR fixes a bug in the autoupdate functionality where the system would incorrectly report success even when the version did not actually change after a pipx upgrade. It introduces proper version comparison logic to ensure only genuine updates are considered successful.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `_is_newer_installed_version()` function to properly compare installed versions using semantic versioning
- Modified `update_core()` to check if the installed version is actually newer before reporting success
- Added test cases to verify correct behavior when version does not change after pipx upgrade
- Integrated `packaging.version` for robust semantic version comparison

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New unit tests cover scenarios where:
- Version remains unchanged after pipx upgrade (should report failure)
- Version is successfully upgraded (should report success)
- Semantic version comparison logic

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [x] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)
```