### PR TITLE
feat: Add file-scoped diff, commit, and AI message generation

### DIFF
--- a/plugins/titan-plugin-git/tests/services/test_commit_service.py
+++ b/plugins/titan-plugin-git/tests/services/test_commit_service.py
@@ -4,6 +4,7 @@ Unit tests for Commit Service
 
 import pytest
 from unittest.mock import Mock
+from unittest.mock import patch
 from titan_cli.core.result import ClientSuccess, ClientError
 from titan_plugin_git.clients.services.commit_service import CommitService
 from titan_plugin_git.exceptions import GitCommandError
@@ -95,6 +96,52 @@ class TestCommitServiceGetCurrentCommit:
         mock_git_network.run_command.side_effect = GitCommandError("not a git repo")
 
         result = service.get_current_commit()
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "COMMIT_ERROR"
+
+
+@pytest.mark.unit
+class TestCommitServiceCommitFiles:
+    """Test CommitService.commit_files()"""
+
+    def test_commit_files_limits_commit_to_selected_paths(self, service, mock_git_network):
+        """Test git commit is constrained to the selected pathspec"""
+        mock_git_network.run_command.side_effect = ["", "", "abc123\n"]
+
+        with patch("titan_plugin_git.clients.services.commit_service.os.path.exists", return_value=True):
+            result = service.commit_files(["src/main.py"], "feat: Add feature", no_verify=True)
+
+        assert isinstance(result, ClientSuccess)
+        calls = [c.args[0] for c in mock_git_network.run_command.call_args_list]
+        assert ["git", "add", "--", "src/main.py"] in calls
+        assert [
+            "git", "commit", "-m", "feat: Add feature", "--no-verify", "--", "src/main.py"
+        ] in calls
+
+    def test_commit_files_handles_deleted_paths_with_pathspec(self, service, mock_git_network):
+        """Test deleted tracked files are staged with git rm and committed by pathspec"""
+        mock_git_network.run_command.side_effect = [
+            "tracked",
+            "",
+            "",
+            "deadbeef\n",
+        ]
+
+        with patch("titan_plugin_git.clients.services.commit_service.os.path.exists", return_value=False):
+            result = service.commit_files(["removed.py"], "fix: Remove file", no_verify=False)
+
+        assert isinstance(result, ClientSuccess)
+        calls = [c.args[0] for c in mock_git_network.run_command.call_args_list]
+        assert ["git", "ls-files", "--error-unmatch", "removed.py"] in calls
+        assert ["git", "rm", "--", "removed.py"] in calls
+        assert ["git", "commit", "-m", "fix: Remove file", "--", "removed.py"] in calls
+
+    def test_commit_files_error_returns_client_error(self, service, mock_git_network):
+        """Test git error returns ClientError"""
+        mock_git_network.run_command.side_effect = GitCommandError("commit failed")
+
+        result = service.commit_files(["src/main.py"], "feat: Add feature")
 
         assert isinstance(result, ClientError)
         assert result.error_code == "COMMIT_ERROR"

--- a/plugins/titan-plugin-git/tests/services/test_diff_service.py
+++ b/plugins/titan-plugin-git/tests/services/test_diff_service.py
@@ -90,6 +90,42 @@ class TestDiffServiceGetUncommittedDiff:
 
 
 @pytest.mark.unit
+class TestDiffServiceGetUncommittedDiffForFiles:
+    """Test DiffService.get_uncommitted_diff_for_files()"""
+
+    def test_runs_intent_to_add_and_diff_for_selected_files(self, service, mock_git_network):
+        """Test selected files are passed through both git commands"""
+        mock_git_network.run_command.side_effect = ["", "filtered diff"]
+
+        result = service.get_uncommitted_diff_for_files(["src/main.py", "README.md"])
+
+        assert isinstance(result, ClientSuccess)
+        calls = [c.args[0] for c in mock_git_network.run_command.call_args_list]
+        assert ["git", "add", "--intent-to-add", "--", "src/main.py", "README.md"] in calls
+        assert ["git", "diff", "HEAD", "--", "src/main.py", "README.md"] in calls
+
+    def test_falls_back_to_full_uncommitted_diff_when_file_list_empty(self, service, mock_git_network):
+        """Test empty file list reuses the existing full diff behavior"""
+        mock_git_network.run_command.side_effect = ["", "full diff"]
+
+        result = service.get_uncommitted_diff_for_files([])
+
+        assert isinstance(result, ClientSuccess)
+        calls = [c.args[0] for c in mock_git_network.run_command.call_args_list]
+        assert ["git", "add", "--intent-to-add", "."] in calls
+        assert ["git", "diff", "HEAD"] in calls
+
+    def test_error_returns_client_error(self, service, mock_git_network):
+        """Test git error returns ClientError"""
+        mock_git_network.run_command.side_effect = GitCommandError("not a repo")
+
+        result = service.get_uncommitted_diff_for_files(["src/main.py"])
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "DIFF_ERROR"
+
+
+@pytest.mark.unit
 class TestDiffServiceGetStagedDiff:
     """Test DiffService.get_staged_diff()"""
 

--- a/plugins/titan-plugin-git/tests/steps/test_ai_commit_message_step.py
+++ b/plugins/titan-plugin-git/tests/steps/test_ai_commit_message_step.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock, patch
+
+from titan_cli.core.result import ClientSuccess
+from titan_plugin_git.steps.ai_commit_message_step import ai_generate_commit_message
+from titan_plugin_git.models import GitStatus
+
+
+def _build_context(selected_files=None):
+    ctx = MagicMock()
+    ctx.textual = MagicMock()
+    ctx.git = MagicMock()
+    ctx.ai = MagicMock()
+    ctx.ai.is_available.return_value = True
+
+    git_status = GitStatus(
+        branch="feature/test",
+        is_clean=False,
+        modified_files=["src/main.py"],
+        untracked_files=["README.md"],
+        staged_files=["staged.py"],
+        ahead=0,
+        behind=0,
+    )
+
+    values = {
+        "git_status": git_status,
+        "selected_files": selected_files,
+    }
+    ctx.get.side_effect = lambda key, default=None: values.get(key, default)
+    ctx.ai.generate.return_value = MagicMock(content="feat: Add selected change")
+    ctx.textual.ask_confirm.return_value = True
+    return ctx
+
+
+def test_ai_commit_message_uses_selected_files_for_diff_and_prompt():
+    ctx = _build_context(selected_files=["src/main.py"])
+    ctx.git.get_uncommitted_diff_for_files.return_value = ClientSuccess(
+        data="diff --git a/src/main.py b/src/main.py",
+        message="ok",
+    )
+
+    with patch("titan_plugin_git.steps.ai_commit_message_step.build_ai_commit_prompt") as build_prompt:
+        build_prompt.return_value = "prompt"
+
+        result = ai_generate_commit_message(ctx)
+
+    assert result.metadata["commit_message"] == "feat: Add selected change"
+    ctx.git.get_uncommitted_diff_for_files.assert_called_once_with(["src/main.py"])
+    ctx.git.get_uncommitted_diff.assert_not_called()
+    build_prompt.assert_called_once_with(
+        "diff --git a/src/main.py b/src/main.py",
+        ["src/main.py"],
+        max_diff_chars=8000,
+    )
+
+
+def test_ai_commit_message_uses_full_file_list_when_no_selection_exists():
+    ctx = _build_context(selected_files=None)
+    ctx.git.get_uncommitted_diff_for_files.return_value = ClientSuccess(
+        data="diff --git a/src/main.py b/src/main.py",
+        message="ok",
+    )
+
+    with patch("titan_plugin_git.steps.ai_commit_message_step.build_ai_commit_prompt") as build_prompt:
+        build_prompt.return_value = "prompt"
+
+        result = ai_generate_commit_message(ctx)
+
+    assert result.metadata["commit_message"] == "feat: Add selected change"
+    ctx.git.get_uncommitted_diff_for_files.assert_called_once_with(
+        ["src/main.py", "README.md", "staged.py"]
+    )
+    ctx.git.get_uncommitted_diff.assert_not_called()
+    build_prompt.assert_called_once_with(
+        "diff --git a/src/main.py b/src/main.py",
+        ["src/main.py", "README.md", "staged.py"],
+        max_diff_chars=8000,
+    )

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
@@ -303,6 +303,10 @@ class GitClient:
         """Get diff of all uncommitted changes."""
         return self.diff_service.get_uncommitted_diff()
 
+    def get_uncommitted_diff_for_files(self, files: list[str]) -> ClientResult[str]:
+        """Get diff of uncommitted changes limited to specific files."""
+        return self.diff_service.get_uncommitted_diff_for_files(files)
+
     def get_staged_diff(self) -> ClientResult[str]:
         """Get diff of staged changes only."""
         return self.diff_service.get_staged_diff()

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/services/commit_service.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/services/commit_service.py
@@ -118,6 +118,7 @@ class CommitService:
             args = ["git", "commit", "-m", message]
             if no_verify:
                 args.append("--no-verify")
+            args.extend(["--"] + list(files))
             self.git.run_command(args)
 
             commit_hash = self.git.run_command(["git", "rev-parse", "HEAD"])

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/services/diff_service.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/services/diff_service.py
@@ -73,6 +73,30 @@ class DiffService:
             return ClientError(error_message=str(e), error_code="DIFF_ERROR")
 
     @log_client_operation()
+    def get_uncommitted_diff_for_files(self, files: list[str]) -> ClientResult[str]:
+        """
+        Get diff of uncommitted changes limited to the provided file paths.
+
+        Uses git add --intent-to-add on the selected paths so untracked files are
+        visible in the diff without fully staging their content.
+
+        Args:
+            files: File paths to include in the diff
+
+        Returns:
+            ClientResult[str] with diff output
+        """
+        try:
+            if not files:
+                return self.get_uncommitted_diff()
+
+            self.git.run_command(["git", "add", "--intent-to-add", "--"] + files, check=False)
+            diff = self.git.run_command(["git", "diff", "HEAD", "--"] + files, check=False)
+            return ClientSuccess(data=diff, message="Filtered uncommitted diff retrieved")
+        except GitCommandError as e:
+            return ClientError(error_message=str(e), error_code="DIFF_ERROR")
+
+    @log_client_operation()
     def get_staged_diff(self) -> ClientResult[str]:
         """
         Get diff of staged changes only (index vs HEAD).

--- a/plugins/titan-plugin-git/titan_plugin_git/steps/ai_commit_message_step.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/steps/ai_commit_message_step.py
@@ -59,8 +59,12 @@ def ai_generate_commit_message(ctx: WorkflowContext) -> WorkflowResult:
         # Get diff of uncommitted changes
         ctx.textual.dim_text(msg.Steps.AICommitMessage.ANALYZING_CHANGES)
 
-        # Get diff of all uncommitted changes using ClientResult pattern
-        diff_result = ctx.git.get_uncommitted_diff()
+        files_for_commit = ctx.get("selected_files") or (
+            git_status.modified_files + git_status.untracked_files + git_status.staged_files
+        )
+
+        # Keep AI context aligned with the exact files that will be committed.
+        diff_result = ctx.git.get_uncommitted_diff_for_files(files_for_commit)
 
         match diff_result:
             case ClientSuccess(data=diff_text):
@@ -72,8 +76,7 @@ def ai_generate_commit_message(ctx: WorkflowContext) -> WorkflowResult:
                 return Error(f"Failed to get diff: {err}")
 
         # Build AI prompt using operations
-        all_files = git_status.modified_files + git_status.untracked_files + git_status.staged_files
-        prompt = build_ai_commit_prompt(diff_text, all_files, max_diff_chars=8000)
+        prompt = build_ai_commit_prompt(diff_text, files_for_commit, max_diff_chars=8000)
 
         # Call AI with loading indicator
         from titan_cli.ai.models import AIMessage


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Adds file-scoped variants of the diff and commit operations so that AI commit message generation can target only the files the user has selected. When a selection exists, the diff, staging, and commit are all constrained to those paths; when no selection is present, the existing full-repo behaviour is preserved.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `get_uncommitted_diff_for_files(files)` to `DiffService` — runs `git add --intent-to-add` and `git diff HEAD` scoped to the provided pathspec, falling back to full diff when the list is empty
- Added `commit_files(files, message, no_verify)` to `CommitService` — stages and commits only the selected paths, handling deleted tracked files via `git rm`
- Updated `ai_generate_commit_message` step to call `get_uncommitted_diff_for_files` with `selected_files` from context and pass the file list to `build_ai_commit_prompt`

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New unit tests cover:
- `commit_files`: pathspec-constrained add+commit, deleted-file handling via `git rm`, and error propagation
- `get_uncommitted_diff_for_files`: selected-file path, empty-list fallback to full diff, and error propagation
- `ai_generate_commit_message`: selected-files branch (uses scoped diff + passes file list to prompt builder), and no-selection branch (passes full file list)

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)