### PR TITLE
feat: Add support for custom fields and update payloads in Jira transitions

### DIFF
--- a/plugins/titan-plugin-jira/tests/services/test_transition_service.py
+++ b/plugins/titan-plugin-jira/tests/services/test_transition_service.py
@@ -159,6 +159,64 @@ class TestTransitionServiceTransitionIssue:
         assert "update" in payload
         assert "comment" in payload["update"]
 
+    def test_transition_with_fields_adds_fields_payload(self, service, mock_jira_network, sample_transitions_response):
+        """Test custom transition fields are included in the payload"""
+        mock_jira_network.make_request.side_effect = [
+            sample_transitions_response,
+            None,
+        ]
+
+        fields = {
+            "customfield_11281": {"id": "19077"},
+            "customfield_11577": {"value": "Done, ready for QA"},
+        }
+
+        service.transition_issue("TEST-123", "Done", fields=fields)
+
+        post_call = mock_jira_network.make_request.call_args_list[1]
+        payload = post_call.kwargs["json"]
+        assert payload["fields"] == fields
+
+    def test_transition_with_comment_and_update_merges_updates(self, service, mock_jira_network, sample_transitions_response):
+        """Test explicit update payload is merged with generated comment update."""
+        mock_jira_network.make_request.side_effect = [
+            sample_transitions_response,
+            None,
+        ]
+
+        update = {
+            "labels": [{"add": "ready-for-qa"}],
+        }
+
+        service.transition_issue(
+            "TEST-123",
+            "Done",
+            comment="Moving to done",
+            update=update,
+        )
+
+        post_call = mock_jira_network.make_request.call_args_list[1]
+        payload = post_call.kwargs["json"]
+        assert payload["update"]["labels"] == [{"add": "ready-for-qa"}]
+        assert "comment" in payload["update"]
+
+    def test_transition_with_fields_and_update_includes_both(self, service, mock_jira_network, sample_transitions_response):
+        """Test fields and update can be sent together in one transition payload."""
+        mock_jira_network.make_request.side_effect = [
+            sample_transitions_response,
+            None,
+        ]
+
+        fields = {"customfield_1": {"id": "100"}}
+        update = {"labels": [{"add": "qa"}]}
+
+        service.transition_issue("TEST-123", "Done", fields=fields, update=update)
+
+        post_call = mock_jira_network.make_request.call_args_list[1]
+        payload = post_call.kwargs["json"]
+        assert payload["fields"] == fields
+        assert payload["update"] == update
+
     def test_case_insensitive_status_match(self, service, mock_jira_network, sample_transitions_response):
         """Test status name matching is case-insensitive"""
         mock_jira_network.make_request.side_effect = [

--- a/plugins/titan-plugin-jira/tests/unit/test_issue_management_steps.py
+++ b/plugins/titan-plugin-jira/tests/unit/test_issue_management_steps.py
@@ -61,6 +61,32 @@ def test_transition_issue_step_success():
     assert result.metadata == {"transition_target_status": "QA"}
 
 
+def test_transition_issue_step_passes_fields_and_update():
+    jira = Mock()
+    jira.transition_issue.return_value = ClientSuccess(data=None, message="ok")
+    fields = {"customfield_11281": {"id": "19077"}}
+    update = {"labels": [{"add": "qa"}]}
+    ctx = make_context(
+        jira,
+        jira_issue_key="TEST-1",
+        target_status="QA",
+        transition_comment="Completed",
+        fields=fields,
+        update=update,
+    )
+
+    result = transition_issue_step(ctx)
+
+    assert isinstance(result, Success)
+    jira.transition_issue.assert_called_once_with(
+        "TEST-1",
+        "QA",
+        comment="Completed",
+        fields=fields,
+        update=update,
+    )
+
+
 def test_verify_issue_state_step_mismatch_returns_error(sample_ui_issue):
     jira = Mock()
     jira.get_issue.return_value = ClientSuccess(data=sample_ui_issue, message="ok")

--- a/plugins/titan-plugin-jira/tests/unit/test_jira_client.py
+++ b/plugins/titan-plugin-jira/tests/unit/test_jira_client.py
@@ -372,11 +372,24 @@ def test_transition_issue_delegates(jira_client):
         return_value=ClientSuccess(data=None, message="Success")
     )
 
-    result = jira_client.transition_issue("TEST-123", "Done", comment="Completed")
+    fields = {"customfield_1": {"id": "100"}}
+    update = {"labels": [{"add": "qa"}]}
+
+    result = jira_client.transition_issue(
+        "TEST-123",
+        "Done",
+        comment="Completed",
+        fields=fields,
+        update=update,
+    )
 
     assert isinstance(result, ClientSuccess)
     jira_client._transition_service.transition_issue.assert_called_once_with(
-        "TEST-123", "Done", "Completed"
+        "TEST-123",
+        "Done",
+        comment="Completed",
+        fields=fields,
+        update=update,
     )
 
 

--- a/plugins/titan-plugin-jira/titan_plugin_jira/clients/jira_client.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/clients/jira_client.py
@@ -191,7 +191,9 @@ class JiraClient:
         self,
         issue_key: str,
         new_status: str,
-        comment: Optional[str] = None
+        comment: Optional[str] = None,
+        fields: Optional[dict] = None,
+        update: Optional[dict] = None,
     ) -> ClientResult[None]:
         """
         Transition issue to new status.
@@ -200,11 +202,19 @@ class JiraClient:
             issue_key: Issue key
             new_status: Target status name
             comment: Optional comment
+            fields: Optional Jira fields payload to send with the transition
+            update: Optional Jira update payload to merge into the transition
 
         Returns:
             ClientResult[None]
         """
-        return self._transition_service.transition_issue(issue_key, new_status, comment)
+        return self._transition_service.transition_issue(
+            issue_key,
+            new_status,
+            comment=comment,
+            fields=fields,
+            update=update,
+        )
 
     # ==================== CREATION OPERATIONS ====================
 

--- a/plugins/titan-plugin-jira/titan_plugin_jira/clients/services/transition_service.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/clients/services/transition_service.py
@@ -70,7 +70,9 @@ class TransitionService:
         self,
         issue_key: str,
         new_status: str,
-        comment: Optional[str] = None
+        comment: Optional[str] = None,
+        fields: Optional[dict] = None,
+        update: Optional[dict] = None,
     ) -> ClientResult[None]:
         """
         Transition issue to new status.
@@ -79,6 +81,8 @@ class TransitionService:
             issue_key: Issue key
             new_status: Target status name
             comment: Optional comment to add
+            fields: Optional Jira fields payload to send with the transition
+            update: Optional Jira update payload to merge into the transition
 
         Returns:
             ClientResult[None] (operation success/failure)
@@ -113,6 +117,9 @@ class TransitionService:
                 "transition": {"id": transition_id}
             }
 
+            if fields:
+                payload["fields"] = fields
+
             # Add comment if provided
             if comment:
                 payload["update"] = {
@@ -129,6 +136,10 @@ class TransitionService:
                         }
                     }]
                 }
+
+            if update:
+                existing_update = payload.get("update", {})
+                payload["update"] = {**existing_update, **update}
 
             # 4. Network call
             self.network.make_request("POST", f"issue/{issue_key}/transitions", json=payload)

--- a/plugins/titan-plugin-jira/titan_plugin_jira/steps/issue_management_steps.py
+++ b/plugins/titan-plugin-jira/titan_plugin_jira/steps/issue_management_steps.py
@@ -70,6 +70,8 @@ def transition_issue_step(ctx: WorkflowContext) -> WorkflowResult:
     issue_key = ctx.get("jira_issue_key")
     target_status = ctx.get("target_status")
     comment = ctx.get("transition_comment")
+    fields = ctx.get("transition_fields", ctx.get("fields"))
+    update = ctx.get("transition_update", ctx.get("update"))
 
     if not issue_key:
         ctx.textual.error_text(msg.Steps.Transitions.ISSUE_KEY_REQUIRED)
@@ -81,7 +83,13 @@ def transition_issue_step(ctx: WorkflowContext) -> WorkflowResult:
         return Error(msg.Steps.Transitions.TARGET_STATUS_REQUIRED)
 
     with ctx.textual.loading(f"Transitioning {issue_key} to {target_status}..."):
-        result = ctx.jira.transition_issue(issue_key, target_status, comment)
+        result = ctx.jira.transition_issue(
+            issue_key,
+            target_status,
+            comment=comment,
+            fields=fields,
+            update=update,
+        )
 
     match result:
         case ClientSuccess():


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR enhances the Jira transition functionality by adding support for custom fields and update payloads. Users can now pass additional field values and update operations when transitioning Jira issues, enabling more flexible and powerful workflow automation.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `fields` and `update` parameters to `JiraClient.transition_issue()` method
- Extended `TransitionService.transition_issue()` to handle custom fields and update payloads
- Updated payload construction logic to include fields and merge update operations
- Modified existing tests and added new test cases to cover the new functionality

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New unit tests cover:
- Transition with custom fields payload
- Merging explicit update payload with generated comment updates
- Combining fields and update payloads in a single transition

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)
```