### PR TITLE
feat: Add format_markdown_message step and wire post-message workflow

### DIFF
--- a/docs/plugins/_generated/slack-step-inventory.json
+++ b/docs/plugins/_generated/slack-step-inventory.json
@@ -48,7 +48,11 @@
         },
         {
           "name": "prompt_message_body",
-          "summary": "Capture a multiline Slack message body for later posting."
+          "summary": "Capture a multiline Slack message for later formatting and posting."
+        },
+        {
+          "name": "format_markdown_message",
+          "summary": "Convert a standard Markdown message into Slack mrkdwn, if provided."
         },
         {
           "name": "post_message",
@@ -133,6 +137,34 @@
       },
       "used_by_workflows": [
         "summarize-slack-target"
+      ]
+    },
+    {
+      "name": "format_markdown_message",
+      "group": "Messaging",
+      "module": "titan_plugin_slack.steps.message_steps",
+      "function": "format_markdown_message_step",
+      "summary": "Convert a standard Markdown message into Slack mrkdwn, if provided.",
+      "docstring_sections": {
+        "Requires": [],
+        "Inputs (from ctx.data)": [
+          "    slack_message_text (str, optional): Already Slack-ready text. If present, this step does",
+          "        nothing and leaves it untouched.",
+          "    slack_message_markdown (str, optional): Standard Markdown text to convert to Slack mrkdwn.",
+          "        Ignored when `slack_message_text` is already present."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    slack_message_text (str): Slack mrkdwn-ready message text, when `slack_message_markdown` was converted."
+        ],
+        "Returns": [
+          "    Skip: If `slack_message_text` is already set, or neither input is provided (a later step",
+          "        can still prompt the user to compose one interactively).",
+          "    Success: If `slack_message_markdown` was converted successfully.",
+          "    Error: If the Textual UI context is not available."
+        ]
+      },
+      "used_by_workflows": [
+        "post-message"
       ]
     },
     {
@@ -235,7 +267,9 @@
           "    Error: If Slack is unavailable, required context is missing, or the Slack request fails."
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "post-message"
+      ]
     },
     {
       "name": "prepare_message_destination",
@@ -259,29 +293,35 @@
           "    Error: If Slack is unavailable, the target is missing or invalid, or the Slack request fails."
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "post-message"
+      ]
     },
     {
       "name": "prompt_message_body",
       "group": "Messaging",
       "module": "titan_plugin_slack.steps.message_steps",
       "function": "prompt_message_body_step",
-      "summary": "Capture a multiline Slack message body for later posting.",
+      "summary": "Capture a multiline Slack message for later formatting and posting.",
       "docstring_sections": {
         "Requires": [],
         "Inputs (from ctx.data)": [
-          "    slack_message_text (str, optional): Pre-filled message text. If already present, the prompt is skipped."
+          "    slack_message_text (str, optional): Already Slack-ready message text. If present, the prompt is skipped.",
+          "    slack_message_markdown (str, optional): Standard Markdown message already provided by a caller. If",
+          "        present (and slack_message_text isn't), the prompt is skipped."
         ],
         "Outputs (saved to ctx.data)": [
-          "    slack_message_text (str): Message text to post later."
+          "    slack_message_markdown (str): Captured message text, to be converted to Slack mrkdwn by a later step."
         ],
         "Returns": [
           "    Success: If the message body is captured successfully.",
-          "    Skip: If the message body already exists in context.",
+          "    Skip: If a message was already provided by the caller.",
           "    Error: If the user cancels or the message body is empty."
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "post-message"
+      ]
     },
     {
       "name": "read_recent_messages",
@@ -376,7 +416,9 @@
           "    Error: If Slack is unavailable, or no match is selected."
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "post-message"
+      ]
     },
     {
       "name": "select_target",
@@ -466,6 +508,7 @@
         ]
       },
       "used_by_workflows": [
+        "post-message",
         "summarize-slack-target"
       ]
     }

--- a/docs/plugins/_meta/slack-step-groups.json
+++ b/docs/plugins/_meta/slack-step-groups.json
@@ -22,7 +22,8 @@
       "steps": [
         {"name": "prepare_message_destination", "summary": "Resolve the selected Slack user or channel target into the destination conversation used for posting."},
         {"name": "open_direct_message", "summary": "Open or reuse a direct message conversation for the selected user target."},
-        {"name": "prompt_message_body", "summary": "Capture a multiline Slack message body for later posting."},
+        {"name": "prompt_message_body", "summary": "Capture a multiline Slack message for later formatting and posting."},
+        {"name": "format_markdown_message", "summary": "Convert a standard Markdown message into Slack mrkdwn, if provided."},
         {"name": "post_message", "summary": "Post the prepared message to the selected Slack conversation."}
       ]
     },

--- a/docs/plugins/generated/slack-step-reference.md
+++ b/docs/plugins/generated/slack-step-reference.md
@@ -21,7 +21,7 @@ Validate the configured Slack connection and expose identity metadata.
   step: validate_connection
 ```
 
-**Used by built-in workflows:** `summarize-slack-target`
+**Used by built-in workflows:** `post-message`, `summarize-slack-target`
 
 **Available to later steps:** `slack_auth`, `slack_team_id`, `slack_team_name`, `slack_user_id`
 
@@ -268,6 +268,8 @@ Select a Slack target from a preferred value or configured default, or search.
   step: select_default_or_search_channel_target
 ```
 
+**Used by built-in workflows:** `post-message`
+
 **Available to later steps:** `slack_target`, `slack_target_type`, `slack_target_id`, `slack_target_name`, `slack_target_query`
 
 **Requires**
@@ -324,6 +326,8 @@ Prepare a Slack message destination from the selected target.
 - plugin: slack
   step: prepare_message_destination
 ```
+
+**Used by built-in workflows:** `post-message`
 
 **Available to later steps:** `slack_conversation`, `slack_conversation_id`
 
@@ -400,7 +404,7 @@ Open or reuse a direct message conversation for the selected Slack user target.
 
 ### `prompt_message_body`
 
-Capture a multiline Slack message body for later posting.
+Capture a multiline Slack message for later formatting and posting.
 
 **How to read this contract**
 
@@ -415,27 +419,76 @@ Capture a multiline Slack message body for later posting.
   step: prompt_message_body
 ```
 
+**Used by built-in workflows:** `post-message`
+
+**Available to later steps:** `slack_message_markdown`
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `slack_message_text` | str, optional | Already Slack-ready message text. If present, the prompt is skipped. |
+| `slack_message_markdown` | str, optional | Standard Markdown message already provided by a caller. If |
+| present (and slack_message_text isn't), the prompt is skipped. | - | - |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `slack_message_markdown` | str | Captured message text, to be converted to Slack mrkdwn by a later step. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `slack_message_markdown` | If the message body is captured successfully. |
+| `Skip` | `slack_message_markdown` | If a message was already provided by the caller. |
+| `Error` | - | If the user cancels or the message body is empty. |
+
+### `format_markdown_message`
+
+Convert a standard Markdown message into Slack mrkdwn, if provided.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: slack
+  step: format_markdown_message
+```
+
+**Used by built-in workflows:** `post-message`
+
 **Available to later steps:** `slack_message_text`
 
 **Inputs (from ctx.data)**
 
 | Name | Type | Description |
 |------|------|-------------|
-| `slack_message_text` | str, optional | Pre-filled message text. If already present, the prompt is skipped. |
+| `slack_message_text` | str, optional | Already Slack-ready text. If present, this step does |
+| nothing and leaves it untouched. | - | - |
+| `slack_message_markdown` | str, optional | Standard Markdown text to convert to Slack mrkdwn. |
+| Ignored when `slack_message_text` is already present. | - | - |
 
 **Outputs (saved to ctx.data)**
 
 | Name | Type | Description |
 |------|------|-------------|
-| `slack_message_text` | str | Message text to post later. |
+| `slack_message_text` | str | Slack mrkdwn-ready message text, when `slack_message_markdown` was converted. |
 
 **Returns**
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `slack_message_text` | If the message body is captured successfully. |
-| `Skip` | `slack_message_text` | If the message body already exists in context. |
-| `Error` | - | If the user cancels or the message body is empty. |
+| `Skip` | `slack_message_text` | If `slack_message_text` is already set, or neither input is provided (a later step |
+| `can still prompt the user to compose one interactively).` | - | - |
+| `Success` | `slack_message_text` | If `slack_message_markdown` was converted successfully. |
+| `Error` | - | If the Textual UI context is not available. |
 
 ### `post_message`
 
@@ -453,6 +506,8 @@ Post a plain-text Slack message to the prepared conversation.
 - plugin: slack
   step: post_message
 ```
+
+**Used by built-in workflows:** `post-message`
 
 **Available to later steps:** `slack_message`, `slack_message_ts`, `slack_message_channel`
 

--- a/docs/plugins/slack/built-in-workflows.md
+++ b/docs/plugins/slack/built-in-workflows.md
@@ -1,6 +1,6 @@
 # Slack Built-in Workflows
 
-The Slack plugin currently ships one built-in workflow for target summaries.
+The Slack plugin currently ships two built-in workflows.
 
 ## `summarize-slack-target`
 
@@ -34,3 +34,51 @@ Search for a person or channel, read recent Slack messages, and summarize them w
 - `ensure_target_conversation`
 - `read_recent_messages`
 - `ai_summarize_messages`
+
+## `post-message`
+
+Resolve a Slack target and post a message, meant to be called as a nested `workflow:` step from any other workflow (project, personal, or another plugin's).
+
+**Source workflow:** `plugins/titan-plugin-slack/titan_plugin_slack/workflows/post-message.yaml`
+
+### Default flow
+
+1. `slack.validate_connection`
+2. `slack.select_default_or_search_channel_target`
+3. `slack.prepare_message_destination`
+4. `slack.prompt_message_body`
+5. `slack.format_markdown_message`
+6. `slack.post_message`
+
+### Typical usage
+
+Call it as a nested step, sharing `ctx.data` with the caller:
+
+```yaml
+- id: post_summary_to_slack
+  name: "Post Summary to Slack"
+  workflow: "plugin:slack/post-message"
+  on_error: continue   # treat this as an optional extra; a caller should never fail because of it
+```
+
+Before calling it, a caller can optionally set:
+
+- `slack_message_text` (str): already Slack-ready text (e.g. a prebuilt table). Used verbatim, never converted.
+- `slack_message_markdown` (str): standard Markdown text. Converted to Slack mrkdwn by `format_markdown_message`.
+- `slack_preferred_target` (str): a person or channel name to auto-select with no prompt, when it resolves to exactly one match.
+
+If neither `slack_message_text` nor `slack_message_markdown` is set, `prompt_message_body` asks the user to type a message interactively - that typed text is then converted the same way a caller-provided Markdown message would be.
+
+### Scope constraints
+
+- always call it with `on_error: continue` on the outer `workflow:` step - it's designed to fail cleanly (missing Slack plugin, not configured, cancelled selection) without ever being the reason a caller workflow fails
+- this workflow depends on messaging scopes (`chat:write`, etc.) and, for `select_default_or_search_channel_target`'s search fallback, conversation-listing scopes
+
+### Related public steps
+
+- `validate_connection`
+- `select_default_or_search_channel_target`
+- `prepare_message_destination`
+- `prompt_message_body`
+- `format_markdown_message`
+- `post_message`

--- a/docs/plugins/slack/workflow-steps.md
+++ b/docs/plugins/slack/workflow-steps.md
@@ -95,7 +95,7 @@ How to read these contracts:
       step: validate_connection
     ```
 
-    **Used by built-in workflows:** `summarize-slack-target`
+    **Used by built-in workflows:** `post-message`, `summarize-slack-target`
 
     **Available to later steps:** `slack_auth`, `slack_team_id`, `slack_team_name`, `slack_user_id`
 
@@ -312,6 +312,8 @@ How to read these contracts:
       step: select_default_or_search_channel_target
     ```
 
+    **Used by built-in workflows:** `post-message`
+
     **Available to later steps:** `slack_target`, `slack_target_type`, `slack_target_id`, `slack_target_name`, `slack_target_query`
 
     **Requires**
@@ -362,6 +364,8 @@ How to read these contracts:
     - plugin: slack
       step: prepare_message_destination
     ```
+
+    **Used by built-in workflows:** `post-message`
 
     **Available to later steps:** `slack_conversation`, `slack_conversation_id`
 
@@ -432,7 +436,7 @@ How to read these contracts:
 
 
 ??? info "`prompt_message_body`"
-    Capture a multiline Slack message body for later posting.
+    Capture a multiline Slack message for later formatting and posting.
 
     **Workflow usage**
 
@@ -441,27 +445,70 @@ How to read these contracts:
       step: prompt_message_body
     ```
 
+    **Used by built-in workflows:** `post-message`
+
+    **Available to later steps:** `slack_message_markdown`
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `slack_message_text` | str, optional | Already Slack-ready message text. If present, the prompt is skipped. |
+    | `slack_message_markdown` | str, optional | Standard Markdown message already provided by a caller. If |
+    | present (and slack_message_text isn't), the prompt is skipped. | - | - |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `slack_message_markdown` | str | Captured message text, to be converted to Slack mrkdwn by a later step. |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `slack_message_markdown` | If the message body is captured successfully. |
+    | `Skip` | `slack_message_markdown` | If a message was already provided by the caller. |
+    | `Error` | - | If the user cancels or the message body is empty. |
+
+
+??? info "`format_markdown_message`"
+    Convert a standard Markdown message into Slack mrkdwn, if provided.
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: slack
+      step: format_markdown_message
+    ```
+
+    **Used by built-in workflows:** `post-message`
+
     **Available to later steps:** `slack_message_text`
 
     **Inputs (from ctx.data)**
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `slack_message_text` | str, optional | Pre-filled message text. If already present, the prompt is skipped. |
+    | `slack_message_text` | str, optional | Already Slack-ready text. If present, this step does |
+    | nothing and leaves it untouched. | - | - |
+    | `slack_message_markdown` | str, optional | Standard Markdown text to convert to Slack mrkdwn. |
+    | Ignored when `slack_message_text` is already present. | - | - |
 
     **Outputs (saved to ctx.data)**
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `slack_message_text` | str | Message text to post later. |
+    | `slack_message_text` | str | Slack mrkdwn-ready message text, when `slack_message_markdown` was converted. |
 
     **Returns**
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `slack_message_text` | If the message body is captured successfully. |
-    | `Skip` | `slack_message_text` | If the message body already exists in context. |
-    | `Error` | - | If the user cancels or the message body is empty. |
+    | `Skip` | `slack_message_text` | If `slack_message_text` is already set, or neither input is provided (a later step |
+    | `can still prompt the user to compose one interactively).` | - | - |
+    | `Success` | `slack_message_text` | If `slack_message_markdown` was converted successfully. |
+    | `Error` | - | If the Textual UI context is not available. |
 
 
 ??? info "`post_message`"
@@ -473,6 +520,8 @@ How to read these contracts:
     - plugin: slack
       step: post_message
     ```
+
+    **Used by built-in workflows:** `post-message`
 
     **Available to later steps:** `slack_message`, `slack_message_ts`, `slack_message_channel`
 

--- a/plugins/titan-plugin-slack/tests/test_formatting.py
+++ b/plugins/titan-plugin-slack/tests/test_formatting.py
@@ -45,25 +45,24 @@ class TestToMrkdwn:
         markdown = "| Name | Version |\n| --- | --- |\n| titan-cli | 0.6.0 |"
         result = SlackFormatter.to_mrkdwn(markdown)
         assert result.startswith("```\n")
+        assert result.endswith("\n```")
         assert "Name" in result and "Version" in result
         assert "titan-cli" in result and "0.6.0" in result
 
-
-class TestTable:
-    def test_renders_headers_and_rows_aligned(self) -> None:
-        result = SlackFormatter.table(
-            rows=[["titan-cli", "0.6.0"], ["ragnarok", "0.9.3"]],
-            headers=["Plugin", "Version"],
+    def test_converts_inline_table_with_multiple_rows_aligned(self) -> None:
+        markdown = (
+            "| Plugin | Version |\n"
+            "| --- | --- |\n"
+            "| titan-cli | 0.6.0 |\n"
+            "| ragnarok | 0.9.3 |"
         )
+        result = SlackFormatter.to_mrkdwn(markdown)
         lines = result.strip("`\n").split("\n")
         assert lines[0].startswith("Plugin")
         assert "titan-cli" in lines[2]
-        assert result.startswith("```")
-        assert result.endswith("```")
+        assert "ragnarok" in lines[3]
 
-    def test_pads_missing_cells(self) -> None:
-        result = SlackFormatter.table(rows=[["a", "b"], ["only-one"]], headers=["Col1", "Col2"])
+    def test_converts_inline_table_with_missing_cells(self) -> None:
+        markdown = "| Col1 | Col2 |\n| --- | --- |\n| only-one |"
+        result = SlackFormatter.to_mrkdwn(markdown)
         assert "only-one" in result
-
-    def test_returns_empty_string_for_no_data(self) -> None:
-        assert SlackFormatter.table(rows=[]) == ""

--- a/plugins/titan-plugin-slack/tests/test_message_steps.py
+++ b/plugins/titan-plugin-slack/tests/test_message_steps.py
@@ -5,6 +5,7 @@ from titan_cli.engine import Error, Skip, Success
 from titan_cli.engine.context import WorkflowContext
 from titan_plugin_slack.models import UISlackConversation, UISlackPostedMessage, UISlackTarget
 from titan_plugin_slack.steps.message_steps import (
+    format_markdown_message_step,
     open_direct_message_step,
     prepare_message_destination_step,
     post_message_step,
@@ -74,24 +75,34 @@ def test_prepare_message_destination_step_uses_channel_target_directly() -> None
     assert conversation.is_im is False
 
 
-def test_prompt_message_body_step_skips_when_preset_exists() -> None:
+def test_prompt_message_body_step_skips_when_text_already_present() -> None:
     ctx = _build_context()
     ctx.data["slack_message_text"] = "Hello"
 
     result = prompt_message_body_step(ctx)
 
     assert isinstance(result, Skip)
-    assert result.metadata == {"slack_message_text": "Hello"}
+    ctx.textual.ask_multiline.assert_not_called()
 
 
-def test_prompt_message_body_step_returns_message_text() -> None:
+def test_prompt_message_body_step_skips_when_markdown_already_present() -> None:
+    ctx = _build_context()
+    ctx.data["slack_message_markdown"] = "**Hello**"
+
+    result = prompt_message_body_step(ctx)
+
+    assert isinstance(result, Skip)
+    ctx.textual.ask_multiline.assert_not_called()
+
+
+def test_prompt_message_body_step_returns_message_markdown() -> None:
     ctx = _build_context()
     ctx.textual.ask_multiline.return_value = "Hello there"
 
     result = prompt_message_body_step(ctx)
 
     assert isinstance(result, Success)
-    assert result.metadata == {"slack_message_text": "Hello there"}
+    assert result.metadata == {"slack_message_markdown": "Hello there"}
 
 
 def test_post_message_step_returns_message_metadata() -> None:
@@ -124,3 +135,33 @@ def test_post_message_step_returns_error_from_client() -> None:
 
     assert isinstance(result, Error)
     assert result.message == "Slack post_message failed: missing_scope"
+
+
+def test_format_markdown_message_step_skips_when_text_already_present() -> None:
+    ctx = _build_context()
+    ctx.data["slack_message_text"] = "Already ready: *bold*"
+    ctx.data["slack_message_markdown"] = "**should be ignored**"
+
+    result = format_markdown_message_step(ctx)
+
+    assert isinstance(result, Skip)
+    assert ctx.data["slack_message_text"] == "Already ready: *bold*"
+
+
+def test_format_markdown_message_step_converts_markdown() -> None:
+    ctx = _build_context()
+    ctx.data["slack_message_markdown"] = "**bold** and a [link](https://example.com)"
+
+    result = format_markdown_message_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["slack_message_text"] == "*bold* and a <https://example.com|link>"
+
+
+def test_format_markdown_message_step_skips_when_nothing_provided() -> None:
+    ctx = _build_context()
+
+    result = format_markdown_message_step(ctx)
+
+    assert isinstance(result, Skip)
+    assert "slack_message_text" not in ctx.data

--- a/plugins/titan-plugin-slack/tests/test_plugin.py
+++ b/plugins/titan-plugin-slack/tests/test_plugin.py
@@ -36,6 +36,7 @@ def test_slack_plugin_exposes_public_steps() -> None:
         "read_recent_messages",
         "ai_summarize_messages",
         "open_direct_message",
+        "format_markdown_message",
         "prompt_message_body",
         "post_message",
     }

--- a/plugins/titan-plugin-slack/tests/test_workflows.py
+++ b/plugins/titan-plugin-slack/tests/test_workflows.py
@@ -22,3 +22,26 @@ def test_summarize_slack_target_workflow_structure() -> None:
     ]
     assert workflow["steps"][1]["step"] == "select_target"
     assert workflow["steps"][3]["params"]["slack_history_limit"] == "${slack_history_limit}"
+
+
+def test_post_message_workflow_structure() -> None:
+    workflow_path = (
+        Path(__file__).parent.parent / "titan_plugin_slack" / "workflows" / "post-message.yaml"
+    )
+
+    with open(workflow_path, encoding="utf-8") as handle:
+        workflow = yaml.safe_load(handle)
+
+    assert workflow["name"] == "Post Slack Message"
+    assert [step["id"] for step in workflow["steps"]] == [
+        "validate_connection",
+        "select_target",
+        "prepare_destination",
+        "compose_message",
+        "format_message",
+        "post_message",
+    ]
+    assert workflow["steps"][1]["step"] == "select_default_or_search_channel_target"
+    assert workflow["steps"][3]["step"] == "prompt_message_body"
+    assert workflow["steps"][4]["step"] == "format_markdown_message"
+    assert all("on_error" not in step for step in workflow["steps"])

--- a/plugins/titan-plugin-slack/titan_plugin_slack/formatting.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/formatting.py
@@ -6,6 +6,11 @@ and there is no native table support. `SlackFormatter` lets any step render
 AI-generated or hand-written content correctly in Slack, while a second,
 standard-Markdown copy of the same source can still be shown elsewhere (e.g.
 the Titan TUI).
+
+`to_mrkdwn` is the only public entry point. A caller with structured tabular
+data (headers/rows) should build a plain Markdown pipe table string and pass
+it through `to_mrkdwn` like any other content - there is no separate table
+API to learn, and it converts everything (prose and tables) consistently.
 """
 
 import re
@@ -33,8 +38,9 @@ class SlackFormatter:
         Convert a standard Markdown document into Slack-flavored mrkdwn.
 
         Handles headers, bold/italic/strikethrough, links, bullet lists, and
-        pipe tables. Fenced code blocks are left untouched since Slack already
-        renders them as-is. Pipe tables are rendered with `SlackFormatter.table`.
+        pipe tables (rendered as a fixed-width grid inside a code block, since
+        Slack has no native table support). Fenced code blocks are left
+        untouched since Slack already renders them as-is.
 
         Args:
             text: Standard Markdown source text.
@@ -50,13 +56,14 @@ class SlackFormatter:
         return "".join(converted)
 
     @staticmethod
-    def table(rows: List[List[str]], headers: Optional[List[str]] = None) -> str:
+    def _render_table(rows: List[List[str]], headers: Optional[List[str]] = None) -> str:
         """
         Render tabular data as a fixed-width Slack table inside a code block.
 
-        Slack's plain-text messages have no native table support, so columns
-        are aligned with padding and wrapped in a fenced code block, which
-        Slack renders in a monospace font.
+        Slack has no native table support, so this is the only way to get an
+        actual comparable grid (e.g. checking one column across many rows) in
+        a plain-text message. Used internally by `to_mrkdwn` when it detects
+        a Markdown pipe table.
 
         Args:
             rows: Table body rows, each a list of cell values.
@@ -118,7 +125,7 @@ class SlackFormatter:
                     SlackFormatter._split_table_row(line)
                     for line in (lines[i], *lines[i + 2:table_end])
                 ]
-                output_lines.append(SlackFormatter.table(rows, headers=header))
+                output_lines.append(SlackFormatter._render_table(rows, headers=header))
                 i = table_end
                 continue
 

--- a/plugins/titan-plugin-slack/titan_plugin_slack/plugin.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/plugin.py
@@ -198,6 +198,7 @@ class SlackPlugin(TitanPlugin):
         from .steps import (
             ai_summarize_messages_step,
             ensure_target_conversation_step,
+            format_markdown_message_step,
             list_public_channels_step,
             list_users_step,
             open_direct_message_step,
@@ -225,6 +226,7 @@ class SlackPlugin(TitanPlugin):
             "read_recent_messages": read_recent_messages_step,
             "ai_summarize_messages": ai_summarize_messages_step,
             "open_direct_message": open_direct_message_step,
+            "format_markdown_message": format_markdown_message_step,
             "prompt_message_body": prompt_message_body_step,
             "post_message": post_message_step,
         }

--- a/plugins/titan-plugin-slack/titan_plugin_slack/steps/__init__.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/steps/__init__.py
@@ -6,6 +6,7 @@ from .discovery_steps import (
     validate_connection_step,
 )
 from .message_steps import (
+    format_markdown_message_step,
     open_direct_message_step,
     prepare_message_destination_step,
     post_message_step,
@@ -29,6 +30,7 @@ __all__ = [
     "list_users_step",
     "prepare_message_destination_step",
     "open_direct_message_step",
+    "format_markdown_message_step",
     "prompt_message_body_step",
     "post_message_step",
     "select_target_step",

--- a/plugins/titan-plugin-slack/titan_plugin_slack/steps/message_steps.py
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/steps/message_steps.py
@@ -2,6 +2,7 @@
 
 from titan_cli.core.result import ClientError, ClientSuccess
 from titan_cli.engine import Error, Skip, Success, WorkflowContext, WorkflowResult
+from ..formatting import SlackFormatter
 from ..models import UISlackConversation
 
 
@@ -113,19 +114,74 @@ def open_direct_message_step(ctx: WorkflowContext) -> WorkflowResult:
     return prepare_message_destination_step(ctx)
 
 
-def prompt_message_body_step(ctx: WorkflowContext) -> WorkflowResult:
+def format_markdown_message_step(ctx: WorkflowContext) -> WorkflowResult:
     """
-    Capture a multiline Slack message body for later posting.
+    Convert a standard Markdown message into Slack mrkdwn, if provided.
+
+    Leaves an already Slack-ready message untouched, so a caller that already
+    built Slack-specific content (e.g. a prebuilt table) is never
+    double-converted.
 
     Inputs (from ctx.data):
-        slack_message_text (str, optional): Pre-filled message text. If already present, the prompt is skipped.
+        slack_message_text (str, optional): Already Slack-ready text. If present, this step does
+            nothing and leaves it untouched.
+        slack_message_markdown (str, optional): Standard Markdown text to convert to Slack mrkdwn.
+            Ignored when `slack_message_text` is already present.
 
     Outputs (saved to ctx.data):
-        slack_message_text (str): Message text to post later.
+        slack_message_text (str): Slack mrkdwn-ready message text, when `slack_message_markdown` was converted.
+
+    Returns:
+        Skip: If `slack_message_text` is already set, or neither input is provided (a later step
+            can still prompt the user to compose one interactively).
+        Success: If `slack_message_markdown` was converted successfully.
+        Error: If the Textual UI context is not available.
+    """
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Format Slack Message")
+
+    if ctx.get("slack_message_text"):
+        ctx.textual.dim_text("Slack message text already provided - using as-is.")
+        ctx.textual.end_step("skip")
+        return Skip("Slack message text already provided")
+
+    markdown = ctx.get("slack_message_markdown")
+    if not markdown:
+        ctx.textual.dim_text("No message provided - you will be asked to compose one.")
+        ctx.textual.end_step("skip")
+        return Skip("No message provided")
+
+    formatted = SlackFormatter.to_mrkdwn(markdown)
+    ctx.textual.success_text("Converted Markdown message to Slack mrkdwn")
+    ctx.textual.end_step("success")
+    return Success(
+        "Converted Markdown message to Slack mrkdwn",
+        metadata={"slack_message_text": formatted},
+    )
+
+
+def prompt_message_body_step(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    Capture a multiline Slack message for later formatting and posting.
+
+    Captured text is saved as `slack_message_markdown` (not `slack_message_text`)
+    so a later step (e.g. `format_markdown_message`) converts it to Slack
+    mrkdwn just like a caller-provided Markdown message would be - typed input
+    shouldn't be posted as raw, unconverted Markdown.
+
+    Inputs (from ctx.data):
+        slack_message_text (str, optional): Already Slack-ready message text. If present, the prompt is skipped.
+        slack_message_markdown (str, optional): Standard Markdown message already provided by a caller. If
+            present (and slack_message_text isn't), the prompt is skipped.
+
+    Outputs (saved to ctx.data):
+        slack_message_markdown (str): Captured message text, to be converted to Slack mrkdwn by a later step.
 
     Returns:
         Success: If the message body is captured successfully.
-        Skip: If the message body already exists in context.
+        Skip: If a message was already provided by the caller.
         Error: If the user cancels or the message body is empty.
     """
     if not ctx.textual:
@@ -133,15 +189,12 @@ def prompt_message_body_step(ctx: WorkflowContext) -> WorkflowResult:
 
     ctx.textual.begin_step("Compose Slack Message")
 
-    existing = ctx.get("slack_message_text")
-    existing_stripped = str(existing).strip() if existing else ""
-    if existing_stripped:
-        ctx.textual.dim_text("Slack message text already provided, skipping prompt.")
+    existing_text = str(ctx.get("slack_message_text") or "").strip()
+    existing_markdown = str(ctx.get("slack_message_markdown") or "").strip()
+    if existing_text or existing_markdown:
+        ctx.textual.dim_text("Slack message already provided, skipping prompt.")
         ctx.textual.end_step("skip")
-        return Skip(
-            "Slack message text already provided",
-            metadata={"slack_message_text": existing_stripped},
-        )
+        return Skip("Slack message already provided")
 
     try:
         body = ctx.textual.ask_multiline("Enter the Slack message:", default="")
@@ -161,7 +214,7 @@ def prompt_message_body_step(ctx: WorkflowContext) -> WorkflowResult:
     ctx.textual.end_step("success")
     return Success(
         "Slack message text captured",
-        metadata={"slack_message_text": body.strip()},
+        metadata={"slack_message_markdown": body.strip()},
     )
 
 
@@ -238,6 +291,7 @@ def post_message_step(ctx: WorkflowContext) -> WorkflowResult:
 __all__ = [
     "prepare_message_destination_step",
     "open_direct_message_step",
+    "format_markdown_message_step",
     "prompt_message_body_step",
     "post_message_step",
 ]

--- a/plugins/titan-plugin-slack/titan_plugin_slack/workflows/post-message.yaml
+++ b/plugins/titan-plugin-slack/titan_plugin_slack/workflows/post-message.yaml
@@ -1,0 +1,33 @@
+name: "Post Slack Message"
+description: "Resolve a Slack target (preferred target, project default, or search) and post a message"
+
+steps:
+  - id: validate_connection
+    name: "Validate Slack Connection"
+    plugin: slack
+    step: validate_connection
+
+  - id: select_target
+    name: "Select Slack Target"
+    plugin: slack
+    step: select_default_or_search_channel_target
+
+  - id: prepare_destination
+    name: "Prepare Slack Destination"
+    plugin: slack
+    step: prepare_message_destination
+
+  - id: compose_message
+    name: "Compose Slack Message"
+    plugin: slack
+    step: prompt_message_body
+
+  - id: format_message
+    name: "Format Slack Message"
+    plugin: slack
+    step: format_markdown_message
+
+  - id: post_message
+    name: "Post Slack Message"
+    plugin: slack
+    step: post_message


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Introduces a new `format_markdown_message` step that converts standard Markdown into Slack mrkdwn format, enabling callers to pass Markdown content directly without pre-converting it. The `post-message` workflow is now fully wired up, connecting `validate_connection`, `select_default_or_search_channel_target`, `prepare_message_destination`, `prompt_message_body`, `format_markdown_message`, and `post_message` into a complete end-to-end flow. Documentation and step inventory metadata are updated to reflect these changes.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `format_markdown_message` step (group: Messaging) that converts `slack_message_markdown` → `slack_message_text` (Slack mrkdwn); skips if `slack_message_text` is already set or no input is provided
- Updated `prompt_message_body` to output `slack_message_markdown` instead of `slack_message_text`, and to skip when either `slack_message_text` or `slack_message_markdown` is already present in context
- Wired `post-message` workflow into the `used_by_workflows` metadata for: `validate_connection`, `select_default_or_search_channel_target`, `prepare_message_destination`, `prompt_message_body`, `post_message`, and `select_target`
- Updated step summaries and input/output contracts in the generated step inventory JSON and step reference Markdown docs
- Added `format_markdown_message` to the Messaging group in `slack-step-groups.json`

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)