### PR TITLE
feat: Enhance PR label selection and add review status features

### DIFF
--- a/docs/plugins/generated/github-step-reference.md
+++ b/docs/plugins/generated/github-step-reference.md
@@ -410,7 +410,7 @@ Asks the user if they want to assign the issue to themselves.
 
 ### `prompt_for_labels`
 
-Prompts the user to select labels for the issue.
+Prompt the user to select repository labels and save them to context.
 
 **How to read this contract**
 
@@ -425,7 +425,7 @@ Prompts the user to select labels for the issue.
   step: prompt_for_labels
 ```
 
-**Available to later steps:** `labels`
+**Available to later steps:** `<output_key>`
 
 **Requires**
 
@@ -433,18 +433,26 @@ Prompts the user to select labels for the issue.
 |------|------|-------------|
 | `ctx.github` | - | An initialized GitHubClient. |
 
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `output_key` | str, optional | Context key where selected labels should be stored. Defaults to `labels`. |
+| `prompt` | str, optional | Prompt text shown to the user. Defaults to `Select labels:`. |
+| `default_selected_key` | str, optional | Context key used to preselect labels. Defaults to `output_key`. |
+
 **Outputs (saved to ctx.data)**
 
 | Name | Type | Description |
 |------|------|-------------|
-| `labels` | list[str] | Labels selected by the user. |
+| `<output_key>` | list[str] | Labels selected by the user. |
 
 **Returns**
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `labels` | If label selection completes successfully. |
-| `Skip` | `labels` | If the repository has no labels. |
+| `Success` | `<output_key>` | If label selection completes successfully. |
+| `Skip` | - | If the repository has no labels. |
 | `Error` | - | If the GitHub client is unavailable or the prompt fails. |
 
 ### `select_cli`

--- a/docs/plugins/github/built-in-workflows.md
+++ b/docs/plugins/github/built-in-workflows.md
@@ -23,9 +23,10 @@ Set `params.draft` to control draft behavior:
 5. `before_pr_generation` hook
 6. `github.ai_suggest_pr_description`
 7. `github.prompt_for_pr_draft`
-8. `before_push` hook
-9. `github.create_pr`
-10. `after_pr` hook
+8. `github.prompt_for_labels` (configured to save into `pr_labels`)
+9. `before_push` hook
+10. `github.create_pr`
+11. `after_pr` hook
 
 ### Hooks
 

--- a/docs/plugins/github/workflow-steps.md
+++ b/docs/plugins/github/workflow-steps.md
@@ -27,7 +27,7 @@ For full contract details for every public step, including documented inputs, ou
 | `prompt_for_pr_draft` | Prompt and Selection | `create-pr-ai` |
 | `prompt_for_issue_body_step` | Prompt and Selection | `create-issue-ai` |
 | `prompt_for_self_assign` | Prompt and Selection | `create-issue-ai` |
-| `prompt_for_labels` | Prompt and Selection | - |
+| `prompt_for_labels` | Prompt and Selection | `create-pr-ai` |
 | `select_cli` | Prompt and Selection | - |
 | `ai_suggest_issue_title_and_body` | Issue Creation | `create-issue-ai` |
 | `preview_and_confirm_issue` | Issue Creation | - |
@@ -82,7 +82,7 @@ Use these steps when a workflow needs interactive user input before creation or 
 - `prompt_for_pr_draft`: ask whether the PR should be created as draft
 - `prompt_for_issue_body_step`: capture the raw issue request before AI expansion
 - `prompt_for_self_assign`: ask whether the current user should be assigned to the issue
-- `prompt_for_labels`: prompt for labels to attach to an issue or PR
+- `prompt_for_labels`: prompt for repository labels and save the selection to a configurable context key
 - `select_cli`: choose which external CLI a workflow should use
 
 ## Issue Creation
@@ -560,7 +560,7 @@ How to read these contracts:
 
 
 ??? info "`prompt_for_labels`"
-    Prompts the user to select labels for the issue.
+    Prompt the user to select repository labels and save them to context.
 
     **Workflow usage**
 
@@ -569,7 +569,7 @@ How to read these contracts:
       step: prompt_for_labels
     ```
 
-    **Available to later steps:** `labels`
+    **Available to later steps:** `<output_key>`
 
     **Requires**
 
@@ -579,20 +579,24 @@ How to read these contracts:
 
     **Inputs (from ctx.data)**
 
-    None documented.
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `output_key` | str, optional | Context key where selected labels should be stored. Defaults to `labels`. |
+    | `prompt` | str, optional | Prompt text shown to the user. Defaults to `Select labels:`. |
+    | `default_selected_key` | str, optional | Context key used to preselect labels. Defaults to `output_key`. |
 
     **Outputs (saved to ctx.data)**
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `labels` | list[str] | Labels selected by the user. |
+    | `<output_key>` | list[str] | Labels selected by the user. |
 
     **Returns**
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `labels` | If label selection completes successfully. |
-    | `Skip` | `labels` | If the repository has no labels. |
+    | `Success` | `<output_key>` | If label selection completes successfully. |
+    | `Skip` | - | If the repository has no labels. |
     | `Error` | - | If the GitHub client is unavailable or the prompt fails. |
 
 

--- a/plugins/titan-plugin-github/tests/conftest.py
+++ b/plugins/titan-plugin-github/tests/conftest.py
@@ -57,6 +57,8 @@ def sample_network_pr(sample_network_user):
         mergedAt=None,
         reviews=[],
         labels=[{"name": "feature"}, {"name": "backend"}],
+        statusCheckRollup=[],
+        reviewDecision="REVIEW_REQUIRED",
         isCrossRepository=False,
         headRepositoryOwnerLogin="test-owner",
     )
@@ -82,6 +84,8 @@ def sample_ui_pr():
         is_mergeable=True,
         is_draft=False,
         review_summary="No reviews",
+        checks_summary="No checks",
+        review_status_summary="review required",
         labels=["feature", "backend"],
         formatted_created_at="15/01/2025 10:00:00",
         formatted_updated_at="15/01/2025 11:00:00",

--- a/plugins/titan-plugin-github/tests/services/test_pr_service.py
+++ b/plugins/titan-plugin-github/tests/services/test_pr_service.py
@@ -43,6 +43,8 @@ def sample_pr_json():
         "mergedAt": None,
         "reviews": [],
         "labels": [{"name": "feature"}, {"name": "backend"}],
+        "statusCheckRollup": [],
+        "reviewDecision": "REVIEW_REQUIRED",
         "isCrossRepository": False,
         "headRepositoryOwner": {"login": "test-owner"},
     }
@@ -69,6 +71,8 @@ def test_get_pull_request_success(pr_service, mock_gh_network, sample_pr_json):
     assert result.data.is_draft is False
     assert result.data.is_cross_repository is False
     assert result.data.head_repository_owner == "test-owner"
+    assert result.data.checks_summary == "No checks"
+    assert result.data.review_status_summary == "review required"
     assert "feature" in result.data.labels
     assert "backend" in result.data.labels
 

--- a/plugins/titan-plugin-github/tests/test_issue_workflow.py
+++ b/plugins/titan-plugin-github/tests/test_issue_workflow.py
@@ -6,6 +6,7 @@ from titan_cli.core.result import ClientSuccess, ClientError
 from titan_cli.core.secrets import SecretManager
 from titan_plugin_github.steps.github_prompt_steps import (
     prompt_for_issue_body_step,
+    prompt_for_labels_step,
     prompt_for_pr_draft_step,
     prompt_for_self_assign_step,
 )
@@ -197,6 +198,45 @@ def test_prompt_for_pr_draft_step_asks_when_unset(mock_secret_manager):
         "Create this pull request as draft?",
         default=False,
     )
+
+
+def test_prompt_for_labels_step_uses_multiselect_and_output_key(mock_secret_manager):
+    ctx = WorkflowContext(
+        secrets=mock_secret_manager,
+        data={
+            "output_key": "pr_labels",
+            "prompt": "Select labels for this pull request:",
+            "pr_labels": ["feature"],
+        },
+    )
+    ctx.github = MagicMock()
+    ctx.textual = MagicMock()
+    ctx.github.list_labels.return_value = ClientSuccess(
+        data=["bug", "feature", "docs"],
+        message="Labels retrieved",
+    )
+    ctx.textual.ask_multiselect.return_value = ["bug", "feature"]
+
+    result = prompt_for_labels_step(ctx)
+    if result.metadata:
+        ctx.data.update(result.metadata)
+
+    assert isinstance(result, Success)
+    assert ctx.get("pr_labels") == ["bug", "feature"]
+    ctx.textual.ask_multiselect.assert_called_once()
+
+
+def test_prompt_for_labels_step_skips_when_repo_has_no_labels(mock_secret_manager):
+    from titan_cli.engine.results import Skip
+
+    ctx = WorkflowContext(secrets=mock_secret_manager, data={})
+    ctx.github = MagicMock()
+    ctx.textual = MagicMock()
+    ctx.github.list_labels.return_value = ClientSuccess(data=[], message="No labels")
+
+    result = prompt_for_labels_step(ctx)
+
+    assert isinstance(result, Skip)
 
 @patch("titan_plugin_github.clients.github_client.GitHubClient")
 def test_create_issue_step(MockGitHubClient, mock_secret_manager):

--- a/plugins/titan-plugin-github/tests/unit/test_formatting.py
+++ b/plugins/titan-plugin-github/tests/unit/test_formatting.py
@@ -8,6 +8,8 @@ from titan_plugin_github.models.formatting import (
     format_pr_stats,
     format_branch_info,
     calculate_review_summary,
+    summarize_status_check_rollup,
+    summarize_review_status,
 )
 
 
@@ -167,3 +169,27 @@ class TestCalculateReviewSummary:
         ]
         result = calculate_review_summary(reviews)
         assert result == "✅ 2 approved"
+
+
+class TestSummarizeStatusCheckRollup:
+    def test_no_checks(self):
+        assert summarize_status_check_rollup([]) == "No checks"
+
+    def test_success_and_pending_and_failure(self):
+        rollup = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "IN_PROGRESS", "conclusion": None},
+            {"status": "COMPLETED", "conclusion": "FAILURE"},
+        ]
+        assert summarize_status_check_rollup(rollup) == "1 failing, 1 pending, 1 passing"
+
+
+class TestSummarizeReviewStatus:
+    def test_draft_takes_precedence(self):
+        assert summarize_review_status("APPROVED", True) == "draft"
+
+    def test_review_required(self):
+        assert summarize_review_status("REVIEW_REQUIRED", False) == "review required"
+
+    def test_ready_for_review_fallback(self):
+        assert summarize_review_status(None, False) == "ready for review"

--- a/plugins/titan-plugin-github/tests/unit/test_formatting.py
+++ b/plugins/titan-plugin-github/tests/unit/test_formatting.py
@@ -177,11 +177,19 @@ class TestSummarizeStatusCheckRollup:
 
     def test_success_and_pending_and_failure(self):
         rollup = [
-            {"status": "COMPLETED", "conclusion": "SUCCESS"},
-            {"status": "IN_PROGRESS", "conclusion": None},
-            {"status": "COMPLETED", "conclusion": "FAILURE"},
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "status": "IN_PROGRESS", "conclusion": None},
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "FAILURE"},
         ]
         assert summarize_status_check_rollup(rollup) == "1 failing, 1 pending, 1 passing"
+
+    def test_ignores_status_context_entries(self):
+        rollup = [
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "StatusContext", "state": "SUCCESS", "context": "danger/euskaltel"},
+            {"__typename": "StatusContext", "state": "SUCCESS", "context": "danger/yoigo"},
+        ]
+        assert summarize_status_check_rollup(rollup) == "1 passing"
 
 
 class TestSummarizeReviewStatus:

--- a/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
@@ -34,6 +34,8 @@ class TestFromRestPR:
             changedFiles=5,
             reviews=reviews,
             labels=[{"name": "feature"}, {"name": "enhancement"}],
+            statusCheckRollup=[{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+            reviewDecision="APPROVED",
             createdAt="2025-01-15T10:00:00Z",
             updatedAt="2025-01-15T12:00:00Z",
         )
@@ -56,6 +58,8 @@ class TestFromRestPR:
         assert ui_pr.is_mergeable is True
         assert ui_pr.is_draft is False
         assert ui_pr.review_summary == "✅ 2 approved"
+        assert ui_pr.checks_summary == "1 passing"
+        assert ui_pr.review_status_summary == "approved"
         assert ui_pr.labels == ["feature", "enhancement"]
         assert ui_pr.formatted_created_at == "15/01/2025 10:00:00"
         assert ui_pr.formatted_updated_at == "15/01/2025 12:00:00"

--- a/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
@@ -333,6 +333,32 @@ class TestPRSelectionOperations:
             include_checks=True,
         ) == "by author · feat/test → main · Checks: 1 passing"
 
+    def test_build_pr_selection_title_escapes_rich_markup_in_pr_title(self):
+        pr = from_rest_pr(
+            NetworkPullRequest(
+                number=9,
+                title="[WIP] fix parser",
+                body="",
+                state="OPEN",
+                isDraft=False,
+                author=NetworkUser(login="author"),
+                headRefName="feat/test",
+                baseRefName="main",
+                mergeable="MERGEABLE",
+                additions=0,
+                deletions=0,
+                changedFiles=0,
+                reviews=[],
+                labels=[],
+                reviewDecision="APPROVED",
+            )
+        )
+
+        assert (
+            build_pr_selection_title(pr, include_review_badge=True)
+            == r"#9: \[WIP\] fix parser  [green]● approved[/green]"
+        )
+
     def test_format_review_status_badge(self):
         assert format_review_status_badge("approved") == "[green]● approved[/green]"
         assert format_review_status_badge("changes requested") == "[red]● changes requested[/red]"

--- a/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
@@ -359,8 +359,34 @@ class TestPRSelectionOperations:
             == r"#9: \[WIP\] fix parser  [green]● approved[/green]"
         )
 
+    def test_build_pr_selection_title_includes_draft_review_badge(self):
+        pr = from_rest_pr(
+            NetworkPullRequest(
+                number=10,
+                title="Draft PR",
+                body="",
+                state="OPEN",
+                isDraft=True,
+                author=NetworkUser(login="author"),
+                headRefName="feat/draft",
+                baseRefName="main",
+                mergeable="MERGEABLE",
+                additions=0,
+                deletions=0,
+                changedFiles=0,
+                reviews=[],
+                labels=[],
+            )
+        )
+
+        assert (
+            build_pr_selection_title(pr, include_review_badge=True)
+            == "#10: Draft PR  [yellow]● draft[/yellow]"
+        )
+
     def test_format_review_status_badge(self):
         assert format_review_status_badge("approved") == "[green]● approved[/green]"
         assert format_review_status_badge("changes requested") == "[red]● changes requested[/red]"
+        assert format_review_status_badge("draft") == "[yellow]● draft[/yellow]"
         assert format_review_status_badge("review required") == "[blue]● review required[/blue]"
         assert format_review_status_badge("ready for review") == "[cyan]● ready for review[/cyan]"

--- a/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
@@ -8,6 +8,7 @@ from titan_plugin_github.models.mappers.pr_mapper import from_rest_pr
 from titan_plugin_github.operations.pr_selection_operations import (
     build_pr_selection_description,
     build_pr_selection_title,
+    format_review_status_badge,
 )
 
 
@@ -322,10 +323,18 @@ class TestPRSelectionOperations:
             )
         )
 
-        assert build_pr_selection_title(pr, highlight_assigned=True) == "⭐ #8: Test"
+        assert (
+            build_pr_selection_title(pr, highlight_assigned=True, include_review_badge=True)
+            == "⭐ #8: Test  [green]● approved[/green]"
+        )
         assert build_pr_selection_description(
             pr,
             include_author=True,
             include_checks=True,
-            include_review_status=True,
-        ) == "by author · feat/test → main · Checks: 1 passing · Review: approved"
+        ) == "by author · feat/test → main · Checks: 1 passing"
+
+    def test_format_review_status_badge(self):
+        assert format_review_status_badge("approved") == "[green]● approved[/green]"
+        assert format_review_status_badge("changes requested") == "[red]● changes requested[/red]"
+        assert format_review_status_badge("review required") == "[blue]● review required[/blue]"
+        assert format_review_status_badge("ready for review") == "[cyan]● ready for review[/cyan]"

--- a/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
@@ -5,6 +5,10 @@ Unit tests for PR mappers
 from unittest.mock import Mock
 from titan_plugin_github.models.network.rest import NetworkPullRequest, NetworkUser
 from titan_plugin_github.models.mappers.pr_mapper import from_rest_pr
+from titan_plugin_github.operations.pr_selection_operations import (
+    build_pr_selection_description,
+    build_pr_selection_title,
+)
 
 
 class TestFromRestPR:
@@ -34,7 +38,7 @@ class TestFromRestPR:
             changedFiles=5,
             reviews=reviews,
             labels=[{"name": "feature"}, {"name": "enhancement"}],
-            statusCheckRollup=[{"status": "COMPLETED", "conclusion": "SUCCESS"}],
+            statusCheckRollup=[{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}],
             reviewDecision="APPROVED",
             createdAt="2025-01-15T10:00:00Z",
             updatedAt="2025-01-15T12:00:00Z",
@@ -270,3 +274,58 @@ class TestFromRestPR:
         # Assert
         assert ui_pr.formatted_created_at == ""
         assert ui_pr.formatted_updated_at == ""
+
+
+class TestPRSelectionOperations:
+    def test_build_pr_selection_description_base(self):
+        pr = from_rest_pr(
+            NetworkPullRequest(
+                number=7,
+                title="Test",
+                body="",
+                state="OPEN",
+                isDraft=False,
+                author=NetworkUser(login="author"),
+                headRefName="feat/test",
+                baseRefName="main",
+                mergeable="MERGEABLE",
+                additions=0,
+                deletions=0,
+                changedFiles=0,
+                reviews=[],
+                labels=[],
+            )
+        )
+
+        assert build_pr_selection_title(pr) == "#7: Test"
+        assert build_pr_selection_description(pr) == "feat/test → main"
+
+    def test_build_pr_selection_description_with_extras(self):
+        pr = from_rest_pr(
+            NetworkPullRequest(
+                number=8,
+                title="Test",
+                body="",
+                state="OPEN",
+                isDraft=False,
+                author=NetworkUser(login="author"),
+                headRefName="feat/test",
+                baseRefName="main",
+                mergeable="MERGEABLE",
+                additions=0,
+                deletions=0,
+                changedFiles=0,
+                reviews=[],
+                labels=[],
+                statusCheckRollup=[{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+                reviewDecision="APPROVED",
+            )
+        )
+
+        assert build_pr_selection_title(pr, highlight_assigned=True) == "⭐ #8: Test"
+        assert build_pr_selection_description(
+            pr,
+            include_author=True,
+            include_checks=True,
+            include_review_status=True,
+        ) == "by author · feat/test → main · Checks: 1 passing · Review: approved"

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/pr_service.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/pr_service.py
@@ -55,6 +55,7 @@ class PRService:
                 "baseRefName", "headRefName", "additions", "deletions",
                 "changedFiles", "mergeable", "isDraft", "createdAt",
                 "updatedAt", "mergedAt", "reviews", "labels",
+                "statusCheckRollup", "reviewDecision",
                 "isCrossRepository", "headRepositoryOwner",
             ]
 
@@ -114,7 +115,7 @@ class PRService:
                 "--search", f"review-requested:{current_user}",
                 "--state", "open",
                 "--limit", str(max_results),
-                "--json", "number,title,author,updatedAt,labels,isDraft,reviewRequests",
+                "--json", "number,title,author,updatedAt,labels,isDraft,reviewRequests,statusCheckRollup,reviewDecision",
             ] + self.gh.get_repo_arg()
 
             output = self.gh.run_command(args)
@@ -171,7 +172,7 @@ class PRService:
                 "pr", "list",
                 "--state", state,
                 "--limit", str(max_results),
-                "--json", "number,title,author,updatedAt,labels,isDraft,state,headRefName,baseRefName",
+                "--json", "number,title,author,updatedAt,labels,isDraft,state,headRefName,baseRefName,statusCheckRollup,reviewDecision",
             ] + self.gh.get_repo_arg()
 
             output = self.gh.run_command(args)
@@ -220,7 +221,7 @@ class PRService:
                 "pr", "list",
                 "--state", state,
                 "--limit", str(max_results),
-                "--json", "number,title,author,updatedAt,labels,isDraft,state,reviewRequests,headRefName,baseRefName",
+                "--json", "number,title,author,updatedAt,labels,isDraft,state,reviewRequests,headRefName,baseRefName,statusCheckRollup,reviewDecision",
             ] + self.gh.get_repo_arg()
 
             output = self.gh.run_command(args)

--- a/plugins/titan-plugin-github/titan_plugin_github/messages.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/messages.py
@@ -7,7 +7,7 @@ class Messages:
         ENTER_ISSUE_BODY: str = "Enter issue body/description (press Meta+Enter or Esc then Enter to finish):"
         CREATE_PR_AS_DRAFT: str = "Create this pull request as draft?"
         ASSIGN_TO_SELF: str = "Assign this issue to yourself?"
-        SELECT_LABELS: str = "Select labels for this issue:"
+        SELECT_LABELS: str = "Select labels:"
         ENTER_PR_BODY_INFO: str = "Enter a description for your pull request. When you are finished, press Meta+Enter (or Esc followed by Enter)."
 
     class GitHub:

--- a/plugins/titan-plugin-github/titan_plugin_github/models/__init__.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/__init__.py
@@ -37,6 +37,8 @@ from .view import (
     UIReviewSuggestion,
 )
 
+from .pr_enums import PRMergeableState, PRReviewDecision, PRState
+
 # Mappers
 from .mappers import (
     from_rest_pr,
@@ -70,6 +72,9 @@ __all__ = [
     "UIIssue",
     "UIRelease",
     "UIReviewSuggestion",
+    "PRState",
+    "PRMergeableState",
+    "PRReviewDecision",
     # Mappers
     "from_rest_pr",
     "from_rest_issue",

--- a/plugins/titan-plugin-github/titan_plugin_github/models/formatting.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/formatting.py
@@ -8,6 +8,8 @@ All presentation/display logic should use these utilities for consistency.
 from datetime import datetime
 from typing import Any, Optional
 
+from .pr_enums import PRReviewDecision, PRState
+
 
 def format_date(iso_date: str) -> str:
     """
@@ -34,7 +36,7 @@ def format_date(iso_date: str) -> str:
         return iso_date
 
 
-def get_pr_status_icon(state: str, is_draft: bool) -> str:
+def get_pr_status_icon(state: PRState | str, is_draft: bool) -> str:
     """
     Get emoji icon for PR state.
 
@@ -51,13 +53,15 @@ def get_pr_status_icon(state: str, is_draft: bool) -> str:
         >>> get_pr_status_icon("OPEN", True)
         '📝'
     """
-    if state == "MERGED":
+    state_value = str(state)
+
+    if state_value == PRState.MERGED:
         return "🟣"
-    elif state == "CLOSED":
+    elif state_value == PRState.CLOSED:
         return "🔴"
     elif is_draft:
         return "📝"
-    elif state == "OPEN":
+    elif state_value == PRState.OPEN:
         return "🟢"
     return "⚪"
 
@@ -152,14 +156,16 @@ def calculate_review_summary(reviews: list) -> str:
 
 def summarize_status_check_rollup(status_check_rollup: list[dict[str, Any]]) -> str:
     """Summarize PR checks into a compact human-readable string."""
-    if not status_check_rollup:
+    check_runs = [check for check in status_check_rollup if check.get("__typename") == "CheckRun"]
+
+    if not check_runs:
         return "No checks"
 
     passing = 0
     failing = 0
     pending = 0
 
-    for check in status_check_rollup:
+    for check in check_runs:
         status = str(check.get("status", "")).upper()
         conclusion = check.get("conclusion")
         conclusion = str(conclusion).upper() if conclusion is not None else None
@@ -184,18 +190,19 @@ def summarize_status_check_rollup(status_check_rollup: list[dict[str, Any]]) -> 
     return ", ".join(parts) if parts else "No checks"
 
 
-def summarize_review_status(review_decision: Optional[str], is_draft: bool) -> str:
+def summarize_review_status(review_decision: Optional[PRReviewDecision | str], is_draft: bool) -> str:
     """Summarize PR review state for list displays."""
     if is_draft:
         return "draft"
 
     mapping = {
-        "APPROVED": "approved",
-        "CHANGES_REQUESTED": "changes requested",
-        "REVIEW_REQUIRED": "review required",
+        PRReviewDecision.APPROVED: "approved",
+        PRReviewDecision.CHANGES_REQUESTED: "changes requested",
+        PRReviewDecision.REVIEW_REQUIRED: "review required",
     }
     if review_decision:
-        return mapping.get(review_decision.upper(), review_decision.lower())
+        normalized = str(review_decision)
+        return mapping.get(normalized, normalized.lower())
 
     return "ready for review"
 

--- a/plugins/titan-plugin-github/titan_plugin_github/models/formatting.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/formatting.py
@@ -6,7 +6,7 @@ Shared formatting functions for converting network data to UI-friendly strings.
 All presentation/display logic should use these utilities for consistency.
 """
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 
 def format_date(iso_date: str) -> str:
@@ -150,6 +150,56 @@ def calculate_review_summary(reviews: list) -> str:
         return f"💬 {len(reviews)} comments"
 
 
+def summarize_status_check_rollup(status_check_rollup: list[dict[str, Any]]) -> str:
+    """Summarize PR checks into a compact human-readable string."""
+    if not status_check_rollup:
+        return "No checks"
+
+    passing = 0
+    failing = 0
+    pending = 0
+
+    for check in status_check_rollup:
+        status = str(check.get("status", "")).upper()
+        conclusion = check.get("conclusion")
+        conclusion = str(conclusion).upper() if conclusion is not None else None
+
+        if status != "COMPLETED" or conclusion is None:
+            pending += 1
+        elif conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+            passing += 1
+        elif conclusion in {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "STARTUP_FAILURE", "STALE"}:
+            failing += 1
+        else:
+            pending += 1
+
+    parts = []
+    if failing:
+        parts.append(f"{failing} failing")
+    if pending:
+        parts.append(f"{pending} pending")
+    if passing:
+        parts.append(f"{passing} passing")
+
+    return ", ".join(parts) if parts else "No checks"
+
+
+def summarize_review_status(review_decision: Optional[str], is_draft: bool) -> str:
+    """Summarize PR review state for list displays."""
+    if is_draft:
+        return "draft"
+
+    mapping = {
+        "APPROVED": "approved",
+        "CHANGES_REQUESTED": "changes requested",
+        "REVIEW_REQUIRED": "review required",
+    }
+    if review_decision:
+        return mapping.get(review_decision.upper(), review_decision.lower())
+
+    return "ready for review"
+
+
 def get_review_state_icon(state: str) -> str:
     """
     Get icon for review state.
@@ -204,6 +254,8 @@ __all__ = [
     "format_pr_stats",
     "format_branch_info",
     "calculate_review_summary",
+    "summarize_status_check_rollup",
+    "summarize_review_status",
     "get_review_state_icon",
     "format_short_sha",
 ]

--- a/plugins/titan-plugin-github/titan_plugin_github/models/mappers/pr_mapper.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/mappers/pr_mapper.py
@@ -14,6 +14,8 @@ from ..formatting import (
     format_pr_stats,
     format_branch_info,
     calculate_review_summary,
+    summarize_status_check_rollup,
+    summarize_review_status,
     format_short_sha,
 )
 
@@ -48,6 +50,8 @@ def from_rest_pr(rest_pr: NetworkPullRequest) -> UIPullRequest:
         is_mergeable=(rest_pr.mergeable == "MERGEABLE"),
         is_draft=rest_pr.isDraft,
         review_summary=calculate_review_summary(rest_pr.reviews),
+        checks_summary=summarize_status_check_rollup(rest_pr.statusCheckRollup),
+        review_status_summary=summarize_review_status(rest_pr.reviewDecision, rest_pr.isDraft),
         labels=label_names,
         formatted_created_at=format_date(rest_pr.createdAt) if rest_pr.createdAt else "",
         formatted_updated_at=format_date(rest_pr.updatedAt) if rest_pr.updatedAt else "",

--- a/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
@@ -57,6 +57,8 @@ class NetworkPullRequest:
     mergedAt: Optional[str] = None  # Keep camelCase from API
     reviews: List[NetworkReview] = field(default_factory=list)
     labels: List[Dict[str, Any]] = field(default_factory=list)  # Raw label objects
+    statusCheckRollup: List[Dict[str, Any]] = field(default_factory=list)
+    reviewDecision: Optional[str] = None
     isCrossRepository: bool = False
     headRepositoryOwnerLogin: Optional[str] = None
 
@@ -103,6 +105,8 @@ class NetworkPullRequest:
             mergedAt=data.get("mergedAt"),
             reviews=reviews,
             labels=data.get("labels", []),  # Keep raw label objects
+            statusCheckRollup=data.get("statusCheckRollup", []),
+            reviewDecision=data.get("reviewDecision"),
             isCrossRepository=data.get("isCrossRepository", False),
             headRepositoryOwnerLogin=(data.get("headRepositoryOwner") or {}).get("login"),
         )

--- a/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
@@ -9,6 +9,15 @@ from typing import List, Optional, Dict, Any
 
 from .user import NetworkUser
 from .review import NetworkReview
+from ...pr_enums import PRMergeableState, PRReviewDecision, PRState
+
+
+def _coerce_enum(value: Any, enum_cls, default):
+    """Coerce a raw API value into a StrEnum member safely."""
+    try:
+        return enum_cls(value)
+    except Exception:
+        return default
 
 
 @dataclass
@@ -43,14 +52,14 @@ class NetworkPullRequest:
     number: int
     title: str
     body: str
-    state: str
+    state: PRState
     author: NetworkUser
     baseRefName: str  # Keep camelCase from API
     headRefName: str  # Keep camelCase from API
     additions: int = 0
     deletions: int = 0
     changedFiles: int = 0  # Keep camelCase from API
-    mergeable: str = "UNKNOWN"  # String: MERGEABLE | CONFLICTING | UNKNOWN
+    mergeable: PRMergeableState = PRMergeableState.UNKNOWN
     isDraft: bool = False  # Keep camelCase from API
     createdAt: Optional[str] = None  # Keep camelCase from API
     updatedAt: Optional[str] = None  # Keep camelCase from API
@@ -58,7 +67,7 @@ class NetworkPullRequest:
     reviews: List[NetworkReview] = field(default_factory=list)
     labels: List[Dict[str, Any]] = field(default_factory=list)  # Raw label objects
     statusCheckRollup: List[Dict[str, Any]] = field(default_factory=list)
-    reviewDecision: Optional[str] = None
+    reviewDecision: Optional[PRReviewDecision] = None
     isCrossRepository: bool = False
     headRepositoryOwnerLogin: Optional[str] = None
 
@@ -91,14 +100,18 @@ class NetworkPullRequest:
             number=data.get("number", 0),
             title=data.get("title", ""),
             body=data.get("body", ""),
-            state=data.get("state", "OPEN"),
+            state=_coerce_enum(data.get("state", PRState.OPEN), PRState, PRState.OPEN),
             author=author,
             baseRefName=data.get("baseRefName", ""),
             headRefName=data.get("headRefName", ""),
             additions=data.get("additions", 0),
             deletions=data.get("deletions", 0),
             changedFiles=data.get("changedFiles", 0),
-            mergeable=data.get("mergeable", "UNKNOWN"),
+            mergeable=_coerce_enum(
+                data.get("mergeable", PRMergeableState.UNKNOWN),
+                PRMergeableState,
+                PRMergeableState.UNKNOWN,
+            ),
             isDraft=data.get("isDraft", False),
             createdAt=data.get("createdAt"),
             updatedAt=data.get("updatedAt"),
@@ -106,7 +119,11 @@ class NetworkPullRequest:
             reviews=reviews,
             labels=data.get("labels", []),  # Keep raw label objects
             statusCheckRollup=data.get("statusCheckRollup", []),
-            reviewDecision=data.get("reviewDecision"),
+            reviewDecision=(
+                _coerce_enum(data.get("reviewDecision"), PRReviewDecision, None)
+                if data.get("reviewDecision") is not None
+                else None
+            ),
             isCrossRepository=data.get("isCrossRepository", False),
             headRepositoryOwnerLogin=(data.get("headRepositoryOwner") or {}).get("login"),
         )

--- a/plugins/titan-plugin-github/titan_plugin_github/models/pr_enums.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/pr_enums.py
@@ -1,0 +1,21 @@
+"""Shared pull request enums for GitHub API data."""
+
+from enum import StrEnum
+
+
+class PRState(StrEnum):
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+    MERGED = "MERGED"
+
+
+class PRMergeableState(StrEnum):
+    MERGEABLE = "MERGEABLE"
+    CONFLICTING = "CONFLICTING"
+    UNKNOWN = "UNKNOWN"
+
+
+class PRReviewDecision(StrEnum):
+    APPROVED = "APPROVED"
+    CHANGES_REQUESTED = "CHANGES_REQUESTED"
+    REVIEW_REQUIRED = "REVIEW_REQUIRED"

--- a/plugins/titan-plugin-github/titan_plugin_github/models/view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/view.py
@@ -154,6 +154,8 @@ class UIPullRequest:
     labels: List[str]  # Just label names
     formatted_created_at: str  # "DD/MM/YYYY HH:MM:SS"
     formatted_updated_at: str  # "DD/MM/YYYY HH:MM:SS"
+    checks_summary: str = ""
+    review_status_summary: str = ""
     is_cross_repository: bool = False
     head_repository_owner: Optional[str] = None
 

--- a/plugins/titan-plugin-github/titan_plugin_github/models/view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/view.py
@@ -13,6 +13,7 @@ These models are GitHub-specific and live in the GitHub plugin, not in the core.
 from dataclasses import dataclass
 from typing import Any, List, Optional
 
+from .pr_enums import PRState
 from .review_enums import FileChangeStatus, FindingSeverity
 
 
@@ -141,7 +142,7 @@ class UIPullRequest:
     title: str
     body: str
     status_icon: str  # "🟢" "🔴" "🟣" "📝" etc.
-    state: str  # "OPEN", "CLOSED", "MERGED"
+    state: PRState
     author_name: str  # Just the username
     head_ref: str  # Head branch name (for operations)
     base_ref: str  # Base branch name (for operations)

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
@@ -29,6 +29,7 @@ from .pr_operations import (
 from .pr_selection_operations import (
     build_pr_selection_description,
     build_pr_selection_title,
+    format_review_status_badge,
 )
 
 from .worktree_operations import (
@@ -73,6 +74,7 @@ __all__ = [
     "fetch_pr_general_comments",
     "build_pr_selection_description",
     "build_pr_selection_title",
+    "format_review_status_badge",
 
     # Worktree operations
     "setup_worktree",

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
@@ -26,6 +26,11 @@ from .pr_operations import (
     fetch_pr_general_comments,
 )
 
+from .pr_selection_operations import (
+    build_pr_selection_description,
+    build_pr_selection_title,
+)
+
 from .worktree_operations import (
     setup_worktree,
     cleanup_worktree,
@@ -66,6 +71,8 @@ __all__ = [
     # PR operations
     "fetch_pr_threads",
     "fetch_pr_general_comments",
+    "build_pr_selection_description",
+    "build_pr_selection_title",
 
     # Worktree operations
     "setup_worktree",

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
@@ -3,6 +3,11 @@
 from titan_plugin_github.models.view import UIPullRequest
 
 
+def escape_rich_markup(text: str) -> str:
+    """Escape square brackets in user-controlled text for Rich markup rendering."""
+    return text.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
 def format_review_status_badge(review_status_summary: str) -> str:
     """Format a compact inline badge for PR review status."""
     badges = {
@@ -11,7 +16,7 @@ def format_review_status_badge(review_status_summary: str) -> str:
         "review required": "[blue]● review required[/blue]",
         "ready for review": "[cyan]● ready for review[/cyan]",
     }
-    return badges.get(review_status_summary, review_status_summary)
+    return badges.get(review_status_summary, escape_rich_markup(review_status_summary))
 
 
 def build_pr_selection_title(
@@ -21,7 +26,7 @@ def build_pr_selection_title(
 ) -> str:
     """Build the title for a PR selection option."""
     prefix = "⭐ " if highlight_assigned else ""
-    title = f"{prefix}#{pr.number}: {pr.title}"
+    title = f"{prefix}#{pr.number}: {escape_rich_markup(pr.title)}"
 
     if include_review_badge and pr.review_status_summary:
         return f"{title}  {format_review_status_badge(pr.review_status_summary)}"

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
@@ -13,6 +13,7 @@ def format_review_status_badge(review_status_summary: str) -> str:
     badges = {
         "approved": "[green]● approved[/green]",
         "changes requested": "[red]● changes requested[/red]",
+        "draft": "[yellow]● draft[/yellow]",
         "review required": "[blue]● review required[/blue]",
         "ready for review": "[cyan]● ready for review[/cyan]",
     }

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
@@ -3,10 +3,30 @@
 from titan_plugin_github.models.view import UIPullRequest
 
 
-def build_pr_selection_title(pr: UIPullRequest, highlight_assigned: bool = False) -> str:
+def format_review_status_badge(review_status_summary: str) -> str:
+    """Format a compact inline badge for PR review status."""
+    badges = {
+        "approved": "[green]● approved[/green]",
+        "changes requested": "[red]● changes requested[/red]",
+        "review required": "[blue]● review required[/blue]",
+        "ready for review": "[cyan]● ready for review[/cyan]",
+    }
+    return badges.get(review_status_summary, review_status_summary)
+
+
+def build_pr_selection_title(
+    pr: UIPullRequest,
+    highlight_assigned: bool = False,
+    include_review_badge: bool = False,
+) -> str:
     """Build the title for a PR selection option."""
     prefix = "⭐ " if highlight_assigned else ""
-    return f"{prefix}#{pr.number}: {pr.title}"
+    title = f"{prefix}#{pr.number}: {pr.title}"
+
+    if include_review_badge and pr.review_status_summary:
+        return f"{title}  {format_review_status_badge(pr.review_status_summary)}"
+
+    return title
 
 
 def build_pr_selection_description(

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/pr_selection_operations.py
@@ -1,0 +1,33 @@
+"""Operations for building PR selection option content."""
+
+from titan_plugin_github.models.view import UIPullRequest
+
+
+def build_pr_selection_title(pr: UIPullRequest, highlight_assigned: bool = False) -> str:
+    """Build the title for a PR selection option."""
+    prefix = "⭐ " if highlight_assigned else ""
+    return f"{prefix}#{pr.number}: {pr.title}"
+
+
+def build_pr_selection_description(
+    pr: UIPullRequest,
+    *,
+    include_author: bool = False,
+    include_checks: bool = False,
+    include_review_status: bool = False,
+) -> str:
+    """Build the description for a PR selection option."""
+    parts: list[str] = []
+
+    if include_author:
+        parts.append(f"by {pr.author_name}")
+
+    parts.append(pr.branch_info)
+
+    if include_checks and pr.checks_summary:
+        parts.append(f"Checks: {pr.checks_summary}")
+
+    if include_review_status and pr.review_status_summary:
+        parts.append(f"Review: {pr.review_status_summary}")
+
+    return " · ".join(parts)

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -37,6 +37,10 @@ from ..operations.thread_resolution_operations import (
     build_thread_resolution_prompt,
     build_thread_actions as build_thread_actions_operation,
 )
+from ..operations.pr_selection_operations import (
+    build_pr_selection_description,
+    build_pr_selection_title,
+)
 
 from ..operations.manifest_operations import (
     build_change_manifest as build_change_manifest_operation,
@@ -584,8 +588,13 @@ def select_pr_for_code_review(ctx: WorkflowContext) -> WorkflowResult:
     options = [
         OptionItem(
             value=pr.number,
-            title=f"⭐ #{pr.number}: {pr.title}" if pr.number in assigned_numbers else f"#{pr.number}: {pr.title}",
-            description=f"by {pr.author_name} · {pr.branch_info}",
+            title=build_pr_selection_title(pr, highlight_assigned=pr.number in assigned_numbers),
+            description=build_pr_selection_description(
+                pr,
+                include_author=True,
+                include_checks=True,
+                include_review_status=True,
+            ),
         )
         for pr in sorted_prs
     ]

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -588,12 +588,15 @@ def select_pr_for_code_review(ctx: WorkflowContext) -> WorkflowResult:
     options = [
         OptionItem(
             value=pr.number,
-            title=build_pr_selection_title(pr, highlight_assigned=pr.number in assigned_numbers),
+            title=build_pr_selection_title(
+                pr,
+                highlight_assigned=pr.number in assigned_numbers,
+                include_review_badge=True,
+            ),
             description=build_pr_selection_description(
                 pr,
                 include_author=True,
                 include_checks=True,
-                include_review_status=True,
             ),
         )
         for pr in sorted_prs

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/github_prompt_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/github_prompt_steps.py
@@ -2,6 +2,7 @@
 from titan_cli.engine.context import WorkflowContext
 from titan_cli.engine.results import WorkflowResult, Success, Error, Skip
 from titan_cli.core.result import ClientSuccess, ClientError
+from titan_cli.ui.tui.widgets import SelectionOption
 from ..messages import msg
 from ..operations import add_assignee_if_missing, parse_comma_separated_list
 
@@ -236,13 +237,18 @@ def prompt_for_self_assign_step(ctx: WorkflowContext) -> WorkflowResult:
 
 def prompt_for_labels_step(ctx: WorkflowContext) -> WorkflowResult:
     """
-    Prompts the user to select labels for the issue.
+    Prompt the user to select repository labels and save them to context.
 
     Requires:
         ctx.github: An initialized GitHubClient.
 
+    Inputs (from ctx.data):
+        output_key (str, optional): Context key where selected labels should be stored. Defaults to "labels".
+        prompt (str, optional): Prompt text shown to the user. Defaults to "Select labels:".
+        default_selected_key (str, optional): Context key used to preselect labels. Defaults to output_key.
+
     Outputs (saved to ctx.data):
-        labels (list[str]): Labels selected by the user.
+        <output_key> (list[str]): Labels selected by the user.
 
     Returns:
         Success: If label selection completes successfully.
@@ -260,6 +266,10 @@ def prompt_for_labels_step(ctx: WorkflowContext) -> WorkflowResult:
         ctx.textual.end_step("error")
         return Error("GitHub client not available")
 
+    output_key = ctx.get("output_key", "labels")
+    prompt = ctx.get("prompt", msg.Prompts.SELECT_LABELS)
+    default_selected_key = ctx.get("default_selected_key", output_key)
+
     try:
         result = ctx.github.list_labels()
         match result:
@@ -269,29 +279,31 @@ def prompt_for_labels_step(ctx: WorkflowContext) -> WorkflowResult:
                     ctx.textual.end_step("skip")
                     return Skip("No labels found in the repository.")
 
-                # Show available labels
-                ctx.textual.dim_text(f"Available labels: {', '.join(available_labels)}")
+                existing_labels = ctx.get(default_selected_key, [])
+                if isinstance(existing_labels, str):
+                    existing_labels = parse_comma_separated_list(existing_labels)
+                if not isinstance(existing_labels, list):
+                    existing_labels = []
 
-                # Get default labels as comma-separated string
-                existing_labels = ctx.get("labels", [])
-                default_value = ",".join(existing_labels) if existing_labels else ""
+                selected_set = set(existing_labels)
+                options = [
+                    SelectionOption(
+                        value=label,
+                        label=label,
+                        selected=label in selected_set,
+                    )
+                    for label in available_labels
+                ]
 
-                # TODO: Implement multi-select in Textual - for now use comma-separated input
-                labels_input = ctx.textual.ask_text(
-                    f"{msg.Prompts.SELECT_LABELS} (comma-separated)",
-                    default=default_value
-                )
+                selected_labels = ctx.textual.ask_multiselect(prompt, options)
 
-                # Parse comma-separated labels
-                selected_labels = parse_comma_separated_list(labels_input)
-
-                ctx.set("labels", selected_labels)
+                ctx.set(output_key, selected_labels)
                 if selected_labels:
                     ctx.textual.success_text(f"Selected labels: {', '.join(selected_labels)}")
                 else:
                     ctx.textual.dim_text("No labels selected")
                 ctx.textual.end_step("success")
-                return Success("Labels selected")
+                return Success("Labels selected", metadata={output_key: selected_labels})
             case ClientError(error_message=err):
                 ctx.textual.error_text(f"Failed to get labels: {err}")
                 ctx.textual.end_step("error")

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/pr_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/pr_review_steps.py
@@ -23,6 +23,8 @@ from ..operations import (
     create_commit_message,
     reply_to_comment_batch,
     prepare_replies_for_sending,
+    build_pr_selection_description,
+    build_pr_selection_title,
 )
 from titan_plugin_git.operations import format_diff_stat_display
 
@@ -433,17 +435,11 @@ def select_pr_for_review_step(ctx: WorkflowContext) -> WorkflowResult:
             # Create options from PRs
             options = []
             for pr in prs:
-                description_parts = [f"Branch: {pr.branch_info}"]
-                if pr.checks_summary:
-                    description_parts.append(f"Checks: {pr.checks_summary}")
-                if pr.review_status_summary:
-                    description_parts.append(f"Review: {pr.review_status_summary}")
-
                 options.append(
                     OptionItem(
                         value=pr.number,
-                        title=f"#{pr.number}: {pr.title}",
-                        description=" · ".join(description_parts)
+                        title=build_pr_selection_title(pr),
+                        description=f"Branch: {build_pr_selection_description(pr)}",
                     )
                 )
 

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/pr_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/pr_review_steps.py
@@ -433,11 +433,17 @@ def select_pr_for_review_step(ctx: WorkflowContext) -> WorkflowResult:
             # Create options from PRs
             options = []
             for pr in prs:
+                description_parts = [f"Branch: {pr.branch_info}"]
+                if pr.checks_summary:
+                    description_parts.append(f"Checks: {pr.checks_summary}")
+                if pr.review_status_summary:
+                    description_parts.append(f"Review: {pr.review_status_summary}")
+
                 options.append(
                     OptionItem(
                         value=pr.number,
                         title=f"#{pr.number}: {pr.title}",
-                        description=f"Branch: {pr.branch_info}"
+                        description=" · ".join(description_parts)
                     )
                 )
 

--- a/plugins/titan-plugin-github/titan_plugin_github/workflows/__previews__/create_pr_ai_preview.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/workflows/__previews__/create_pr_ai_preview.py
@@ -38,6 +38,7 @@ def create_create_pr_ai_mock_context() -> WorkflowContext:
 
     # Override prompts to auto-confirm (non-interactive preview)
     views.prompts.ask_confirm = lambda question, default=True: True
+    views.prompts.ask_multiselect = lambda question, options: [option.value for option in options[:2]]
 
     # Create mock clients with workflow-specific data
     git = MockGitClient()
@@ -97,6 +98,7 @@ def preview_workflow():
     from titan_plugin_git.steps.push_step import create_git_push_step
     from titan_plugin_github.steps.ai_pr_step import ai_suggest_pr_description_step
     from titan_plugin_github.steps.github_prompt_steps import (
+        prompt_for_labels_step,
         prompt_for_pr_body_step,
         prompt_for_pr_draft_step,
         prompt_for_pr_title_step,
@@ -110,6 +112,7 @@ def preview_workflow():
         ("push", create_git_push_step),
         ("ai_pr_description", ai_suggest_pr_description_step),
         ("prompt_pr_draft", prompt_for_pr_draft_step),
+        ("prompt_pr_labels", prompt_for_labels_step),
         ("prompt_pr_title", prompt_for_pr_title_step),
         ("prompt_pr_body", prompt_for_pr_body_step),
     ]

--- a/plugins/titan-plugin-github/titan_plugin_github/workflows/create-pr-ai.yaml
+++ b/plugins/titan-plugin-github/titan_plugin_github/workflows/create-pr-ai.yaml
@@ -48,6 +48,14 @@ steps:
     plugin: github
     step: prompt_for_pr_draft
 
+  - id: select_pr_labels
+    name: "Select PR Labels"
+    plugin: github
+    step: prompt_for_labels
+    params:
+      output_key: pr_labels
+      prompt: "Select labels for this pull request:"
+
   - hook: before_push
 
   - id: create_pr

--- a/titan_cli/engine/mock_context.py
+++ b/titan_cli/engine/mock_context.py
@@ -10,6 +10,8 @@ Each preview should create its own mock context with customized data.
 from typing import Optional
 from dataclasses import dataclass
 
+from titan_cli.core.result import ClientSuccess
+
 
 @dataclass
 class MockGitStatus:
@@ -144,6 +146,10 @@ class MockGitHubClient:
             "base": base,
             "draft": draft
         }
+
+    def list_labels(self):
+        """Mock repository labels for workflow previews."""
+        return ClientSuccess(data=["bug", "feature", "documentation"], message="Labels retrieved")
 
 
 class MockSecretManager:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
This PR enhances the GitHub plugin with improved label selection functionality and adds review status visibility for pull requests. The changes include making the label prompt step configurable, adding review status badges to PR selection, and improving test coverage for PR services.

## 🔧 Changes Made
- Enhanced `prompt_for_labels` step to support configurable output keys and improved documentation
- Added review status badge display in PR selection titles and removed redundant review status from descriptions
- Added PR selection operations and enhanced formatting utilities
- Improved test coverage for PR service with additional status check rollup and review decision fields
- Updated documentation across multiple files to reflect new functionality and parameter changes

## 🧪 Testing
- [x] Unit tests added/updated (`poetry run pytest`)
- [x] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

New unit tests were added to verify the enhanced PR service functionality, including checks for status summaries and review decisions. The test coverage for GitHub PR services has been improved.

## 📊 Logs
- [ ] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)