### PR TITLE
feat: Add GitHub releases step and PR draft prompt

### DIFF
--- a/docs/plugins/_generated/github-step-inventory.json
+++ b/docs/plugins/_generated/github-step-inventory.json
@@ -38,6 +38,10 @@
           "summary": "Prompt for a pull request body."
         },
         {
+          "name": "prompt_for_pr_draft",
+          "summary": "Ask whether the pull request should be created as a draft."
+        },
+        {
           "name": "prompt_for_issue_body_step",
           "summary": "Prompt for free-form issue input before AI expansion."
         },
@@ -218,6 +222,15 @@
           "summary": "Remove a worktree created during workflow execution."
         }
       ]
+    },
+    {
+      "name": "Releases",
+      "steps": [
+        {
+          "name": "select_release",
+          "summary": "List published GitHub releases and select one to use as a notes source."
+        }
+      ]
     }
   ],
   "steps": [
@@ -335,7 +348,9 @@
           "    Success or Error"
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "review-pr-thread-resolution"
+      ]
     },
     {
       "name": "build_change_manifest",
@@ -433,7 +448,9 @@
           "    Success, Skip (no actionable decisions), or Error"
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "review-pr-thread-resolution"
+      ]
     },
     {
       "name": "build_thread_review_candidates",
@@ -451,7 +468,9 @@
           "    Success, Skip (no candidates), or Error"
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "review-pr-thread-resolution"
+      ]
     },
     {
       "name": "build_thread_review_contexts",
@@ -460,7 +479,9 @@
       "function": "build_thread_review_contexts",
       "summary": "Enrich thread candidates with diff hunk context and full reply history.",
       "docstring_sections": {
-        "Requires": [],
+        "Requires": [
+          "    ctx.github: Optional GitHub client used to inspect referenced commits."
+        ],
         "Inputs (from ctx.data)": [],
         "Outputs (saved to ctx.data)": [
           "    thread_review_contexts (List[ThreadReviewContext])"
@@ -469,7 +490,9 @@
           "    Success, Skip (no candidates), or Error"
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "review-pr-thread-resolution"
+      ]
     },
     {
       "name": "check_clean_state",
@@ -729,7 +752,8 @@
         ]
       },
       "used_by_workflows": [
-        "review-pr"
+        "review-pr",
+        "review-pr-thread-resolution"
       ]
     },
     {
@@ -817,7 +841,9 @@
           "    Success or Error"
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "review-pr-thread-resolution"
+      ]
     },
     {
       "name": "preview_and_confirm_issue",
@@ -868,14 +894,18 @@
       "group": "Prompt and Selection",
       "module": "titan_plugin_github.steps.github_prompt_steps",
       "function": "prompt_for_labels_step",
-      "summary": "Prompts the user to select labels for the issue.",
+      "summary": "Prompt the user to select repository labels and save them to context.",
       "docstring_sections": {
         "Requires": [
           "    ctx.github: An initialized GitHubClient."
         ],
-        "Inputs (from ctx.data)": [],
+        "Inputs (from ctx.data)": [
+          "    output_key (str, optional): Context key where selected labels should be stored. Defaults to \"labels\".",
+          "    prompt (str, optional): Prompt text shown to the user. Defaults to \"Select labels:\".",
+          "    default_selected_key (str, optional): Context key used to preselect labels. Defaults to output_key."
+        ],
         "Outputs (saved to ctx.data)": [
-          "    labels (list[str]): Labels selected by the user."
+          "    <output_key> (list[str]): Labels selected by the user."
         ],
         "Returns": [
           "    Success: If label selection completes successfully.",
@@ -883,7 +913,9 @@
           "    Error: If the GitHub client is unavailable or the prompt fails."
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "create-pr-ai"
+      ]
     },
     {
       "name": "prompt_for_pr_body",
@@ -906,6 +938,31 @@
         ]
       },
       "used_by_workflows": []
+    },
+    {
+      "name": "prompt_for_pr_draft",
+      "group": "Prompt and Selection",
+      "module": "titan_plugin_github.steps.github_prompt_steps",
+      "function": "prompt_for_pr_draft_step",
+      "summary": "Ask whether the pull request should be created as a draft.",
+      "docstring_sections": {
+        "Requires": [
+          "    ctx.textual: Textual UI components."
+        ],
+        "Inputs (from ctx.data)": [
+          "    draft (bool | None, optional): Draft mode from workflow params. Use True/False to skip the prompt, or None to ask interactively."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    pr_is_draft (bool): Whether the PR should be created as a draft."
+        ],
+        "Returns": [
+          "    Success: If the draft preference was resolved successfully.",
+          "    Error: If the user cancels or the prompt fails."
+        ]
+      },
+      "used_by_workflows": [
+        "create-pr-ai"
+      ]
     },
     {
       "name": "prompt_for_pr_title",
@@ -1076,7 +1133,8 @@
         ]
       },
       "used_by_workflows": [
-        "review-pr"
+        "review-pr",
+        "review-pr-thread-resolution"
       ]
     },
     {
@@ -1099,7 +1157,8 @@
         ]
       },
       "used_by_workflows": [
-        "review-pr"
+        "review-pr",
+        "review-pr-thread-resolution"
       ]
     },
     {
@@ -1124,6 +1183,33 @@
       "used_by_workflows": [
         "respond-pr-comments"
       ]
+    },
+    {
+      "name": "select_release",
+      "group": "Releases",
+      "module": "titan_plugin_github.steps.release_steps",
+      "function": "select_release_step",
+      "summary": "List published GitHub releases and select one to use as a notes source.",
+      "docstring_sections": {
+        "Requires": [
+          "    ctx.github: An initialized GitHubClient."
+        ],
+        "Inputs (from ctx.data)": [
+          "    github_release_limit (int, optional): Maximum number of releases to list. Defaults to 15."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    selected_release (UIRelease): Selected GitHub release, including its notes body.",
+          "    selected_release_tag (str): Tag name of the selected release.",
+          "    selected_release_notes (str): Release notes body of the selected release.",
+          "    selected_release_url (str): URL of the selected release."
+        ],
+        "Returns": [
+          "    Success: If a release is selected successfully.",
+          "    Skip: If no published releases exist.",
+          "    Error: If the GitHub client is not available or the request fails."
+        ]
+      },
+      "used_by_workflows": []
     },
     {
       "name": "select_review_strategy",
@@ -1185,7 +1271,8 @@
         ]
       },
       "used_by_workflows": [
-        "review-pr"
+        "review-pr",
+        "review-pr-thread-resolution"
       ]
     },
     {
@@ -1205,7 +1292,8 @@
         ]
       },
       "used_by_workflows": [
-        "review-pr"
+        "review-pr",
+        "review-pr-thread-resolution"
       ]
     },
     {

--- a/docs/plugins/_generated/slack-step-inventory.json
+++ b/docs/plugins/_generated/slack-step-inventory.json
@@ -31,7 +31,7 @@
         },
         {
           "name": "select_default_or_search_channel_target",
-          "summary": "Choose one configured default channel or fall back to manual Slack channel search."
+          "summary": "Choose one configured default channel or fall back to a unified person/channel search."
         }
       ]
     },
@@ -349,28 +349,31 @@
       "group": "Selection and Target Resolution",
       "module": "titan_plugin_slack.steps.target_steps",
       "function": "select_default_or_search_channel_target_step",
-      "summary": "Select a Slack channel from the configured defaults or search for another one.",
+      "summary": "Select a Slack target from a preferred value or configured default, or search.",
       "docstring_sections": {
         "Requires": [
           "    ctx.slack: An initialized SlackClient."
         ],
         "Inputs (from ctx.data)": [
+          "    slack_preferred_target (str, optional): Person or channel name (without `#`) to select",
+          "        automatically without prompting, when it resolves to exactly one match. Takes priority",
+          "        over configured default channels and manual search.",
           "    slack_target_query (str, optional): Pre-filled query used if the user chooses to search manually.",
           "    slack_search_limit (int, optional): Maximum number of matches to return during manual search. Defaults to 20.",
-          "    slack_search_page_size (int, optional): Page size used while scanning Slack channels. Defaults to 1000.",
+          "    slack_search_page_size (int, optional): Page size used while scanning Slack. Defaults to 1000.",
           "    slack_search_max_pages (int, optional): Maximum pages to scan while searching. Defaults to 50.",
           "    slack_exclude_archived (bool, optional): Whether to exclude archived channels while searching. Defaults to True."
         ],
         "Outputs (saved to ctx.data)": [
           "    slack_target (UISlackTarget): Canonical selected Slack target.",
-          "    slack_target_type (str): Selected target type (`channel`).",
-          "    slack_target_id (str): Slack channel ID.",
+          "    slack_target_type (str): Selected target type (`user` or `channel`).",
+          "    slack_target_id (str): Slack target identifier.",
           "    slack_target_name (str): User-facing target name.",
           "    slack_target_query (str): Query used to resolve the selection, when manual search was used."
         ],
         "Returns": [
-          "    Success: If the channel target is selected successfully.",
-          "    Error: If Slack is unavailable, the configured channel cannot be resolved, or no match is selected."
+          "    Success: If the target is selected successfully.",
+          "    Error: If Slack is unavailable, or no match is selected."
         ]
       },
       "used_by_workflows": []

--- a/docs/plugins/_meta/github-step-groups.json
+++ b/docs/plugins/_meta/github-step-groups.json
@@ -16,6 +16,7 @@
       "steps": [
         {"name": "prompt_for_pr_title", "summary": "Prompt for a pull request title."},
         {"name": "prompt_for_pr_body", "summary": "Prompt for a pull request body."},
+        {"name": "prompt_for_pr_draft", "summary": "Ask whether the pull request should be created as a draft."},
         {"name": "prompt_for_issue_body_step", "summary": "Prompt for free-form issue input before AI expansion."},
         {"name": "prompt_for_self_assign", "summary": "Ask whether the current user should be assigned."},
         {"name": "prompt_for_labels", "summary": "Prompt for GitHub labels to attach to an issue or PR."},
@@ -76,6 +77,12 @@
       "steps": [
         {"name": "create_worktree", "summary": "Create an isolated worktree for GitHub-focused workflow tasks."},
         {"name": "cleanup_worktree", "summary": "Remove a worktree created during workflow execution."}
+      ]
+    },
+    {
+      "name": "Releases",
+      "steps": [
+        {"name": "select_release", "summary": "List published GitHub releases and select one to use as a notes source."}
       ]
     }
   ]

--- a/docs/plugins/_meta/slack-step-groups.json
+++ b/docs/plugins/_meta/slack-step-groups.json
@@ -14,7 +14,7 @@
       "steps": [
         {"name": "select_user_target", "summary": "Filter visible Slack users by query and select one canonical user target."},
         {"name": "select_channel_target", "summary": "Filter visible Slack channels by query and select one canonical channel target."},
-        {"name": "select_default_or_search_channel_target", "summary": "Choose one configured default channel or fall back to manual Slack channel search."}
+        {"name": "select_default_or_search_channel_target", "summary": "Choose one configured default channel or fall back to a unified person/channel search."}
       ]
     },
     {

--- a/docs/plugins/generated/github-step-reference.md
+++ b/docs/plugins/generated/github-step-reference.md
@@ -327,6 +327,52 @@ Interactively prompts the user for a Pull Request body.
 | `Error` | - | If the user cancels. |
 | `Skip` | `pr_body` | If pr_body already exists. |
 
+### `prompt_for_pr_draft`
+
+Ask whether the pull request should be created as a draft.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: github
+  step: prompt_for_pr_draft
+```
+
+**Used by built-in workflows:** `create-pr-ai`
+
+**Available to later steps:** `pr_is_draft`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.textual` | - | Textual UI components. |
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `draft` | bool | None, optional | Draft mode from workflow params. Use True/False to skip the prompt, or None to ask interactively. |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `pr_is_draft` | bool | Whether the PR should be created as a draft. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `pr_is_draft` | If the draft preference was resolved successfully. |
+| `Error` | - | If the user cancels or the prompt fails. |
+
 ### `prompt_for_issue_body_step`
 
 Interactively prompts the user for a GitHub issue body.
@@ -425,6 +471,8 @@ Prompt the user to select repository labels and save them to context.
   step: prompt_for_labels
 ```
 
+**Used by built-in workflows:** `create-pr-ai`
+
 **Available to later steps:** `<output_key>`
 
 **Requires**
@@ -437,9 +485,9 @@ Prompt the user to select repository labels and save them to context.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `output_key` | str, optional | Context key where selected labels should be stored. Defaults to `labels`. |
-| `prompt` | str, optional | Prompt text shown to the user. Defaults to `Select labels:`. |
-| `default_selected_key` | str, optional | Context key used to preselect labels. Defaults to `output_key`. |
+| `output_key` | str, optional | Context key where selected labels should be stored. Defaults to "labels". |
+| `prompt` | str, optional | Prompt text shown to the user. Defaults to "Select labels:". |
+| `default_selected_key` | str, optional | Context key used to preselect labels. Defaults to output_key. |
 
 **Outputs (saved to ctx.data)**
 
@@ -452,7 +500,7 @@ Prompt the user to select repository labels and save them to context.
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
 | `Success` | `<output_key>` | If label selection completes successfully. |
-| `Skip` | - | If the repository has no labels. |
+| `Skip` | `<output_key>` | If the repository has no labels. |
 | `Error` | - | If the GitHub client is unavailable or the prompt fails. |
 
 ### `select_cli`
@@ -472,7 +520,7 @@ Ask user to explicitly choose which AI CLI to use for PR analysis.
   step: select_cli
 ```
 
-**Used by built-in workflows:** `review-pr`
+**Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
 **Returns**
 
@@ -900,7 +948,7 @@ List all open PRs and ask user to select one.
   step: select_pr_for_code_review
 ```
 
-**Used by built-in workflows:** `review-pr`
+**Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
 **Available to later steps:** `review_pr_number`, `review_pr_title`, `review_pr_head`, `review_pr_base`
 
@@ -936,7 +984,7 @@ Fetch all data needed for a full PR review cycle.
   step: fetch_pr_review_bundle
 ```
 
-**Used by built-in workflows:** `review-pr`
+**Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
 **Available to later steps:** `review_pr`, `review_diff`, `review_changed_files`, `review_changed_files_with_stats`, `review_commit_sha`, `review_threads`, `review_general_comments`, `pr_template`
 
@@ -1450,7 +1498,7 @@ Present each ReviewActionProposal to the user for approval, editing, or skipping
   step: validate_review_actions
 ```
 
-**Used by built-in workflows:** `review-pr`
+**Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
 **Available to later steps:** `approved_action_proposals (List[ReviewActionProposal])`
 
@@ -1483,7 +1531,7 @@ Submit approved ReviewActionProposal objects to GitHub.
   step: submit_review_actions
 ```
 
-**Used by built-in workflows:** `review-pr`
+**Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
 **Returns**
 
@@ -1508,15 +1556,9 @@ Select open inline threads worth AI analysis.
   step: build_thread_review_candidates
 ```
 
+**Used by built-in workflows:** `review-pr-thread-resolution`
+
 **Available to later steps:** `thread_review_candidates (List[ThreadReviewCandidate])`
-
-**Inputs (from ctx.data)**
-
-| Name | Type | Description |
-|------|------|-------------|
-| review_threads (List[UICommentThread]) | - | - |
-| review_pr (UIPullRequest) | - | - |
-| review_current_user (str) | - | Authenticated GitHub login running Titan |
 
 **Outputs (saved to ctx.data)**
 
@@ -1547,7 +1589,15 @@ Enrich thread candidates with diff hunk context and full reply history.
   step: build_thread_review_contexts
 ```
 
+**Used by built-in workflows:** `review-pr-thread-resolution`
+
 **Available to later steps:** `thread_review_contexts (List[ThreadReviewContext])`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.github` | - | Optional GitHub client used to inspect referenced commits. |
 
 **Outputs (saved to ctx.data)**
 
@@ -1577,6 +1627,8 @@ AI call: decide what to do with each open thread.
 - plugin: github
   step: ai_thread_resolution
 ```
+
+**Used by built-in workflows:** `review-pr-thread-resolution`
 
 **Available to later steps:** `raw_thread_decisions`
 
@@ -1609,6 +1661,8 @@ Parse and validate raw AI output into ThreadDecision models.
   step: normalize_thread_decisions
 ```
 
+**Used by built-in workflows:** `review-pr-thread-resolution`
+
 **Available to later steps:** `thread_decisions`
 
 **Outputs (saved to ctx.data)**
@@ -1639,6 +1693,8 @@ Transform ThreadDecision objects into ReviewActionProposal objects.
 - plugin: github
   step: build_thread_actions
 ```
+
+**Used by built-in workflows:** `review-pr-thread-resolution`
 
 **Available to later steps:** `review_action_proposals (List[ReviewActionProposal])`
 
@@ -1716,3 +1772,53 @@ Cleanup a worktree created for PR review.
 |--------|-----------------------|-------------|
 | `Success` | - | Worktree cleaned up |
 | `Exit` | - | No worktree to cleanup |
+
+## Releases
+
+### `select_release`
+
+List published GitHub releases and select one to use as a notes source.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: github
+  step: select_release
+```
+
+**Available to later steps:** `selected_release`, `selected_release_tag`, `selected_release_notes`, `selected_release_url`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.github` | - | An initialized GitHubClient. |
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `github_release_limit` | int, optional | Maximum number of releases to list. Defaults to 15. |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `selected_release` | UIRelease | Selected GitHub release, including its notes body. |
+| `selected_release_tag` | str | Tag name of the selected release. |
+| `selected_release_notes` | str | Release notes body of the selected release. |
+| `selected_release_url` | str | URL of the selected release. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `selected_release`, `selected_release_tag`, `selected_release_notes`, `selected_release_url` | If a release is selected successfully. |
+| `Skip` | `selected_release`, `selected_release_tag`, `selected_release_notes`, `selected_release_url` | If no published releases exist. |
+| `Error` | - | If the GitHub client is not available or the request fails. |

--- a/docs/plugins/generated/slack-step-reference.md
+++ b/docs/plugins/generated/slack-step-reference.md
@@ -253,7 +253,7 @@ Select a Slack channel target through query filtering and final confirmation.
 
 ### `select_default_or_search_channel_target`
 
-Select a Slack channel from the configured defaults or search for another one.
+Select a Slack target from a preferred value or configured default, or search.
 
 **How to read this contract**
 
@@ -280,9 +280,12 @@ Select a Slack channel from the configured defaults or search for another one.
 
 | Name | Type | Description |
 |------|------|-------------|
+| `slack_preferred_target` | str, optional | Person or channel name (without `#`) to select |
+| automatically without prompting, when it resolves to exactly one match. Takes priority | - | - |
+| over configured default channels and manual search. | - | - |
 | `slack_target_query` | str, optional | Pre-filled query used if the user chooses to search manually. |
 | `slack_search_limit` | int, optional | Maximum number of matches to return during manual search. Defaults to 20. |
-| `slack_search_page_size` | int, optional | Page size used while scanning Slack channels. Defaults to 1000. |
+| `slack_search_page_size` | int, optional | Page size used while scanning Slack. Defaults to 1000. |
 | `slack_search_max_pages` | int, optional | Maximum pages to scan while searching. Defaults to 50. |
 | `slack_exclude_archived` | bool, optional | Whether to exclude archived channels while searching. Defaults to True. |
 
@@ -291,8 +294,8 @@ Select a Slack channel from the configured defaults or search for another one.
 | Name | Type | Description |
 |------|------|-------------|
 | `slack_target` | UISlackTarget | Canonical selected Slack target. |
-| `slack_target_type` | str | Selected target type (`channel`). |
-| `slack_target_id` | str | Slack channel ID. |
+| `slack_target_type` | str | Selected target type (`user` or `channel`). |
+| `slack_target_id` | str | Slack target identifier. |
 | `slack_target_name` | str | User-facing target name. |
 | `slack_target_query` | str | Query used to resolve the selection, when manual search was used. |
 
@@ -300,8 +303,8 @@ Select a Slack channel from the configured defaults or search for another one.
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `slack_target`, `slack_target_type`, `slack_target_id`, `slack_target_name`, `slack_target_query` | If the channel target is selected successfully. |
-| `Error` | - | If Slack is unavailable, the configured channel cannot be resolved, or no match is selected. |
+| `Success` | `slack_target`, `slack_target_type`, `slack_target_id`, `slack_target_name`, `slack_target_query` | If the target is selected successfully. |
+| `Error` | - | If Slack is unavailable, or no match is selected. |
 
 ## Messaging
 

--- a/docs/plugins/github/client-api.md
+++ b/docs/plugins/github/client-api.md
@@ -523,6 +523,42 @@ client.create_release(
 - `verify_tag`: Optional. Verify that the tag exists before creating the release.
 - `prerelease`: Optional. Mark the release as prerelease.
 
+### List releases
+
+Lists published GitHub releases for the repository.
+
+**Call:**
+
+```python
+client.list_releases(
+    limit=15,
+    exclude_drafts=True,
+)
+```
+
+**Parameters:**
+
+- `limit`: Optional. Maximum number of releases to return. Defaults to `15`.
+- `exclude_drafts`: Optional. Exclude draft releases from the result. Defaults to `True`.
+
+Returns a `ClientResult[List[UIRelease]]`. Each `UIRelease` includes `tag_name`, `title`, `url`, `is_prerelease`, `published_at`, and `is_draft`. The `body` field is left empty for list results — call `get_release` to fetch the full notes.
+
+### Get a release
+
+Fetches a single GitHub release, including its full notes body.
+
+**Call:**
+
+```python
+client.get_release(tag_name="v1.2.0")
+```
+
+**Parameters:**
+
+- `tag_name`: Required. Tag of the release to fetch.
+
+Returns a `ClientResult[UIRelease]` with `body` populated with the release notes text.
+
 ---
 
 ## Team operations

--- a/docs/plugins/github/workflow-steps.md
+++ b/docs/plugins/github/workflow-steps.md
@@ -12,6 +12,7 @@ For full contract details for every public step, including documented inputs, ou
 - [Pull Request Review](#pull-request-review)
 - [Code Review](#code-review)
 - [Worktree Support](#worktree-support)
+- [Releases](#releases)
 
 ## Summary
 
@@ -62,6 +63,7 @@ For full contract details for every public step, including documented inputs, ou
 | `build_thread_actions` | Code Review | - |
 | `create_worktree` | Worktree Support | - |
 | `cleanup_worktree` | Worktree Support | - |
+| `select_release` | Releases | - |
 
 ## Pull Requests
 
@@ -137,6 +139,12 @@ Use these steps when a GitHub workflow should operate in a dedicated worktree.
 
 - `create_worktree`: create an isolated worktree for GitHub-focused workflow tasks
 - `cleanup_worktree`: remove a worktree created during workflow execution
+
+## Releases
+
+Use this step to let a workflow pick a published GitHub release and read its notes.
+
+- `select_release`: list published GitHub releases and select one to use as a notes source
 
 <!-- BEGIN GENERATED STEP CONTRACTS -->
 ## Detailed Step Contracts
@@ -388,11 +396,7 @@ How to read these contracts:
 
     **Inputs (from ctx.data)**
 
-    | Name | Type | Description |
-    |------|------|-------------|
-    | review_threads (List[UICommentThread]) | - | - |
-    | review_pr (UIPullRequest) | - | - |
-    | review_current_user (str) | - | Authenticated GitHub login running Titan |
+    None documented.
 
     **Outputs (saved to ctx.data)**
 
@@ -470,7 +474,7 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `draft` | bool or null, optional | Workflow draft mode. Use `true` or `false` to skip the prompt, or `null` to ask interactively. |
+    | `draft` | bool | None, optional | Draft mode from workflow params. Use True/False to skip the prompt, or None to ask interactively. |
 
     **Outputs (saved to ctx.data)**
 
@@ -573,6 +577,8 @@ How to read these contracts:
       step: prompt_for_labels
     ```
 
+    **Used by built-in workflows:** `create-pr-ai`
+
     **Available to later steps:** `<output_key>`
 
     **Requires**
@@ -585,9 +591,9 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `output_key` | str, optional | Context key where selected labels should be stored. Defaults to `labels`. |
-    | `prompt` | str, optional | Prompt text shown to the user. Defaults to `Select labels:`. |
-    | `default_selected_key` | str, optional | Context key used to preselect labels. Defaults to `output_key`. |
+    | `output_key` | str, optional | Context key where selected labels should be stored. Defaults to "labels". |
+    | `prompt` | str, optional | Prompt text shown to the user. Defaults to "Select labels:". |
+    | `default_selected_key` | str, optional | Context key used to preselect labels. Defaults to output_key. |
 
     **Outputs (saved to ctx.data)**
 
@@ -600,7 +606,7 @@ How to read these contracts:
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
     | `Success` | `<output_key>` | If label selection completes successfully. |
-    | `Skip` | - | If the repository has no labels. |
+    | `Skip` | `<output_key>` | If the repository has no labels. |
     | `Error` | - | If the GitHub client is unavailable or the prompt fails. |
 
 
@@ -614,7 +620,7 @@ How to read these contracts:
       step: select_cli
     ```
 
-    **Used by built-in workflows:** `review-pr`
+    **Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
     **Inputs (from ctx.data)**
 
@@ -1032,7 +1038,7 @@ How to read these contracts:
       step: select_pr_for_code_review
     ```
 
-    **Used by built-in workflows:** `review-pr`
+    **Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
     **Available to later steps:** `review_pr_number`, `review_pr_title`, `review_pr_head`, `review_pr_base`
 
@@ -1066,7 +1072,7 @@ How to read these contracts:
       step: fetch_pr_review_bundle
     ```
 
-    **Used by built-in workflows:** `review-pr`
+    **Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
     **Available to later steps:** `review_pr`, `review_diff`, `review_changed_files`, `review_changed_files_with_stats`, `review_commit_sha`, `review_threads`, `review_general_comments`, `pr_template`
 
@@ -1540,7 +1546,7 @@ How to read these contracts:
       step: validate_review_actions
     ```
 
-    **Used by built-in workflows:** `review-pr`
+    **Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
     **Available to later steps:** `approved_action_proposals (List[ReviewActionProposal])`
 
@@ -1571,7 +1577,7 @@ How to read these contracts:
       step: submit_review_actions
     ```
 
-    **Used by built-in workflows:** `review-pr`
+    **Used by built-in workflows:** `review-pr`, `review-pr-thread-resolution`
 
     **Inputs (from ctx.data)**
 
@@ -1597,6 +1603,8 @@ How to read these contracts:
     - plugin: github
       step: build_thread_review_candidates
     ```
+
+    **Used by built-in workflows:** `review-pr-thread-resolution`
 
     **Available to later steps:** `thread_review_candidates (List[ThreadReviewCandidate])`
 
@@ -1627,7 +1635,15 @@ How to read these contracts:
       step: build_thread_review_contexts
     ```
 
+    **Used by built-in workflows:** `review-pr-thread-resolution`
+
     **Available to later steps:** `thread_review_contexts (List[ThreadReviewContext])`
+
+    **Requires**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `ctx.github` | - | Optional GitHub client used to inspect referenced commits. |
 
     **Inputs (from ctx.data)**
 
@@ -1655,6 +1671,8 @@ How to read these contracts:
     - plugin: github
       step: ai_thread_resolution
     ```
+
+    **Used by built-in workflows:** `review-pr-thread-resolution`
 
     **Available to later steps:** `raw_thread_decisions`
 
@@ -1685,6 +1703,8 @@ How to read these contracts:
       step: normalize_thread_decisions
     ```
 
+    **Used by built-in workflows:** `review-pr-thread-resolution`
+
     **Available to later steps:** `thread_decisions`
 
     **Inputs (from ctx.data)**
@@ -1713,6 +1733,8 @@ How to read these contracts:
     - plugin: github
       step: build_thread_actions
     ```
+
+    **Used by built-in workflows:** `review-pr-thread-resolution`
 
     **Available to later steps:** `review_action_proposals (List[ReviewActionProposal])`
 
@@ -1794,6 +1816,50 @@ How to read these contracts:
     |--------|-----------------------|-------------|
     | `Success` | - | Worktree cleaned up |
     | `Exit` | - | No worktree to cleanup |
+
+
+### Releases
+
+??? info "`select_release`"
+    List published GitHub releases and select one to use as a notes source.
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: github
+      step: select_release
+    ```
+
+    **Available to later steps:** `selected_release`, `selected_release_tag`, `selected_release_notes`, `selected_release_url`
+
+    **Requires**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `ctx.github` | - | An initialized GitHubClient. |
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `github_release_limit` | int, optional | Maximum number of releases to list. Defaults to 15. |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `selected_release` | UIRelease | Selected GitHub release, including its notes body. |
+    | `selected_release_tag` | str | Tag name of the selected release. |
+    | `selected_release_notes` | str | Release notes body of the selected release. |
+    | `selected_release_url` | str | URL of the selected release. |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `selected_release`, `selected_release_tag`, `selected_release_notes`, `selected_release_url` | If a release is selected successfully. |
+    | `Skip` | `selected_release`, `selected_release_tag`, `selected_release_notes`, `selected_release_url` | If no published releases exist. |
+    | `Error` | - | If the GitHub client is not available or the request fails. |
 <!-- END GENERATED STEP CONTRACTS -->
 
 ## Docstring-based reference

--- a/docs/plugins/slack/overview.md
+++ b/docs/plugins/slack/overview.md
@@ -84,6 +84,7 @@ Titan currently requests these Slack scopes during OAuth:
 - [Client API](./client-api.md): direct Python methods exposed by `SlackClient`
 - [Workflow Steps](./workflow-steps.md): public reusable workflow steps grouped by functionality
 - [Built-in Workflows](./built-in-workflows.md): workflows shipped by the plugin
+- `SlackFormatter` (`titan_plugin_slack.formatting`): stateless text formatting toolkit (see below)
 
 ## Accessing the Client
 
@@ -109,3 +110,23 @@ The Slack plugin currently ships one built-in workflow:
 - `summarize-slack-target`
 
 Other Slack capabilities remain available as public reusable steps for composition from project workflows or other plugin workflows.
+
+## Message Formatting
+
+Slack messages sent through `chat.postMessage` render `mrkdwn`, not standard Markdown: bold uses a single asterisk (`*bold*`), there is no header syntax, and there is no native table support. `SlackFormatter` converts standard Markdown (e.g. AI-generated text) into Slack's mrkdwn, so the same source content can also be rendered as normal Markdown elsewhere (like the Titan TUI).
+
+```python
+from titan_plugin_slack.formatting import SlackFormatter
+
+# Convert a full Markdown document (headers, bold/italic/strikethrough,
+# links, bullet lists, and pipe tables) into Slack mrkdwn.
+slack_text = SlackFormatter.to_mrkdwn(markdown_summary)
+
+# Or build a Slack-friendly table directly from row data.
+table_text = SlackFormatter.table(
+    rows=[["titan-cli", "0.6.0"], ["ragnarok", "0.9.3"]],
+    headers=["Plugin", "Version"],
+)
+```
+
+Both methods are stateless and can be called from any step, project workflow, or personal script — no plugin registration required.

--- a/docs/plugins/slack/workflow-steps.md
+++ b/docs/plugins/slack/workflow-steps.md
@@ -44,7 +44,7 @@ Use these steps to resolve a reusable Slack target object for later workflows.
 
 - `select_user_target`: filter visible Slack users by query and select one canonical user target
 - `select_channel_target`: filter visible Slack channels by query and select one canonical channel target
-- `select_default_or_search_channel_target`: choose one configured default channel or fall back to manual Slack channel search
+- `select_default_or_search_channel_target`: choose one configured default channel or fall back to a unified person/channel search
 
 ## Messaging
 
@@ -67,8 +67,8 @@ Use these steps to resolve a target conversation, read its recent messages, and 
 ## Notes
 
 - Built-in workflows may use only a subset of these steps.
-- `select_default_or_search_channel_target` is the step that uses repo-configured `default_channels`; it is available for custom workflows but is not used by any built-in workflow.
-- The built-in summary workflow uses the unified `select_target` step, so it can resolve either a person or a channel from one search.
+- `select_default_or_search_channel_target` is the step that uses repo-configured `default_channels`; when none are configured, or the user chooses to search instead, it falls back to the unified `select_target` search (person or channel). It is available for custom workflows but is not used by any built-in workflow.
+- The built-in summary workflow uses the unified `select_target` step directly, so it can resolve either a person or a channel from one search.
 
 <!-- BEGIN GENERATED STEP CONTRACTS -->
 ## Detailed Step Contracts
@@ -303,7 +303,7 @@ How to read these contracts:
 
 
 ??? info "`select_default_or_search_channel_target`"
-    Select a Slack channel from the configured defaults or search for another one.
+    Select a Slack target from a preferred value or configured default, or search.
 
     **Workflow usage**
 
@@ -324,9 +324,12 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
+    | `slack_preferred_target` | str, optional | Person or channel name (without `#`) to select |
+    | automatically without prompting, when it resolves to exactly one match. Takes priority | - | - |
+    | over configured default channels and manual search. | - | - |
     | `slack_target_query` | str, optional | Pre-filled query used if the user chooses to search manually. |
     | `slack_search_limit` | int, optional | Maximum number of matches to return during manual search. Defaults to 20. |
-    | `slack_search_page_size` | int, optional | Page size used while scanning Slack channels. Defaults to 1000. |
+    | `slack_search_page_size` | int, optional | Page size used while scanning Slack. Defaults to 1000. |
     | `slack_search_max_pages` | int, optional | Maximum pages to scan while searching. Defaults to 50. |
     | `slack_exclude_archived` | bool, optional | Whether to exclude archived channels while searching. Defaults to True. |
 
@@ -335,8 +338,8 @@ How to read these contracts:
     | Name | Type | Description |
     |------|------|-------------|
     | `slack_target` | UISlackTarget | Canonical selected Slack target. |
-    | `slack_target_type` | str | Selected target type (`channel`). |
-    | `slack_target_id` | str | Slack channel ID. |
+    | `slack_target_type` | str | Selected target type (`user` or `channel`). |
+    | `slack_target_id` | str | Slack target identifier. |
     | `slack_target_name` | str | User-facing target name. |
     | `slack_target_query` | str | Query used to resolve the selection, when manual search was used. |
 
@@ -344,8 +347,8 @@ How to read these contracts:
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `slack_target`, `slack_target_type`, `slack_target_id`, `slack_target_name`, `slack_target_query` | If the channel target is selected successfully. |
-    | `Error` | - | If Slack is unavailable, the configured channel cannot be resolved, or no match is selected. |
+    | `Success` | `slack_target`, `slack_target_type`, `slack_target_id`, `slack_target_name`, `slack_target_query` | If the target is selected successfully. |
+    | `Error` | - | If Slack is unavailable, or no match is selected. |
 
 
 ### Messaging

--- a/plugins/titan-plugin-github/tests/services/test_release_service.py
+++ b/plugins/titan-plugin-github/tests/services/test_release_service.py
@@ -124,3 +124,86 @@ class TestReleaseServiceCreateRelease:
         assert isinstance(result, ClientError)
         assert result.error_code == "INVALID_INPUT"
         mock_gh_network.run_command.assert_not_called()
+
+
+class TestReleaseServiceListReleases:
+    """Test ReleaseService.list_releases()."""
+
+    def test_list_releases_returns_ui_releases(self, mock_gh_network):
+        service = ReleaseService(mock_gh_network)
+        mock_gh_network.get_repo_arg.return_value = ["--repo", "masorange/titan-cli"]
+        mock_gh_network.run_command.return_value = (
+            '[{"tagName":"0.6.0","name":"0.6.0","url":"https://github.com/masorange/titan-cli/releases/tag/0.6.0",'
+            '"isPrerelease":false,"isDraft":false,"publishedAt":"2026-02-01T00:00:00Z"},'
+            '{"tagName":"0.5.0","name":"0.5.0","url":"https://github.com/masorange/titan-cli/releases/tag/0.5.0",'
+            '"isPrerelease":false,"isDraft":false,"publishedAt":"2026-01-01T00:00:00Z"}]'
+        )
+
+        result = service.list_releases(limit=15)
+
+        assert isinstance(result, ClientSuccess)
+        assert [release.tag_name for release in result.data] == ["0.6.0", "0.5.0"]
+        assert mock_gh_network.run_command.call_args.args[0] == [
+            "release", "list",
+            "--limit", "15",
+            "--json", "tagName,name,publishedAt,isPrerelease,isDraft",
+            "--repo", "masorange/titan-cli",
+        ]
+
+    def test_list_releases_excludes_drafts_by_default(self, mock_gh_network):
+        service = ReleaseService(mock_gh_network)
+        mock_gh_network.get_repo_arg.return_value = []
+        mock_gh_network.run_command.return_value = (
+            '[{"tagName":"0.6.0","name":"0.6.0","url":"","isPrerelease":false,"isDraft":false},'
+            '{"tagName":"0.7.0-draft","name":"0.7.0-draft","url":"","isPrerelease":false,"isDraft":true}]'
+        )
+
+        result = service.list_releases()
+
+        assert isinstance(result, ClientSuccess)
+        assert [release.tag_name for release in result.data] == ["0.6.0"]
+
+    def test_list_releases_api_error(self, mock_gh_network):
+        service = ReleaseService(mock_gh_network)
+        mock_gh_network.get_repo_arg.return_value = []
+        mock_gh_network.run_command.side_effect = GitHubAPIError("not found")
+
+        result = service.list_releases()
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "API_ERROR"
+
+
+class TestReleaseServiceGetRelease:
+    """Test ReleaseService.get_release()."""
+
+    def test_get_release_returns_ui_release_with_body(self, mock_gh_network):
+        service = ReleaseService(mock_gh_network)
+        mock_gh_network.get_repo_arg.return_value = ["--repo", "masorange/titan-cli"]
+        mock_gh_network.run_command.return_value = (
+            '{"tagName":"0.6.0","name":"0.6.0",'
+            '"url":"https://github.com/masorange/titan-cli/releases/tag/0.6.0",'
+            '"isPrerelease":false,"isDraft":false,"publishedAt":"2026-02-01T00:00:00Z",'
+            '"body":"- Added Slack plugin\\n- Fixed thread resolution"}'
+        )
+
+        result = service.get_release("0.6.0")
+
+        assert isinstance(result, ClientSuccess)
+        assert result.data.tag_name == "0.6.0"
+        assert result.data.body == "- Added Slack plugin\n- Fixed thread resolution"
+        assert mock_gh_network.run_command.call_args.args[0] == [
+            "release", "view", "0.6.0",
+            "--json", "tagName,name,url,isPrerelease,isDraft,publishedAt,body",
+            "--repo", "masorange/titan-cli",
+        ]
+
+    def test_get_release_api_error(self, mock_gh_network):
+        service = ReleaseService(mock_gh_network)
+        mock_gh_network.get_repo_arg.return_value = []
+        mock_gh_network.run_command.side_effect = GitHubAPIError("release not found")
+
+        result = service.get_release("0.6.0")
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "API_ERROR"

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -364,7 +364,7 @@ def test_build_thread_review_contexts_resolves_referenced_commits_against_fork_h
     ctx = WorkflowContext(secrets=Mock())
     ctx.textual = _FakeTextual()
     ctx.github = Mock()
-    ctx.data["review_pr"] = _make_pr(is_cross_repository=True, head_repository_name="fork-repo")
+    ctx.data["review_pr"] = _make_pr(is_cross_repository=True, author_name="author", head_repository_name="fork-repo")
     ctx.data["thread_review_candidates"] = [
         ThreadReviewCandidate(
             thread_id="thread_123",

--- a/plugins/titan-plugin-github/tests/unit/test_release_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_release_steps.py
@@ -1,0 +1,102 @@
+from unittest.mock import Mock
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import Error, Skip, Success, WorkflowContext
+from titan_plugin_github.models.view import UIRelease
+from titan_plugin_github.steps.release_steps import select_release_step
+
+
+class MockTextual:
+    def __init__(self):
+        self.begin_step = Mock()
+        self.end_step = Mock()
+        self.error_text = Mock()
+        self.success_text = Mock()
+        self.dim_text = Mock()
+        self.ask_option = Mock()
+
+    def loading(self, _message):
+        class _Loader:
+            def __enter__(self_inner):
+                return None
+
+            def __exit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _Loader()
+
+
+def make_context(mock_github_client=None, **data):
+    ctx = WorkflowContext(secrets=Mock(), textual=MockTextual(), github=mock_github_client)
+    ctx.data.update(data)
+    return ctx
+
+
+def _release(tag_name="0.6.0", body="Release notes"):
+    return UIRelease(
+        tag_name=tag_name,
+        title=tag_name,
+        url=f"https://github.com/masorange/titan-cli/releases/tag/{tag_name}",
+        is_prerelease=False,
+        body=body,
+    )
+
+
+def test_select_release_step_errors_without_github_client():
+    ctx = make_context(None)
+
+    result = select_release_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "GitHub client not available"
+
+
+def test_select_release_step_skips_when_no_releases():
+    github = Mock()
+    github.list_releases.return_value = ClientSuccess(data=[])
+    ctx = make_context(github)
+
+    result = select_release_step(ctx)
+
+    assert isinstance(result, Skip)
+    ctx.textual.end_step.assert_called_once_with("skip")
+
+
+def test_select_release_step_errors_when_list_fails():
+    github = Mock()
+    github.list_releases.return_value = ClientError(error_message="boom", error_code="API_ERROR")
+    ctx = make_context(github)
+
+    result = select_release_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "boom"
+
+
+def test_select_release_step_returns_selected_release_notes():
+    github = Mock()
+    listed = _release("0.6.0", body="")
+    fetched = _release("0.6.0", body="- Added Slack plugin\n- Fixed thread resolution")
+    github.list_releases.return_value = ClientSuccess(data=[listed])
+    github.get_release.return_value = ClientSuccess(data=fetched)
+    ctx = make_context(github)
+    ctx.textual.ask_option.return_value = "0.6.0"
+
+    result = select_release_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["selected_release_tag"] == "0.6.0"
+    assert result.metadata["selected_release_notes"] == "- Added Slack plugin\n- Fixed thread resolution"
+    github.get_release.assert_called_once_with("0.6.0")
+
+
+def test_select_release_step_errors_when_no_selection():
+    github = Mock()
+    github.list_releases.return_value = ClientSuccess(data=[_release()])
+    ctx = make_context(github)
+    ctx.textual.ask_option.return_value = None
+
+    result = select_release_step(ctx)
+
+    assert isinstance(result, Error)
+    assert result.message == "No release was selected."

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/github_client.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/github_client.py
@@ -305,6 +305,16 @@ class GitHubClient:
             prerelease=prerelease,
         )
 
+    def list_releases(
+        self, limit: int = 15, exclude_drafts: bool = True
+    ) -> ClientResult[List[UIRelease]]:
+        """List published GitHub releases for the repository."""
+        return self._release_service.list_releases(limit=limit, exclude_drafts=exclude_drafts)
+
+    def get_release(self, tag_name: str) -> ClientResult[UIRelease]:
+        """Get a single GitHub release, including its full notes body."""
+        return self._release_service.get_release(tag_name)
+
     # ============================================================================
     # Team Operations
     # ============================================================================

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/release_service.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/release_service.py
@@ -7,7 +7,7 @@ Uses gh CLI through the network layer.
 """
 
 import json
-from typing import Optional
+from typing import List, Optional
 
 from titan_cli.core.result import ClientResult, ClientSuccess, ClientError
 from titan_cli.core.logging import log_client_operation
@@ -23,7 +23,7 @@ class ReleaseService:
     """
     Service for GitHub release operations.
 
-    Handles creating GitHub releases for a repository.
+    Handles creating, listing, and reading GitHub releases for a repository.
     """
 
     def __init__(self, gh_network: GHNetwork):
@@ -99,6 +99,86 @@ class ReleaseService:
             return ClientSuccess(
                 data=ui_release,
                 message=f"Release '{tag_name}' created"
+            )
+
+        except json.JSONDecodeError as e:
+            return ClientError(
+                error_message=f"Failed to parse release data: {e}",
+                error_code="JSON_PARSE_ERROR"
+            )
+        except GitHubAPIError as e:
+            return ClientError(error_message=str(e), error_code="API_ERROR")
+
+    @log_client_operation()
+    def list_releases(
+        self,
+        limit: int = 15,
+        exclude_drafts: bool = True,
+    ) -> ClientResult[List[UIRelease]]:
+        """
+        List published GitHub releases for the repository.
+
+        Args:
+            limit: Maximum number of releases to return
+            exclude_drafts: Whether to exclude draft releases from the result
+
+        Returns:
+            ClientResult[List[UIRelease]]
+        """
+        try:
+            args = [
+                "release", "list",
+                "--limit", str(limit),
+                "--json", "tagName,name,publishedAt,isPrerelease,isDraft",
+            ] + self.gh.get_repo_arg()
+
+            output = self.gh.run_command(args)
+            data = json.loads(output)
+
+            releases = [
+                from_network_release(NetworkRelease.from_json(item))
+                for item in data
+                if not (exclude_drafts and item.get("isDraft"))
+            ]
+
+            return ClientSuccess(
+                data=releases,
+                message=f"Retrieved {len(releases)} releases"
+            )
+
+        except json.JSONDecodeError as e:
+            return ClientError(
+                error_message=f"Failed to parse releases: {e}",
+                error_code="JSON_PARSE_ERROR"
+            )
+        except GitHubAPIError as e:
+            return ClientError(error_message=str(e), error_code="API_ERROR")
+
+    @log_client_operation()
+    def get_release(self, tag_name: str) -> ClientResult[UIRelease]:
+        """
+        Get a single GitHub release, including its full notes body.
+
+        Args:
+            tag_name: Tag of the release to fetch
+
+        Returns:
+            ClientResult[UIRelease]
+        """
+        try:
+            args = [
+                "release", "view", tag_name,
+                "--json", "tagName,name,url,isPrerelease,isDraft,publishedAt,body",
+            ] + self.gh.get_repo_arg()
+
+            output = self.gh.run_command(args)
+            data = json.loads(output)
+            network_release = NetworkRelease.from_json(data)
+            ui_release = from_network_release(network_release)
+
+            return ClientSuccess(
+                data=ui_release,
+                message=f"Release '{tag_name}' retrieved"
             )
 
         except json.JSONDecodeError as e:

--- a/plugins/titan-plugin-github/titan_plugin_github/models/mappers/release_mapper.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/mappers/release_mapper.py
@@ -19,4 +19,7 @@ def from_network_release(network_release: NetworkRelease) -> UIRelease:
         title=network_release.name,
         url=network_release.url,
         is_prerelease=network_release.is_prerelease,
+        body=network_release.body,
+        published_at=network_release.published_at,
+        is_draft=network_release.is_draft,
     )

--- a/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/release.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/release.py
@@ -15,6 +15,9 @@ class NetworkRelease:
     name: str
     url: str
     is_prerelease: bool
+    body: str = ""
+    published_at: str = ""
+    is_draft: bool = False
 
     @classmethod
     def from_json(cls, data: Dict[str, Any]) -> "NetworkRelease":
@@ -26,4 +29,7 @@ class NetworkRelease:
             name=data.get("name", "") or data.get("tagName", ""),
             url=data.get("url", ""),
             is_prerelease=bool(data.get("isPrerelease", False)),
+            body=data.get("body", "") or "",
+            published_at=data.get("publishedAt", "") or "",
+            is_draft=bool(data.get("isDraft", False)),
         )

--- a/plugins/titan-plugin-github/titan_plugin_github/models/view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/view.py
@@ -239,15 +239,18 @@ class UIPRCreated:
 @dataclass
 class UIRelease:
     """
-    UI model for a newly created GitHub release.
+    UI model for a GitHub release.
 
-    Returned after create_release — contains the identifiers needed
-    to display the result or navigate to the release page.
+    Returned by create_release, list_releases, and get_release — contains
+    the identifiers and notes body needed to display or summarize a release.
     """
     tag_name: str
     title: str
     url: str
     is_prerelease: bool
+    body: str = ""
+    published_at: str = ""
+    is_draft: bool = False
 
 
 @dataclass

--- a/plugins/titan-plugin-github/titan_plugin_github/plugin.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/plugin.py
@@ -182,6 +182,7 @@ class GitHubPlugin(TitanPlugin):
             build_thread_actions,
         )
         from .steps.select_cli_step import select_cli_step
+        from .steps.release_steps import select_release_step
         return {
             "create_pr": create_pr_step,
             "prompt_for_pr_title": prompt_for_pr_title_step,
@@ -213,6 +214,8 @@ class GitHubPlugin(TitanPlugin):
             "fetch_pr_review_bundle": fetch_pr_review_bundle,
             # CLI selection
             "select_cli": select_cli_step,
+            # Releases
+            "select_release": select_release_step,
             # Phase 2: cheap context steps (pre-AI)
             "build_change_manifest": build_change_manifest,
             "build_existing_comments_index": build_existing_comments_index,

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/release_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/release_steps.py
@@ -1,0 +1,94 @@
+"""Reusable workflow steps for GitHub release selection."""
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import Error, Skip, Success, WorkflowContext, WorkflowResult
+from titan_cli.ui.tui.widgets import OptionItem
+
+
+def select_release_step(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    List published GitHub releases and select one to use as a notes source.
+
+    Requires:
+        ctx.github: An initialized GitHubClient.
+
+    Inputs (from ctx.data):
+        github_release_limit (int, optional): Maximum number of releases to list. Defaults to 15.
+
+    Outputs (saved to ctx.data):
+        selected_release (UIRelease): Selected GitHub release, including its notes body.
+        selected_release_tag (str): Tag name of the selected release.
+        selected_release_notes (str): Release notes body of the selected release.
+        selected_release_url (str): URL of the selected release.
+
+    Returns:
+        Success: If a release is selected successfully.
+        Skip: If no published releases exist.
+        Error: If the GitHub client is not available or the request fails.
+    """
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Select GitHub Release")
+
+    if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
+        ctx.textual.end_step("error")
+        return Error("GitHub client not available")
+
+    limit = ctx.get("github_release_limit", 15)
+
+    with ctx.textual.loading("Fetching GitHub releases..."):
+        result = ctx.github.list_releases(limit=limit)
+
+    match result:
+        case ClientSuccess(data=releases):
+            pass
+        case ClientError(error_message=err):
+            ctx.textual.error_text(err)
+            ctx.textual.end_step("error")
+            return Error(err)
+
+    if not releases:
+        ctx.textual.dim_text("No published GitHub releases found.")
+        ctx.textual.end_step("skip")
+        return Skip("No published GitHub releases found")
+
+    options = [
+        OptionItem(
+            value=release.tag_name,
+            title=release.title,
+            description=release.published_at or release.url,
+        )
+        for release in releases
+    ]
+
+    selected_tag = ctx.textual.ask_option("Select a GitHub release:", options=options)
+    if not selected_tag:
+        ctx.textual.error_text("No release was selected.")
+        ctx.textual.end_step("error")
+        return Error("No release was selected.")
+
+    with ctx.textual.loading(f"Fetching notes for {selected_tag}..."):
+        release_result = ctx.github.get_release(selected_tag)
+
+    match release_result:
+        case ClientSuccess(data=release):
+            ctx.textual.success_text(f"Selected release {release.tag_name}")
+            ctx.textual.end_step("success")
+            return Success(
+                f"Selected GitHub release {release.tag_name}",
+                metadata={
+                    "selected_release": release,
+                    "selected_release_tag": release.tag_name,
+                    "selected_release_notes": release.body,
+                    "selected_release_url": release.url,
+                },
+            )
+        case ClientError(error_message=err):
+            ctx.textual.error_text(err)
+            ctx.textual.end_step("error")
+            return Error(err)
+
+
+__all__ = ["select_release_step"]

--- a/plugins/titan-plugin-slack/tests/test_formatting.py
+++ b/plugins/titan-plugin-slack/tests/test_formatting.py
@@ -1,0 +1,69 @@
+from titan_plugin_slack.formatting import SlackFormatter
+
+
+class TestToMrkdwn:
+    def test_converts_bold(self) -> None:
+        assert SlackFormatter.to_mrkdwn("This is **bold** text") == "This is *bold* text"
+
+    def test_converts_bold_with_underscores(self) -> None:
+        assert SlackFormatter.to_mrkdwn("This is __bold__ text") == "This is *bold* text"
+
+    def test_converts_italic(self) -> None:
+        assert SlackFormatter.to_mrkdwn("This is *italic* text") == "This is _italic_ text"
+
+    def test_converts_strikethrough(self) -> None:
+        assert SlackFormatter.to_mrkdwn("This is ~~gone~~ text") == "This is ~gone~ text"
+
+    def test_converts_header_to_bold_line(self) -> None:
+        assert SlackFormatter.to_mrkdwn("## Release 0.6.0") == "*Release 0.6.0*"
+
+    def test_converts_bullet_list(self) -> None:
+        markdown = "- First item\n- Second item"
+        assert SlackFormatter.to_mrkdwn(markdown) == "• First item\n• Second item"
+
+    def test_converts_link(self) -> None:
+        markdown = "See [the docs](https://example.com/docs) for details"
+        assert (
+            SlackFormatter.to_mrkdwn(markdown)
+            == "See <https://example.com/docs|the docs> for details"
+        )
+
+    def test_drops_horizontal_rule(self) -> None:
+        markdown = "Before\n\n---\n\nAfter"
+        assert SlackFormatter.to_mrkdwn(markdown) == "Before\n\n\n\nAfter"
+
+    def test_leaves_fenced_code_blocks_untouched(self) -> None:
+        markdown = "Before\n```python\n**not bold**\n```\nAfter"
+        result = SlackFormatter.to_mrkdwn(markdown)
+        assert "```python\n**not bold**\n```" in result
+
+    def test_bold_and_italic_do_not_interfere(self) -> None:
+        markdown = "A **bold** word and an *italic* word"
+        assert SlackFormatter.to_mrkdwn(markdown) == "A *bold* word and an _italic_ word"
+
+    def test_converts_inline_table(self) -> None:
+        markdown = "| Name | Version |\n| --- | --- |\n| titan-cli | 0.6.0 |"
+        result = SlackFormatter.to_mrkdwn(markdown)
+        assert result.startswith("```\n")
+        assert "Name" in result and "Version" in result
+        assert "titan-cli" in result and "0.6.0" in result
+
+
+class TestTable:
+    def test_renders_headers_and_rows_aligned(self) -> None:
+        result = SlackFormatter.table(
+            rows=[["titan-cli", "0.6.0"], ["ragnarok", "0.9.3"]],
+            headers=["Plugin", "Version"],
+        )
+        lines = result.strip("`\n").split("\n")
+        assert lines[0].startswith("Plugin")
+        assert "titan-cli" in lines[2]
+        assert result.startswith("```")
+        assert result.endswith("```")
+
+    def test_pads_missing_cells(self) -> None:
+        result = SlackFormatter.table(rows=[["a", "b"], ["only-one"]], headers=["Col1", "Col2"])
+        assert "only-one" in result
+
+    def test_returns_empty_string_for_no_data(self) -> None:
+        assert SlackFormatter.table(rows=[]) == ""

--- a/plugins/titan-plugin-slack/tests/test_target_steps.py
+++ b/plugins/titan-plugin-slack/tests/test_target_steps.py
@@ -102,16 +102,109 @@ def test_select_default_or_search_channel_target_uses_configured_default() -> No
     assert result.metadata["slack_target_id"] == "C2"
 
 
-def test_select_default_or_search_channel_target_falls_back_to_search_when_no_defaults() -> None:
+def test_select_default_or_search_channel_target_falls_back_to_unified_search_when_no_defaults() -> None:
     ctx = _build_context()
     ctx.slack = MagicMock()
     ctx.slack.default_channels = []
     ctx.textual.ask_text.return_value = "eng"
     channel = UISlackChannel(id="C2", name="eng-backend")
+    ctx.slack.search_users.return_value = ClientSuccess(data=[])
     ctx.slack.search_channels.return_value = ClientSuccess(data=[channel])
-    ctx.textual.ask_option.return_value = channel
+    target = UISlackTarget(target_type="channel", target_id="C2", target_name="eng-backend")
+    ctx.textual.ask_option.return_value = target
 
     result = select_default_or_search_channel_target_step(ctx)
 
     assert isinstance(result, Success)
     assert result.metadata["slack_target_id"] == "C2"
+
+
+def test_select_default_or_search_channel_target_falls_back_to_a_person_when_no_defaults() -> None:
+    ctx = _build_context()
+    ctx.slack = MagicMock()
+    ctx.slack.default_channels = []
+    ctx.textual.ask_text.return_value = "alex"
+    user = UISlackUser(id="U1", name="alex", real_name="Alex Smith")
+    ctx.slack.search_users.return_value = ClientSuccess(data=[user])
+    ctx.slack.search_channels.return_value = ClientSuccess(data=[])
+    target = UISlackTarget(target_type="user", target_id="U1", target_name="Alex Smith")
+    ctx.textual.ask_option.return_value = target
+
+    result = select_default_or_search_channel_target_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["slack_target_type"] == "user"
+    assert result.metadata["slack_target_id"] == "U1"
+
+
+def test_select_default_or_search_channel_target_search_other_falls_back_to_unified_search() -> None:
+    ctx = _build_context()
+    ctx.slack = MagicMock()
+    ctx.slack.default_channels = ["eng-backend"]
+    ctx.textual.ask_option.side_effect = [
+        SEARCH_OTHER_TARGET,
+        UISlackTarget(target_type="user", target_id="U1", target_name="Alex Smith"),
+    ]
+    ctx.textual.ask_text.return_value = "alex"
+    user = UISlackUser(id="U1", name="alex", real_name="Alex Smith")
+    ctx.slack.search_users.return_value = ClientSuccess(data=[user])
+    ctx.slack.search_channels.return_value = ClientSuccess(data=[])
+
+    result = select_default_or_search_channel_target_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["slack_target_type"] == "user"
+    assert result.metadata["slack_target_id"] == "U1"
+
+
+def test_select_default_or_search_channel_target_auto_selects_preferred_channel() -> None:
+    ctx = _build_context()
+    ctx.slack = MagicMock()
+    ctx.data["slack_preferred_target"] = "titan-releases"
+    channel = UISlackChannel(id="C9", name="titan-releases")
+    ctx.slack.search_users.return_value = ClientSuccess(data=[])
+    ctx.slack.search_channels.return_value = ClientSuccess(data=[channel])
+
+    result = select_default_or_search_channel_target_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["slack_target_type"] == "channel"
+    assert result.metadata["slack_target_id"] == "C9"
+    assert result.metadata["slack_target_name"] == "titan-releases"
+    ctx.textual.ask_option.assert_not_called()
+
+
+def test_select_default_or_search_channel_target_auto_selects_preferred_person() -> None:
+    ctx = _build_context()
+    ctx.slack = MagicMock()
+    ctx.data["slack_preferred_target"] = "Alejandro Lopez Ruiz"
+    user = UISlackUser(id="U9", name="alopez", real_name="Alejandro Lopez Ruiz")
+    ctx.slack.search_users.return_value = ClientSuccess(data=[user])
+    ctx.slack.search_channels.return_value = ClientSuccess(data=[])
+
+    result = select_default_or_search_channel_target_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["slack_target_type"] == "user"
+    assert result.metadata["slack_target_id"] == "U9"
+    assert result.metadata["slack_target_name"] == "Alejandro Lopez Ruiz"
+    ctx.textual.ask_option.assert_not_called()
+
+
+def test_select_default_or_search_channel_target_falls_back_when_preferred_target_ambiguous() -> None:
+    ctx = _build_context()
+    ctx.slack = MagicMock()
+    ctx.slack.default_channels = ["eng-backend"]
+    ctx.data["slack_preferred_target"] = "does-not-exist"
+    ctx.slack.search_users.return_value = ClientSuccess(data=[])
+    ctx.slack.search_channels.side_effect = [
+        ClientSuccess(data=[]),  # resolving the preferred target fails
+        ClientSuccess(data=[UISlackChannel(id="C2", name="eng-backend")]),  # configured default
+    ]
+    ctx.textual.ask_option.return_value = "eng-backend"
+
+    result = select_default_or_search_channel_target_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["slack_target_id"] == "C2"
+    ctx.textual.dim_text.assert_called_once()

--- a/plugins/titan-plugin-slack/tests/test_target_steps.py
+++ b/plugins/titan-plugin-slack/tests/test_target_steps.py
@@ -5,6 +5,7 @@ from titan_cli.engine import Error, Success
 from titan_cli.engine.context import WorkflowContext
 from titan_plugin_slack.models import UISlackChannel, UISlackTarget, UISlackUser
 from titan_plugin_slack.steps.target_steps import (
+    SEARCH_OTHER_TARGET,
     select_channel_target_step,
     select_default_or_search_channel_target_step,
     select_user_target_step,

--- a/plugins/titan-plugin-slack/titan_plugin_slack/formatting.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/formatting.py
@@ -1,0 +1,194 @@
+"""Slack text formatting toolkit.
+
+Slack messages sent through `chat.postMessage` render `mrkdwn`, not standard
+Markdown: bold uses a single asterisk (`*bold*`), there is no header syntax,
+and there is no native table support. `SlackFormatter` lets any step render
+AI-generated or hand-written content correctly in Slack, while a second,
+standard-Markdown copy of the same source can still be shown elsewhere (e.g.
+the Titan TUI).
+"""
+
+import re
+from typing import List, Optional
+
+
+class SlackFormatter:
+    """Namespace of stateless helpers that format text for Slack's mrkdwn renderer."""
+
+    _CODE_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+    _TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$")
+    _TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$")
+    _HEADER_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+    _BULLET_RE = re.compile(r"^(\s*)[-*]\s+(.*)$")
+    _HR_RE = re.compile(r"^\s*[-*_]{3,}\s*$")
+    _BOLD_RE = re.compile(r"\*\*(.+?)\*\*|__(.+?)__")
+    _STRIKETHROUGH_RE = re.compile(r"~~(.+?)~~")
+    _ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)([^*\n]+?)(?<!\*)\*(?!\*)")
+    _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+    _BOLD_PLACEHOLDER = "\x00BOLD{}\x00"
+
+    @staticmethod
+    def to_mrkdwn(text: str) -> str:
+        """
+        Convert a standard Markdown document into Slack-flavored mrkdwn.
+
+        Handles headers, bold/italic/strikethrough, links, bullet lists, and
+        pipe tables. Fenced code blocks are left untouched since Slack already
+        renders them as-is. Pipe tables are rendered with `SlackFormatter.table`.
+
+        Args:
+            text: Standard Markdown source text.
+
+        Returns:
+            Text formatted for Slack's mrkdwn renderer.
+        """
+        segments = SlackFormatter._split_on_code_fences(text)
+        converted = [
+            segment if is_code else SlackFormatter._convert_prose_block(segment)
+            for segment, is_code in segments
+        ]
+        return "".join(converted)
+
+    @staticmethod
+    def table(rows: List[List[str]], headers: Optional[List[str]] = None) -> str:
+        """
+        Render tabular data as a fixed-width Slack table inside a code block.
+
+        Slack's plain-text messages have no native table support, so columns
+        are aligned with padding and wrapped in a fenced code block, which
+        Slack renders in a monospace font.
+
+        Args:
+            rows: Table body rows, each a list of cell values.
+            headers: Optional header row.
+
+        Returns:
+            A fenced code block containing the aligned table, or an empty
+            string if there is no data to render.
+        """
+        if not rows and not headers:
+            return ""
+
+        column_count = len(headers) if headers else max(len(row) for row in rows)
+        widths = [len(headers[col]) if headers else 0 for col in range(column_count)]
+        for row in rows:
+            for col in range(column_count):
+                cell = row[col] if col < len(row) else ""
+                widths[col] = max(widths[col], len(cell))
+
+        def render_row(cells: List[str]) -> str:
+            padded = [
+                (cells[col] if col < len(cells) else "").ljust(widths[col])
+                for col in range(column_count)
+            ]
+            return " | ".join(padded).rstrip()
+
+        lines = []
+        if headers:
+            lines.append(render_row(headers))
+            lines.append("-+-".join("-" * width for width in widths))
+        lines.extend(render_row(row) for row in rows)
+
+        return "```\n" + "\n".join(lines) + "\n```"
+
+    @staticmethod
+    def _split_on_code_fences(text: str) -> List[tuple]:
+        """Split text into (segment, is_code_fence) pairs, preserving fences verbatim."""
+        segments: List[tuple] = []
+        last_end = 0
+        for match in SlackFormatter._CODE_FENCE_RE.finditer(text):
+            if match.start() > last_end:
+                segments.append((text[last_end:match.start()], False))
+            segments.append((match.group(0), True))
+            last_end = match.end()
+        if last_end < len(text):
+            segments.append((text[last_end:], False))
+        return segments
+
+    @staticmethod
+    def _convert_prose_block(text: str) -> str:
+        """Convert a non-code-fence block: tables as blocks, other lines individually."""
+        lines = text.split("\n")
+        output_lines: List[str] = []
+        i = 0
+        while i < len(lines):
+            table_end = SlackFormatter._find_table_block_end(lines, i)
+            if table_end is not None:
+                header, *rows = [
+                    SlackFormatter._split_table_row(line)
+                    for line in (lines[i], *lines[i + 2:table_end])
+                ]
+                output_lines.append(SlackFormatter.table(rows, headers=header))
+                i = table_end
+                continue
+
+            line = lines[i]
+            if SlackFormatter._HR_RE.match(line):
+                output_lines.append("")
+            else:
+                output_lines.append(SlackFormatter._convert_line(line))
+            i += 1
+
+        return "\n".join(output_lines)
+
+    @staticmethod
+    def _find_table_block_end(lines: List[str], start: int) -> Optional[int]:
+        """Return the exclusive end index of a Markdown table starting at `start`, or None."""
+        if start + 1 >= len(lines):
+            return None
+        if not SlackFormatter._TABLE_ROW_RE.match(lines[start]):
+            return None
+        if not SlackFormatter._TABLE_SEPARATOR_RE.match(lines[start + 1]):
+            return None
+
+        end = start + 2
+        while end < len(lines) and SlackFormatter._TABLE_ROW_RE.match(lines[end]):
+            end += 1
+        return end
+
+    @staticmethod
+    def _split_table_row(line: str) -> List[str]:
+        """Split a Markdown table row into trimmed cell values."""
+        stripped = line.strip()
+        if stripped.startswith("|"):
+            stripped = stripped[1:]
+        if stripped.endswith("|"):
+            stripped = stripped[:-1]
+        return [cell.strip() for cell in stripped.split("|")]
+
+    @staticmethod
+    def _convert_line(line: str) -> str:
+        """Convert a single non-table, non-code line to Slack mrkdwn."""
+        header_match = SlackFormatter._HEADER_RE.match(line)
+        if header_match:
+            return f"*{SlackFormatter._convert_inline(header_match.group(2))}*"
+
+        bullet_match = SlackFormatter._BULLET_RE.match(line)
+        if bullet_match:
+            indent, rest = bullet_match.groups()
+            return f"{indent}• {SlackFormatter._convert_inline(rest)}"
+
+        return SlackFormatter._convert_inline(line)
+
+    @staticmethod
+    def _convert_inline(text: str) -> str:
+        """Convert inline emphasis and links to Slack mrkdwn within a single line."""
+        placeholders: List[str] = []
+
+        def stash_bold(match: "re.Match") -> str:
+            content = match.group(1) or match.group(2)
+            placeholders.append(content)
+            return SlackFormatter._BOLD_PLACEHOLDER.format(len(placeholders) - 1)
+
+        text = SlackFormatter._BOLD_RE.sub(stash_bold, text)
+        text = SlackFormatter._STRIKETHROUGH_RE.sub(r"~\1~", text)
+        text = SlackFormatter._ITALIC_RE.sub(r"_\1_", text)
+        text = SlackFormatter._LINK_RE.sub(r"<\2|\1>", text)
+
+        for index, content in enumerate(placeholders):
+            text = text.replace(SlackFormatter._BOLD_PLACEHOLDER.format(index), f"*{content}*")
+
+        return text
+
+
+__all__ = ["SlackFormatter"]

--- a/plugins/titan-plugin-slack/titan_plugin_slack/steps/target_steps.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/steps/target_steps.py
@@ -115,16 +115,21 @@ def select_channel_target_step(ctx: WorkflowContext) -> WorkflowResult:
 
 def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> WorkflowResult:
     """
-    Select a Slack channel from the configured defaults, or search people/channels.
+    Select a Slack target from a preferred value or configured default, or search.
 
-    When no default channels are configured, or when the user chooses to search
-    instead of using a default, this falls back to the unified person-or-channel
-    search (`select_target_step`).
+    If `slack_preferred_target` is set and resolves to exactly one person or
+    channel, it is selected automatically with no prompt at all. Otherwise, this
+    falls back to the configured `default_channels` picker, or, when none are
+    configured (or the user chooses to search instead), to the unified
+    person-or-channel search (`select_target_step`).
 
     Requires:
         ctx.slack: An initialized SlackClient.
 
     Inputs (from ctx.data):
+        slack_preferred_target (str, optional): Person or channel name (without `#`) to select
+            automatically without prompting, when it resolves to exactly one match. Takes priority
+            over configured default channels and manual search.
         slack_target_query (str, optional): Pre-filled query used if the user chooses to search manually.
         slack_search_limit (int, optional): Maximum number of matches to return during manual search. Defaults to 20.
         slack_search_page_size (int, optional): Page size used while scanning Slack. Defaults to 1000.
@@ -140,13 +145,23 @@ def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> Workfl
 
     Returns:
         Success: If the target is selected successfully.
-        Error: If Slack is unavailable, the configured channel cannot be resolved, or no match is selected.
+        Error: If Slack is unavailable, or no match is selected.
     """
     if not ctx.textual:
         return Error("Textual UI context is not available for this step.")
 
     if not ctx.slack:
         return Error("Slack client not available")
+
+    preferred_target = ctx.get("slack_preferred_target")
+    if preferred_target:
+        auto_selected = _try_auto_select_target(ctx, str(preferred_target))
+        if auto_selected is not None:
+            return auto_selected
+        ctx.textual.dim_text(
+            f"Preferred Slack target '{preferred_target}' did not resolve to exactly one "
+            "person or channel - falling back to default channel selection."
+        )
 
     configured_channels = getattr(ctx.slack, "default_channels", []) or []
     if not configured_channels:
@@ -212,6 +227,94 @@ def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> Workfl
             ctx.textual.error_text(err)
             ctx.textual.end_step("error")
             return Error(err)
+
+
+def _try_auto_select_target(ctx: WorkflowContext, query: str) -> "Success | None":
+    """
+    Resolve `query` to exactly one Slack person or channel and auto-select it.
+
+    Returns None (no prompt shown, no step lifecycle started) when the query is
+    too short, the search fails, or it matches zero or more than one target -
+    auto-selection only ever happens on an unambiguous exact match.
+    """
+    normalized_query = normalize_search_query(query)
+    if len(normalized_query.lstrip("#")) < MIN_QUERY_LENGTH:
+        return None
+
+    search_limit = ctx.get("slack_search_limit", MAX_TARGET_OPTIONS)
+    page_size = ctx.get("slack_search_page_size", 1000)
+    max_pages = ctx.get("slack_search_max_pages", 50)
+    exclude_archived = ctx.get("slack_exclude_archived", True)
+
+    with ctx.textual.loading(f"Resolving preferred Slack target '{query}'..."):
+        users_result = ctx.slack.search_users(
+            normalized_query,
+            max_matches=search_limit,
+            page_size=page_size,
+            max_pages=max_pages,
+        )
+        channels_result = ctx.slack.search_channels(
+            normalized_query,
+            max_matches=search_limit,
+            page_size=page_size,
+            max_pages=max_pages,
+            exclude_archived=exclude_archived,
+        )
+
+    match users_result:
+        case ClientSuccess(data=matched_users):
+            users = matched_users
+        case ClientError():
+            users = []
+
+    match channels_result:
+        case ClientSuccess(data=matched_channels):
+            channels = matched_channels
+        case ClientError():
+            channels = []
+
+    exact_users = [
+        user
+        for user in users
+        if normalize_search_query(user.name) == normalized_query
+        or normalize_search_query(user.real_name or "") == normalized_query
+    ]
+    exact_channels = [
+        channel
+        for channel in channels
+        if _normalize_channel_name(channel.name) == normalized_query.lstrip("#")
+    ]
+
+    matches = [("user", user) for user in exact_users] + [
+        ("channel", channel) for channel in exact_channels
+    ]
+    if len(matches) != 1:
+        return None
+
+    target_type, item = matches[0]
+    team_id = ctx.get("slack_team_id")
+    connection_id = ctx.get("slack_connection_id")
+    target = (
+        build_user_target(item, team_id=team_id, connection_id=connection_id)
+        if target_type == "user"
+        else build_channel_target(item, team_id=team_id, connection_id=connection_id)
+    )
+
+    ctx.textual.begin_step("Select Slack Channel Target")
+    ctx.textual.success_text(
+        f"Using preferred Slack target: {target.target_name} ({target.target_id})"
+    )
+    ctx.textual.end_step("success")
+    return Success(
+        "Selected preferred Slack target",
+        metadata={
+            "slack_target": target,
+            "slack_target_type": target.target_type,
+            "slack_target_id": target.target_id,
+            "slack_target_name": target.target_name,
+            "slack_target_query": query,
+        },
+    )
 
 
 def _select_target_step(

--- a/plugins/titan-plugin-slack/titan_plugin_slack/steps/target_steps.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/steps/target_steps.py
@@ -9,11 +9,12 @@ from ..operations import (
     build_user_target,
     normalize_search_query,
 )
+from .summary_steps import select_target_step
 
 
 MIN_QUERY_LENGTH = 2
 MAX_TARGET_OPTIONS = 20
-SEARCH_ANOTHER_CHANNEL = "__search_another_channel__"
+SEARCH_OTHER_TARGET = "__search_other_target__"
 
 
 def select_user_target_step(ctx: WorkflowContext) -> WorkflowResult:
@@ -114,7 +115,11 @@ def select_channel_target_step(ctx: WorkflowContext) -> WorkflowResult:
 
 def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> WorkflowResult:
     """
-    Select a Slack channel from the configured defaults or search for another one.
+    Select a Slack channel from the configured defaults, or search people/channels.
+
+    When no default channels are configured, or when the user chooses to search
+    instead of using a default, this falls back to the unified person-or-channel
+    search (`select_target_step`).
 
     Requires:
         ctx.slack: An initialized SlackClient.
@@ -122,19 +127,19 @@ def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> Workfl
     Inputs (from ctx.data):
         slack_target_query (str, optional): Pre-filled query used if the user chooses to search manually.
         slack_search_limit (int, optional): Maximum number of matches to return during manual search. Defaults to 20.
-        slack_search_page_size (int, optional): Page size used while scanning Slack channels. Defaults to 1000.
+        slack_search_page_size (int, optional): Page size used while scanning Slack. Defaults to 1000.
         slack_search_max_pages (int, optional): Maximum pages to scan while searching. Defaults to 50.
         slack_exclude_archived (bool, optional): Whether to exclude archived channels while searching. Defaults to True.
 
     Outputs (saved to ctx.data):
         slack_target (UISlackTarget): Canonical selected Slack target.
-        slack_target_type (str): Selected target type (`channel`).
-        slack_target_id (str): Slack channel ID.
+        slack_target_type (str): Selected target type (`user` or `channel`).
+        slack_target_id (str): Slack target identifier.
         slack_target_name (str): User-facing target name.
         slack_target_query (str): Query used to resolve the selection, when manual search was used.
 
     Returns:
-        Success: If the channel target is selected successfully.
+        Success: If the target is selected successfully.
         Error: If Slack is unavailable, the configured channel cannot be resolved, or no match is selected.
     """
     if not ctx.textual:
@@ -145,7 +150,7 @@ def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> Workfl
 
     configured_channels = getattr(ctx.slack, "default_channels", []) or []
     if not configured_channels:
-        return select_channel_target_step(ctx)
+        return select_target_step(ctx)
 
     ctx.textual.begin_step("Select Slack Channel Target")
 
@@ -159,14 +164,14 @@ def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> Workfl
     ]
     options.append(
         OptionItem(
-            value=SEARCH_ANOTHER_CHANNEL,
-            title="Search another channel",
-            description="Look up a channel by name",
+            value=SEARCH_OTHER_TARGET,
+            title="Search for someone or another channel",
+            description="Look up a person or channel by name",
         )
     )
 
     selected = ctx.textual.ask_option(
-        "Select a configured channel or search for another one:",
+        "Select a configured channel or search for someone or another channel:",
         options=options,
     )
     if not selected:
@@ -174,9 +179,9 @@ def select_default_or_search_channel_target_step(ctx: WorkflowContext) -> Workfl
         ctx.textual.end_step("error")
         return Error("No Slack channel was selected.")
 
-    if selected == SEARCH_ANOTHER_CHANNEL:
+    if selected == SEARCH_OTHER_TARGET:
         ctx.textual.end_step("skip")
-        return select_channel_target_step(ctx)
+        return select_target_step(ctx)
 
     configured_channel_name = str(selected)
     resolved = _resolve_channel_by_name(ctx, configured_channel_name)


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Adds two new steps to the GitHub plugin: `select_release` for listing and selecting published GitHub releases as a notes source, and `prompt_for_pr_draft` to interactively ask whether a PR should be created as a draft. Also improves the Slack target step with preferred target resolution and unified person/channel search, and updates the `prompt_for_labels_step` to support configurable output keys and prompts.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `select_release` step (`Releases` group) — lists published GitHub releases (up to a configurable limit) and saves the selected release's tag, notes body, and URL to context
- Added `prompt_for_pr_draft` step — prompts the user interactively to choose draft mode, or skips the prompt if `draft` is already set in workflow params; saves `pr_is_draft` to context
- Updated `prompt_for_labels_step` to support `output_key`, `prompt`, and `default_selected_key` inputs for flexible reuse across workflows
- Added preferred target resolution and unified person/channel search to the Slack target step
- Updated `used_by_workflows` metadata for several steps to include `review-pr-thread-resolution` and `create-pr-ai`
- Registered the new `Releases` step group in the GitHub step inventory

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

<!-- If logs were added, list them:
- `event_name` (DEBUG/INFO/ERROR) — description of when it fires and what fields it includes
Example:
- `git_command_ok` (DEBUG) — subcommand, duration
- `ai_call_failed` (DEBUG) — provider, operation, max_tokens, duration
-->

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)