### PR TITLE
refactor: Improve autoupdate logic and add target version validation

### DIFF
--- a/tests/core/test_autoupdate.py
+++ b/tests/core/test_autoupdate.py
@@ -3,18 +3,14 @@ from unittest.mock import Mock
 from titan_cli.utils import autoupdate
 
 
-def test_update_core_prefers_runtime_version_after_pipx_upgrade(mocker):
-    """Report the version from the updated runtime when pipx upgrade succeeds."""
+def test_update_core_reports_verified_version_after_pipx_upgrade(mocker):
+    """Report the externally verified version when pipx upgrade succeeds."""
     newer_version = "999.0.0"
     mock_run = mocker.patch("titan_cli.utils.autoupdate.subprocess.run")
     mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
     mocker.patch(
-        "titan_cli.utils.autoupdate._get_installed_version_runtime",
+        "titan_cli.utils.autoupdate.get_installed_version",
         return_value=newer_version,
-    )
-    mocker.patch(
-        "titan_cli.utils.autoupdate._get_installed_version_pipx",
-        return_value=autoupdate.__version__,
     )
 
     result = autoupdate.update_core()
@@ -29,20 +25,53 @@ def test_update_core_fails_when_version_does_not_change_after_pipx_upgrade(mocke
     mock_run = mocker.patch("titan_cli.utils.autoupdate.subprocess.run")
     mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
     mocker.patch(
-        "titan_cli.utils.autoupdate._get_installed_version_runtime",
+        "titan_cli.utils.autoupdate.get_installed_version",
         return_value=autoupdate.__version__,
-    )
-    mocker.patch(
-        "titan_cli.utils.autoupdate._get_installed_version_pipx",
-        return_value=None,
     )
 
     result = autoupdate.update_core()
 
     assert result["success"] is False
-    assert result["installed_version"] is None
+    assert result["installed_version"] == autoupdate.__version__
     assert result["error"] == (
         f"Installed version remains at {autoupdate.__version__}; update did not apply"
+    )
+
+
+def test_update_core_succeeds_when_target_version_is_installed(mocker):
+    """Accept an update only when the visible installed version reaches target."""
+    target_version = "999.0.0"
+    mock_run = mocker.patch("titan_cli.utils.autoupdate.subprocess.run")
+    mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+    mocker.patch(
+        "titan_cli.utils.autoupdate.get_installed_version",
+        return_value=target_version,
+    )
+
+    result = autoupdate.update_core(target_version=target_version)
+
+    assert result["success"] is True
+    assert result["method"] == "pipx"
+    assert result["installed_version"] == target_version
+
+
+def test_update_core_fails_when_installed_version_is_below_target(mocker):
+    """Reject partial upgrades that do not reach the requested latest version."""
+    installed_version = "999.0.0"
+    target_version = "999.0.1"
+    mock_run = mocker.patch("titan_cli.utils.autoupdate.subprocess.run")
+    mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+    mocker.patch(
+        "titan_cli.utils.autoupdate.get_installed_version",
+        return_value=installed_version,
+    )
+
+    result = autoupdate.update_core(target_version=target_version)
+
+    assert result["success"] is False
+    assert result["installed_version"] == installed_version
+    assert result["error"] == (
+        f"Installed version is {installed_version}; expected at least {target_version}"
     )
 
 
@@ -50,3 +79,21 @@ def test_is_newer_installed_version_requires_higher_semver():
     """Only a strictly newer installed version should count as a successful update."""
     assert autoupdate._is_newer_installed_version("999.0.0") is True
     assert autoupdate._is_newer_installed_version(autoupdate.__version__) is False
+
+
+def test_meets_target_version_requires_target_or_higher():
+    """Target validation should not accept lower installed versions."""
+    assert autoupdate.meets_target_version("999.0.1", "999.0.0") is True
+    assert autoupdate.meets_target_version("999.0.0", "999.0.0") is True
+    assert autoupdate.meets_target_version("999.0.0", "999.0.1") is False
+
+
+def test_get_active_titan_version_parses_version_command(mocker):
+    """Read the version from the titan executable currently visible on PATH."""
+    mocker.patch("titan_cli.utils.autoupdate.shutil.which", return_value="/bin/titan")
+    mocker.patch(
+        "titan_cli.utils.autoupdate.subprocess.run",
+        return_value=Mock(returncode=0, stdout="Titan CLI v999.0.0\n", stderr=""),
+    )
+
+    assert autoupdate._get_active_titan_version() == "999.0.0"

--- a/tests/core/test_cli_autoupdate.py
+++ b/tests/core/test_cli_autoupdate.py
@@ -1,0 +1,77 @@
+from typer.testing import CliRunner
+
+from titan_cli.cli import app
+
+
+def test_cli_update_does_not_launch_tui_after_successful_update(mocker):
+    """A successful update should exit and ask the user to rerun Titan."""
+    runner = CliRunner()
+    mocker.patch(
+        "titan_cli.cli.check_for_updates",
+        return_value={
+            "update_available": True,
+            "current_version": "999.0.0",
+            "latest_version": "999.0.1",
+            "is_dev_install": False,
+            "error": None,
+        },
+    )
+    update_core = mocker.patch(
+        "titan_cli.cli.update_core",
+        return_value={
+            "success": True,
+            "method": "pipx",
+            "installed_version": "999.0.1",
+            "error": None,
+        },
+    )
+    mocker.patch(
+        "titan_cli.cli.update_plugins",
+        return_value={"success": True, "skipped": False, "error": None},
+    )
+    mocker.patch("titan_cli.cli.get_installed_version", return_value="999.0.1")
+    launch_tui = mocker.patch("titan_cli.cli.launch_tui")
+
+    result = runner.invoke(app, input="Y\n")
+
+    assert result.exit_code == 0
+    update_core.assert_called_once_with(target_version="999.0.1")
+    launch_tui.assert_not_called()
+    assert "Please run `titan` again" in result.output
+
+
+def test_cli_update_fails_when_final_version_check_fails(mocker):
+    """Do not report success if plugins leave Titan below the target version."""
+    runner = CliRunner()
+    mocker.patch(
+        "titan_cli.cli.check_for_updates",
+        return_value={
+            "update_available": True,
+            "current_version": "999.0.0",
+            "latest_version": "999.0.2",
+            "is_dev_install": False,
+            "error": None,
+        },
+    )
+    mocker.patch(
+        "titan_cli.cli.update_core",
+        return_value={
+            "success": True,
+            "method": "pipx",
+            "installed_version": "999.0.2",
+            "error": None,
+        },
+    )
+    mocker.patch(
+        "titan_cli.cli.update_plugins",
+        return_value={"success": True, "skipped": False, "error": None},
+    )
+    mocker.patch("titan_cli.cli.get_installed_version", return_value="999.0.1")
+    launch_tui = mocker.patch("titan_cli.cli.launch_tui")
+
+    result = runner.invoke(app, input="Y\n")
+
+    assert result.exit_code == 1
+    launch_tui.assert_not_called()
+    assert "Failed to verify Titan CLI after plugin update" in result.output
+    assert "expected at least 999.0.2" in result.output

--- a/titan_cli/cli.py
+++ b/titan_cli/cli.py
@@ -4,14 +4,19 @@ Titan CLI - Main CLI application
 Combines all tool commands into a single CLI interface.
 """
 import os
-import subprocess
 import sys
 import typer
 
 from titan_cli import __version__
 from titan_cli.messages import msg
 from titan_cli.ui.tui import launch_tui
-from titan_cli.utils.autoupdate import check_for_updates, update_core, update_plugins
+from titan_cli.utils.autoupdate import (
+    check_for_updates,
+    get_installed_version,
+    meets_target_version,
+    update_core,
+    update_plugins,
+)
 from titan_cli.core.logging import setup_logging, get_logger
 
 
@@ -86,7 +91,7 @@ def main(
 
                     # Step 1: update core
                     typer.echo("⏳ Updating Titan CLI...")
-                    core_result = update_core()
+                    core_result = update_core(target_version=latest)
 
                     if not core_result["success"]:
                         logger.error("update_core_failed", error=core_result["error"])
@@ -116,12 +121,30 @@ def main(
                     if not plugins_result.get("skipped"):
                         typer.echo("✅ Plugins updated")
 
-                    logger.info("update_successful", version=installed_version)
-                    typer.echo()
-                    typer.echo("🔄 Relaunching Titan with new version...")
-                    typer.echo()
+                    final_version = get_installed_version()
+                    if not final_version or not meets_target_version(final_version, latest):
+                        logger.error(
+                            "update_final_version_check_failed",
+                            expected=latest,
+                            installed=final_version,
+                        )
+                        typer.echo(
+                            "❌ Failed to verify Titan CLI after plugin update: "
+                            f"installed version is {final_version or 'unknown'}, "
+                            f"expected at least {latest}"
+                        )
+                        typer.echo()
+                        typer.echo("   Please update manually:")
+                        typer.echo("     pipx upgrade --force titan-cli")
+                        typer.echo("     pipx upgrade --include-injected titan-cli")
+                        sys.exit(1)
 
-                    subprocess.run(["titan"] + sys.argv[1:], shell=False, check=False)
+                    logger.info("update_successful", version=final_version)
+                    typer.echo()
+                    typer.echo(
+                        "✅ Update complete. Please run `titan` again to use "
+                        f"v{final_version}."
+                    )
                     sys.exit(0)
                 else:
                     logger.info("update_skipped")

--- a/titan_cli/utils/autoupdate.py
+++ b/titan_cli/utils/autoupdate.py
@@ -1,6 +1,8 @@
 """Auto-update utility for Titan CLI."""
 
 import os
+import re
+import shutil
 import sys
 import subprocess
 from typing import Dict, Optional
@@ -101,7 +103,7 @@ def check_for_updates() -> Dict[str, any]:
     return result
 
 
-def update_core() -> Dict[str, any]:
+def update_core(target_version: Optional[str] = None) -> Dict[str, any]:
     """
     Upgrade the titan-cli core package.
 
@@ -118,6 +120,13 @@ def update_core() -> Dict[str, any]:
     if mock_version:
         if os.environ.get("TITAN_MOCK_CORE_FAIL"):
             return {"success": False, "method": None, "installed_version": None, "error": "Mock core failure"}
+        if target_version and not _meets_target_version(mock_version, target_version):
+            return {
+                "success": False,
+                "method": None,
+                "installed_version": mock_version,
+                "error": _target_version_error(mock_version, target_version),
+            }
         return {"success": True, "method": "pipx", "installed_version": mock_version, "error": None}
 
     result = {
@@ -138,15 +147,14 @@ def update_core() -> Dict[str, any]:
         )
 
         if proc.returncode == 0:
-            installed_version = _get_installed_version_runtime() or _get_installed_version_pipx()
-            if installed_version and _is_newer_installed_version(installed_version):
+            installed_version = get_installed_version()
+            if installed_version and _is_expected_installed_version(installed_version, target_version):
                 result["success"] = True
                 result["method"] = "pipx"
                 result["installed_version"] = installed_version
             elif installed_version:
-                result["error"] = (
-                    f"Installed version remains at {installed_version}; update did not apply"
-                )
+                result["installed_version"] = installed_version
+                result["error"] = _target_version_error(installed_version, target_version)
             else:
                 result["error"] = "Could not verify installed version"
             return result
@@ -167,15 +175,14 @@ def update_core() -> Dict[str, any]:
         )
 
         if proc.returncode == 0:
-            installed_version = _get_installed_version_runtime() or _get_installed_version_pip()
-            if installed_version and _is_newer_installed_version(installed_version):
+            installed_version = get_installed_version()
+            if installed_version and _is_expected_installed_version(installed_version, target_version):
                 result["success"] = True
                 result["method"] = "pip"
                 result["installed_version"] = installed_version
             elif installed_version:
-                result["error"] = (
-                    f"Installed version remains at {installed_version}; update did not apply"
-                )
+                result["installed_version"] = installed_version
+                result["error"] = _target_version_error(installed_version, target_version)
             else:
                 result["error"] = "Could not verify installed version"
         else:
@@ -185,6 +192,40 @@ def update_core() -> Dict[str, any]:
     except subprocess.TimeoutExpired:
         result["error"] = "Update timed out"
         return result
+
+
+def get_installed_version() -> Optional[str]:
+    """Get the Titan version that is visible to the user after installation."""
+    return (
+        _get_active_titan_version()
+        or _get_installed_version_pipx()
+        or _get_installed_version_pip()
+        or _get_installed_version_runtime()
+    )
+
+
+def _get_active_titan_version() -> Optional[str]:
+    """Get the version reported by the `titan` command currently on PATH."""
+    titan_command = shutil.which("titan")
+    if not titan_command:
+        return None
+
+    try:
+        proc = subprocess.run(
+            [titan_command, "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if proc.returncode != 0:
+            return None
+
+        match = re.search(r"v?(\d+(?:\.\d+)+(?:[-+\.a-zA-Z0-9]*)?)", proc.stdout.strip())
+        if match:
+            return match.group(1)
+    except Exception:
+        pass
+    return None
 
 
 def update_plugins() -> Dict[str, any]:
@@ -303,6 +344,41 @@ def _is_newer_installed_version(installed_version: str) -> bool:
         return version.parse(installed_version) > version.parse(__version__)
     except Exception:
         return installed_version != __version__
+
+
+def _is_expected_installed_version(
+    installed_version: str,
+    target_version: Optional[str] = None,
+) -> bool:
+    """Return True when installed version satisfies the expected post-update state."""
+    if target_version:
+        return _meets_target_version(installed_version, target_version)
+    return _is_newer_installed_version(installed_version)
+
+
+def _meets_target_version(installed_version: str, target_version: str) -> bool:
+    """Return True when installed version is at least the requested target."""
+    try:
+        return version.parse(installed_version) >= version.parse(target_version)
+    except Exception:
+        return installed_version == target_version
+
+
+def meets_target_version(installed_version: str, target_version: str) -> bool:
+    """Return True when installed version is at least the requested target."""
+    return _meets_target_version(installed_version, target_version)
+
+
+def _target_version_error(
+    installed_version: str,
+    target_version: Optional[str] = None,
+) -> str:
+    """Build a precise error for a failed post-update version check."""
+    if target_version:
+        return (
+            f"Installed version is {installed_version}; expected at least {target_version}"
+        )
+    return f"Installed version remains at {installed_version}; update did not apply"
 
 
 def get_update_message(update_info: Dict[str, any]) -> Optional[str]:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR refactors the autoupdate functionality to improve reliability and adds validation for target version requirements. The changes ensure that updates are only considered successful when the installed version meets or exceeds the expected target version, preventing partial or failed updates from being reported as successful.

## 🔧 Changes Made
- Refactored autoupdate logic to validate installed version against target version
- Added new validation functions to check version requirements
- Improved error handling and messaging for failed updates
- Updated CLI behavior to prevent TUI launch after successful updates
- Enhanced test coverage for autoupdate scenarios including failure cases

## 🧪 Testing
- [x] Unit tests added/updated (`poetry run pytest`)
- [x] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

New unit tests cover:
- Successful updates when target version is installed
- Failed updates when installed version is below target
- CLI behavior after successful and failed updates
- Version validation logic

## 📊 Logs
- [ ] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)