### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/plugins/titan-plugin-git/pyproject.toml
+++ b/plugins/titan-plugin-git/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_git"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.5.0"
+titan-cli = ">=0.6.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugins/titan-plugin-github/pyproject.toml
+++ b/plugins/titan-plugin-github/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_github"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.5.0"
+titan-cli = ">=0.6.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugins/titan-plugin-jira/pyproject.toml
+++ b/plugins/titan-plugin-jira/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_jira"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.5.0"
+titan-cli = ">=0.6.0"
 requests = ">=2.31.0"
 pydantic = ">=2.0.0"
 jinja2 = ">=3.0.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2910,7 +2910,7 @@ files = []
 develop = true
 
 [package.dependencies]
-titan-cli = ">=0.5.0"
+titan-cli = ">=0.6.0"
 
 [package.source]
 type = "directory"
@@ -2927,7 +2927,7 @@ files = []
 develop = true
 
 [package.dependencies]
-titan-cli = ">=0.5.0"
+titan-cli = ">=0.6.0"
 
 [package.source]
 type = "directory"
@@ -2947,7 +2947,7 @@ develop = true
 jinja2 = ">=3.0.0"
 pydantic = ">=2.0.0"
 requests = ">=2.31.0"
-titan-cli = ">=0.5.0"
+titan-cli = ">=0.6.0"
 
 [package.source]
 type = "directory"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "titan-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "Modular development tools orchestrator - Streamline your workflows with AI integration and intuitive terminal UI"
 authors = ["MasOrange Apps Team <apps-management-stores@masorange.es>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump `titan-cli` version to `0.6.0`
- Update plugin `titan-cli` dependency constraints

## What's included in 0.6.0

- fix: Git status parsing for unstaged files (#225)
- feat: Enhance PR label selection and add review status features (#228)
- feat: Add support for prompting PR draft status in GitHub workflows (#226)
- feat: Enable GitHub PR thread resolution workflow (#227)

## Release

After this PR is merged, run the publish workflow from `master` to create the tag, publish to PyPI, and create the GitHub release.
