### PR TITLE
docs: Add session bootstrap guidance to agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,15 @@ Documentation for AI coding agents working on Titan CLI.
 
 ---
 
+## 🧭 Session Bootstrap
+
+Before doing any work in this repo, read [`harness/README.md`](harness/README.md) — it names
+the current-focus domain/task and points to that domain's own state files
+(`feature-list.json`, `progress.md`, `session-handoff.md`). Don't ask which task we're on;
+that file answers it.
+
+---
+
 ## 📋 Project Overview
 
 **Titan CLI** is a modular development tools orchestrator that streamlines workflows through plugins, configuration management, and an intuitive terminal UI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 Documentation for the Titan CLI project to assist Claude in development.
 
+## Session Bootstrap
+
+Before doing any work in this repo, read [`harness/README.md`](harness/README.md) — it names
+the current-focus domain/task and points to that domain's own state files
+(`feature-list.json`, `progress.md`, `session-handoff.md`). Don't ask which task we're on;
+that file answers it.
+
 ## Project Overview
 
 Titan CLI is a command-line tool with a Textual-based TUI (Terminal User Interface) that enables automated workflows for Git, GitHub, Jira, and other services, with AI integration for intelligent assistance.


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Adds a "Session Bootstrap" section to both `AGENTS.md` and `CLAUDE.md` directing AI agents to read `harness/README.md` before starting any work. This ensures agents always pick up the current-focus task and state files without needing to ask.

## 🔧 Changes Made
- Added `🧭 Session Bootstrap` section to `AGENTS.md` with link to `harness/README.md`
- Added `Session Bootstrap` section to `CLAUDE.md` with the same guidance
- Both sections reference the domain state files (`feature-list.json`, `progress.md`, `session-handoff.md`)

## 🧪 Testing
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- Documentation-only change; no code logic affected -->

## 📊 Logs
- [x] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)