### PR TITLE
feat: Add Firebase plugin with Remote Config read support

### DIFF
--- a/.titan/operations/plugin_docs_operations.py
+++ b/.titan/operations/plugin_docs_operations.py
@@ -24,6 +24,10 @@ OFFICIAL_PLUGIN_REFS = {
         "package_dir": "plugins/titan-plugin-jira",
         "plugin_ref": "titan_plugin_jira.plugin:JiraPlugin",
     },
+    "firebase": {
+        "package_dir": "plugins/titan-plugin-firebase",
+        "plugin_ref": "titan_plugin_firebase.plugin:FirebasePlugin",
+    },
     "slack": {
         "package_dir": "plugins/titan-plugin-slack",
         "plugin_ref": "titan_plugin_slack.plugin:SlackPlugin",
@@ -34,6 +38,7 @@ WORKFLOW_STEPS_PAGE_PATHS = {
     "git": "docs/plugins/git/workflow-steps.md",
     "github": "docs/plugins/github/workflow-steps.md",
     "jira": "docs/plugins/jira/workflow-steps.md",
+    "firebase": "docs/plugins/firebase/workflow-steps.md",
     "slack": "docs/plugins/slack/workflow-steps.md",
 }
 

--- a/docs/concepts/oauth-manager.md
+++ b/docs/concepts/oauth-manager.md
@@ -1,0 +1,48 @@
+# OAuth Manager
+
+Titan centralizes plugin OAuth coordination in `titan_cli.core.oauth`.
+
+The manager is provider-neutral: plugins describe the credential they need with
+an `OAuthRequest`, and the manager resolves an `OAuthCredential` from environment
+variables, Titan's OAuth token store, legacy secret keys, or a registered OAuth
+provider.
+
+## Current Scope
+
+- Async API: `OAuthManager.get_credential(...)`
+- Blocking wrappers for today's synchronous workflow executor
+- Provider-neutral events through `OAuthEventSink`
+- Queue-backed event sink for a future shared runtime event queue
+- One SecretManager JSON blob per OAuth credential
+- Credential-scoped locks for refresh/login coordination
+- Google OAuth provider integration for Firebase Remote Config tokens
+- Legacy Firebase token keys still read for migration safety
+
+Firebase can now obtain refreshable credentials through browser-based Google
+OAuth with PKCE. Manual Firebase access tokens can still be stored in the OAuth
+token store, but they do not include expiry metadata.
+
+## Refresh Strategy
+
+Provider-backed token sets should store `expires_at`.
+
+Before returning a credential, the manager checks whether the token is still
+valid outside the configured refresh margin. The default margin is 300 seconds.
+If the token is expired or near expiry and a refresh token exists, the manager:
+
+1. Acquires the credential lock.
+2. Reads storage again in case another worker already refreshed it.
+3. Calls the provider refresh method only if refresh is still needed.
+4. Stores the refreshed token set as a single blob.
+5. Emits safe lifecycle events without token values.
+
+This prevents duplicate refreshes when several workflows, screens, or future
+headless jobs ask for the same credential concurrently.
+
+## Planned Evolution
+
+The next provider work should migrate Slack to the same manager.
+
+That future work should keep UI concerns outside `titan_cli.core.oauth`: a TUI,
+CLI prompt, server process, or headless runner should observe the same events and
+decide how to present authorization, errors, retries, and progress.

--- a/docs/plugins/_generated/firebase-step-inventory.json
+++ b/docs/plugins/_generated/firebase-step-inventory.json
@@ -44,7 +44,8 @@
           "    prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to True."
         ],
         "Outputs (saved to ctx.data)": [
-          "    firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.",
+          "    firebase_account (Optional[str]): Reserved until Firebase token identity can be resolved; currently None.",
+          "    firebase_auth_source (Optional[str]): Safe source label for the token Titan will use.",
           "    firebase_login_command (str): Command the user can run to create an ADC session.",
           "    firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.",
           "    firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login."
@@ -139,7 +140,8 @@
           "    prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to False."
         ],
         "Outputs (saved to ctx.data)": [
-          "    firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.",
+          "    firebase_account (Optional[str]): Reserved until Firebase token identity can be resolved; currently None.",
+          "    firebase_auth_source (Optional[str]): Safe source label for the token Titan will use.",
           "    firebase_login_command (str): Command the user can run to create an ADC session.",
           "    firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.",
           "    firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login."

--- a/docs/plugins/_generated/firebase-step-inventory.json
+++ b/docs/plugins/_generated/firebase-step-inventory.json
@@ -6,11 +6,11 @@
       "steps": [
         {
           "name": "firebase_login",
-          "summary": "Validate the current user's Google Cloud ADC session for Firebase workflows."
+          "summary": "Validate Firebase OAuth auth from Titan OAuth store, env var, or Google Cloud ADC."
         },
         {
           "name": "firebase_status",
-          "summary": "Report the current Firebase ADC authentication status."
+          "summary": "Report the current Firebase OAuth authentication status."
         }
       ]
     },
@@ -20,6 +20,10 @@
         {
           "name": "firebase_remoteconfig_get",
           "summary": "Read one Firebase project's Remote Config template and expose its ETag."
+        },
+        {
+          "name": "firebase_remoteconfig_inventory",
+          "summary": "Build a key inventory across configured Firebase brand projects."
         }
       ]
     }
@@ -30,25 +34,30 @@
       "group": "Authentication",
       "module": "titan_plugin_firebase.steps.login_step",
       "function": "execute_firebase_login_step",
-      "summary": "Validate that the current user has a Firebase ADC session.",
+      "summary": "Validate that the current user has Firebase OAuth authentication.",
       "docstring_sections": {
         "Requires": [
           "    ctx.firebase: An initialized FirebaseClient."
         ],
         "Inputs (from ctx.data)": [
-          "    fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True."
+          "    fail_on_missing_auth (bool, optional): Return Error when auth is missing. Defaults to True.",
+          "    prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to True."
         ],
         "Outputs (saved to ctx.data)": [
           "    firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.",
-          "    firebase_login_command (str): Command the user can run to create an ADC session."
+          "    firebase_login_command (str): Command the user can run to create an ADC session.",
+          "    firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.",
+          "    firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login."
         ],
         "Returns": [
-          "    Success: If gcloud ADC is available.",
-          "    Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.",
-          "    Skip: If ADC auth is missing and fail_on_missing_auth is False."
+          "    Success: If Firebase OAuth auth is available.",
+          "    Error: If Firebase client or auth is missing and fail_on_missing_auth is True.",
+          "    Skip: If auth is missing and fail_on_missing_auth is False."
         ]
       },
-      "used_by_workflows": []
+      "used_by_workflows": [
+        "list-remoteconfig-keys"
+      ]
     },
     {
       "name": "firebase_remoteconfig_get",
@@ -78,26 +87,67 @@
       "used_by_workflows": []
     },
     {
-      "name": "firebase_status",
-      "group": "Authentication",
-      "module": "titan_plugin_firebase.steps.login_step",
-      "function": "execute_firebase_status_step",
-      "summary": "Report the current Firebase ADC authentication status.",
+      "name": "firebase_remoteconfig_inventory",
+      "group": "Remote Config",
+      "module": "titan_plugin_firebase.steps.remoteconfig_inventory_step",
+      "function": "execute_firebase_remoteconfig_inventory_step",
+      "summary": "Build a key inventory across configured Firebase Remote Config projects.",
       "docstring_sections": {
         "Requires": [
           "    ctx.firebase: An initialized FirebaseClient."
         ],
         "Inputs (from ctx.data)": [
-          "    fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True."
+          "    project_targets (list[dict], optional): Explicit Firebase project targets.",
+          "    firebase_project_targets (list[dict], optional): Alternate explicit target key.",
+          "    projects (list[dict|str], optional): Firebase project targets or project IDs.",
+          "    brand_projects (dict, optional): Brand/environment project mapping override.",
+          "    brand (str, optional): Single brand filter.",
+          "    brands (list[str]|str, optional): Brand filter list or comma-separated string.",
+          "    environment (str, optional): Single environment filter.",
+          "    environments (list[str]|str, optional): Environment filter list or comma-separated string.",
+          "    continue_on_error (bool, optional): Continue when one project read fails. Defaults to True."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    firebase_remoteconfig_inventory (dict): Aggregated inventory payload.",
+          "    firebase_remoteconfig_keys (list[dict]): Unique key inventory rows.",
+          "    firebase_remoteconfig_targets (list[dict]): Project targets that were requested.",
+          "    firebase_remoteconfig_project_count (int): Number of projects read successfully.",
+          "    firebase_remoteconfig_key_count (int): Number of unique keys found.",
+          "    firebase_remoteconfig_failures (list[dict]): Project read failures, when any."
+        ],
+        "Returns": [
+          "    Success: If at least one project is read and key inventory is built.",
+          "    Error: If Firebase is unavailable, no targets are configured, or all project reads fail."
+        ]
+      },
+      "used_by_workflows": [
+        "list-remoteconfig-keys"
+      ]
+    },
+    {
+      "name": "firebase_status",
+      "group": "Authentication",
+      "module": "titan_plugin_firebase.steps.login_step",
+      "function": "execute_firebase_status_step",
+      "summary": "Report the current Firebase OAuth authentication status.",
+      "docstring_sections": {
+        "Requires": [
+          "    ctx.firebase: An initialized FirebaseClient."
+        ],
+        "Inputs (from ctx.data)": [
+          "    fail_on_missing_auth (bool, optional): Return Error when auth is missing. Defaults to True.",
+          "    prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to False."
         ],
         "Outputs (saved to ctx.data)": [
           "    firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.",
-          "    firebase_login_command (str): Command the user can run to create an ADC session."
+          "    firebase_login_command (str): Command the user can run to create an ADC session.",
+          "    firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.",
+          "    firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login."
         ],
         "Returns": [
-          "    Success: If gcloud ADC is available.",
-          "    Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.",
-          "    Skip: If ADC auth is missing and fail_on_missing_auth is False."
+          "    Success: If Firebase OAuth auth is available.",
+          "    Error: If Firebase client or auth is missing and fail_on_missing_auth is True.",
+          "    Skip: If auth is missing and fail_on_missing_auth is False."
         ]
       },
       "used_by_workflows": []

--- a/docs/plugins/_generated/firebase-step-inventory.json
+++ b/docs/plugins/_generated/firebase-step-inventory.json
@@ -82,7 +82,7 @@
         ],
         "Returns": [
           "    Success: If the Remote Config template is read successfully.",
-          "    Error: If Firebase is unavailable, no project ID is provided, or the API request fails."
+          "    Error: If Firebase is unavailable, no project ID is provided, the API request fails, or the template payload is malformed."
         ]
       },
       "used_by_workflows": []

--- a/docs/plugins/_generated/firebase-step-inventory.json
+++ b/docs/plugins/_generated/firebase-step-inventory.json
@@ -1,0 +1,106 @@
+{
+  "plugin": "firebase",
+  "groups": [
+    {
+      "name": "Authentication",
+      "steps": [
+        {
+          "name": "firebase_login",
+          "summary": "Validate the current user's Google Cloud ADC session for Firebase workflows."
+        },
+        {
+          "name": "firebase_status",
+          "summary": "Report the current Firebase ADC authentication status."
+        }
+      ]
+    },
+    {
+      "name": "Remote Config",
+      "steps": [
+        {
+          "name": "firebase_remoteconfig_get",
+          "summary": "Read one Firebase project's Remote Config template and expose its ETag."
+        }
+      ]
+    }
+  ],
+  "steps": [
+    {
+      "name": "firebase_login",
+      "group": "Authentication",
+      "module": "titan_plugin_firebase.steps.login_step",
+      "function": "execute_firebase_login_step",
+      "summary": "Validate that the current user has a Firebase ADC session.",
+      "docstring_sections": {
+        "Requires": [
+          "    ctx.firebase: An initialized FirebaseClient."
+        ],
+        "Inputs (from ctx.data)": [
+          "    fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.",
+          "    firebase_login_command (str): Command the user can run to create an ADC session."
+        ],
+        "Returns": [
+          "    Success: If gcloud ADC is available.",
+          "    Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.",
+          "    Skip: If ADC auth is missing and fail_on_missing_auth is False."
+        ]
+      },
+      "used_by_workflows": []
+    },
+    {
+      "name": "firebase_remoteconfig_get",
+      "group": "Remote Config",
+      "module": "titan_plugin_firebase.steps.remoteconfig_get_step",
+      "function": "execute_firebase_remoteconfig_get_step",
+      "summary": "Read a Firebase Remote Config template for one project.",
+      "docstring_sections": {
+        "Requires": [
+          "    ctx.firebase: An initialized FirebaseClient."
+        ],
+        "Inputs (from ctx.data)": [
+          "    project_id (str, optional): Firebase project ID to read.",
+          "    firebase_project_id (str, optional): Alternate project ID key from a previous step."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    firebase_project_id (str): Firebase project ID used for the request.",
+          "    firebase_remoteconfig_template (dict): Remote Config template JSON payload.",
+          "    firebase_remoteconfig_etag (Optional[str]): ETag returned by Firebase for later publishing.",
+          "    firebase_remoteconfig_version (Optional[dict]): Remote Config template version payload."
+        ],
+        "Returns": [
+          "    Success: If the Remote Config template is read successfully.",
+          "    Error: If Firebase is unavailable, no project ID is provided, or the API request fails."
+        ]
+      },
+      "used_by_workflows": []
+    },
+    {
+      "name": "firebase_status",
+      "group": "Authentication",
+      "module": "titan_plugin_firebase.steps.login_step",
+      "function": "execute_firebase_status_step",
+      "summary": "Report the current Firebase ADC authentication status.",
+      "docstring_sections": {
+        "Requires": [
+          "    ctx.firebase: An initialized FirebaseClient."
+        ],
+        "Inputs (from ctx.data)": [
+          "    fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True."
+        ],
+        "Outputs (saved to ctx.data)": [
+          "    firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.",
+          "    firebase_login_command (str): Command the user can run to create an ADC session."
+        ],
+        "Returns": [
+          "    Success: If gcloud ADC is available.",
+          "    Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.",
+          "    Skip: If ADC auth is missing and fail_on_missing_auth is False."
+        ]
+      },
+      "used_by_workflows": []
+    }
+  ]
+}

--- a/docs/plugins/_meta/firebase-step-groups.json
+++ b/docs/plugins/_meta/firebase-step-groups.json
@@ -1,0 +1,27 @@
+{
+  "plugin": "firebase",
+  "groups": [
+    {
+      "name": "Authentication",
+      "steps": [
+        {
+          "name": "firebase_login",
+          "summary": "Validate the current user's Google Cloud ADC session for Firebase workflows."
+        },
+        {
+          "name": "firebase_status",
+          "summary": "Report the current Firebase ADC authentication status."
+        }
+      ]
+    },
+    {
+      "name": "Remote Config",
+      "steps": [
+        {
+          "name": "firebase_remoteconfig_get",
+          "summary": "Read one Firebase project's Remote Config template and expose its ETag."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/plugins/_meta/firebase-step-groups.json
+++ b/docs/plugins/_meta/firebase-step-groups.json
@@ -6,11 +6,11 @@
       "steps": [
         {
           "name": "firebase_login",
-          "summary": "Validate the current user's Google Cloud ADC session for Firebase workflows."
+          "summary": "Validate Firebase OAuth auth from Titan OAuth store, env var, or Google Cloud ADC."
         },
         {
           "name": "firebase_status",
-          "summary": "Report the current Firebase ADC authentication status."
+          "summary": "Report the current Firebase OAuth authentication status."
         }
       ]
     },
@@ -20,6 +20,10 @@
         {
           "name": "firebase_remoteconfig_get",
           "summary": "Read one Firebase project's Remote Config template and expose its ETag."
+        },
+        {
+          "name": "firebase_remoteconfig_inventory",
+          "summary": "Build a key inventory across configured Firebase brand projects."
         }
       ]
     }

--- a/docs/plugins/firebase/built-in-workflows.md
+++ b/docs/plugins/firebase/built-in-workflows.md
@@ -1,7 +1,26 @@
 # Firebase Built-In Workflows
 
-PR1 does not ship a built-in Firebase workflow.
+## `list-remoteconfig-keys`
 
-The plugin exposes authentication and single-project Remote Config read steps so
-project workflows can call them directly. The planned PR2 workflow will add the
-multibrand Remote Config flow after the Firebase plugin branch is merged.
+Reads Remote Config templates across configured Firebase brand/environment
+projects and stores a normalized key inventory in workflow context.
+
+```yaml
+name: "List Firebase Remote Config Keys"
+steps:
+  - plugin: firebase
+    step: firebase_login
+
+  - plugin: firebase
+    step: firebase_remoteconfig_inventory
+```
+
+Configure targets with `plugins.firebase.config.projects` or
+`plugins.firebase.config.brand_projects`. The workflow is read-only and keeps
+reading later projects by default when one project returns an error.
+
+If `plugins.firebase.config.oauth_client_id` is configured and no Firebase token
+is available, `firebase_login` opens Google OAuth in the browser and stores a
+refreshable credential before listing Remote Config keys. If the client ID is
+not configured yet, the workflow asks for it first and saves it in the user
+keyring.

--- a/docs/plugins/firebase/built-in-workflows.md
+++ b/docs/plugins/firebase/built-in-workflows.md
@@ -1,0 +1,7 @@
+# Firebase Built-In Workflows
+
+PR1 does not ship a built-in Firebase workflow.
+
+The plugin exposes authentication and single-project Remote Config read steps so
+project workflows can call them directly. The planned PR2 workflow will add the
+multibrand Remote Config flow after the Firebase plugin branch is merged.

--- a/docs/plugins/firebase/client-api.md
+++ b/docs/plugins/firebase/client-api.md
@@ -1,0 +1,55 @@
+# Firebase Client API
+
+The public client is `titan_plugin_firebase.client.FirebaseClient`.
+
+## Authentication
+
+### `is_available() -> bool`
+
+Returns `True` when `gcloud` is installed and an ADC access token can be
+obtained with:
+
+```bash
+gcloud auth application-default print-access-token
+```
+
+### `get_active_account() -> str | None`
+
+Returns the active account reported by `gcloud auth list`, or `None` when no
+active account can be resolved.
+
+### `get_adc_access_token() -> str | None`
+
+Returns the current ADC access token. Tokens are read from the local gcloud ADC
+session and are never persisted by Titan.
+
+### `get_login_command() -> str`
+
+Returns the exact login command shown by Firebase auth steps:
+
+```bash
+gcloud auth application-default login
+```
+
+## Remote Config
+
+### `get_remote_config(project_id: str) -> RemoteConfigTemplate`
+
+Reads:
+
+```text
+GET {api_base_url}/projects/{project_id}/remoteConfig
+```
+
+The request uses an ADC bearer token and returns a `RemoteConfigTemplate` with:
+
+- `project_id`: Firebase project ID used for the request
+- `template`: Remote Config JSON payload
+- `etag`: response `ETag` header, needed by future publish operations
+- `version`: convenience property for `template["version"]`
+
+Error handling distinguishes common Remote Config cases:
+
+- `401`: ADC token rejected or expired; run the ADC login command
+- `403`: account lacks permission on the Firebase project
+- `404`: project/template not found

--- a/docs/plugins/firebase/client-api.md
+++ b/docs/plugins/firebase/client-api.md
@@ -4,10 +4,17 @@ The public client is `titan_plugin_firebase.client.FirebaseClient`.
 
 ## Authentication
 
-### `is_available() -> bool`
+### `is_available(*, sink=None) -> bool`
 
-Returns `True` when `gcloud` is installed and an ADC access token can be
-obtained with:
+Returns `True` when an OAuth access token can be resolved from
+`FIREBASE_ACCESS_TOKEN`, Titan's OAuth token store, legacy Firebase keyring
+keys, plugin configuration, or Google Cloud ADC.
+
+The optional `sink` receives provider-neutral OAuth events. UI and headless
+callers can observe resolution/refresh/login events without coupling the OAuth
+manager to a specific presentation layer.
+
+ADC tokens are obtained with:
 
 ```bash
 gcloud auth application-default print-access-token
@@ -22,6 +29,76 @@ active account can be resolved.
 
 Returns the current ADC access token. Tokens are read from the local gcloud ADC
 session and are never persisted by Titan.
+
+### `build_oauth_request(interactive=False) -> OAuthRequest`
+
+Builds the provider-neutral request used by Titan's OAuth manager. Firebase uses
+provider `google`, connection ID `firebase:<project>`, the configured
+`oauth_scopes`, the `access_token_env_var`, and legacy secret keys for
+backwards compatibility.
+
+### `get_oauth_credential(*, sink=None, interactive=False) -> OAuthCredential | None`
+
+Returns the credential resolved by Titan's OAuth manager, if one is available.
+This method can read environment tokens, stored OAuth token-set blobs, and
+legacy Firebase keyring tokens. When `interactive=True` and `oauth_client_id` is
+configured, the Google OAuth provider opens the browser, receives the localhost
+callback, exchanges the authorization code with PKCE, and stores a refreshable
+token set.
+
+### `get_access_token(*, sink=None, interactive=False) -> str | None`
+
+Returns the token Titan will use for Firebase REST calls. It checks the
+configured `access_token_env_var` first, which defaults to
+`FIREBASE_ACCESS_TOKEN`, through the OAuth manager. It then checks plugin
+configuration and finally falls back to ADC.
+
+With provider-backed Google OAuth, the OAuth manager refreshes stored tokens
+before returning them when they are expired or inside the refresh margin. When
+refresh fails during an interactive resolution, the stale token-set blob is
+deleted and Titan runs a fresh authorization flow.
+
+### `save_access_token(token: str, scope="user") -> None`
+
+Stores a token as a single OAuth token-set blob through Titan's shared OAuth
+manager. The default `user` scope writes to the system keyring. Tokens stored
+this way are still short-lived OAuth access tokens; manually pasted tokens do
+not include `expires_at`, so refresh or replace them when Firebase rejects them
+as expired.
+
+Browser-based Google OAuth stores `access_token`, `refresh_token`, `expires_at`,
+token type, and granted scopes automatically; callers should prefer that flow
+over manual access tokens.
+
+### `save_oauth_client_id(client_id: str, client_secret=None, scope="user") -> None`
+
+Stores a Google OAuth desktop client ID and optional Desktop app client secret
+in the user keyring, then configures the current Firebase client session for
+browser login. Titan saves both generic Firebase keys and project-specific keys
+when a project name is available, so the same Google OAuth client can be reused
+across Firebase projects. If no client secret is provided, stale saved client
+secret keys are deleted so Titan does not send a mismatched OAuth pair later.
+
+### `delete_oauth_client_id(scope="user") -> bool`
+
+Deletes saved Google OAuth client IDs and client secrets for the current
+project/generic Firebase scope, clears the runtime OAuth client configuration,
+and unregisters the Google provider from the current client session.
+
+### `configure_google_oauth(client_id: str, client_secret=None) -> None`
+
+Configures browser-based Google OAuth for the current client session without
+persisting the client ID or secret. This registers the Google provider used by
+the shared OAuth manager for login and refresh. If the client ID changes and no
+new client secret is provided, the previous runtime client secret is cleared.
+
+### `invalidate_access_token_source(source: str | None, scope="user") -> bool`
+
+Marks a rejected token source as unusable for the current client session.
+Legacy keyring tokens are deleted from the selected secret scope; OAuth
+token-store credentials are deleted from Titan's OAuth store. Environment,
+plugin config, and ADC sources are ignored for the remainder of the current
+client session.
 
 ### `get_login_command() -> str`
 
@@ -41,7 +118,8 @@ Reads:
 GET {api_base_url}/projects/{project_id}/remoteConfig
 ```
 
-The request uses an ADC bearer token and returns a `RemoteConfigTemplate` with:
+The request uses an OAuth bearer token and sends `x-goog-user-project` with the
+same project ID as quota project. It returns a `RemoteConfigTemplate` with:
 
 - `project_id`: Firebase project ID used for the request
 - `template`: Remote Config JSON payload
@@ -50,6 +128,26 @@ The request uses an ADC bearer token and returns a `RemoteConfigTemplate` with:
 
 Error handling distinguishes common Remote Config cases:
 
-- `401`: ADC token rejected or expired; run the ADC login command
+- `401`: OAuth token rejected or expired. The error keeps the resolved
+  `auth_source`, so workflow steps can invalidate that source, prompt for
+  fresh auth, and retry once.
 - `403`: account lacks permission on the Firebase project
 - `404`: project/template not found
+
+### `get_remote_config_inventory(targets, continue_on_error=True) -> RemoteConfigInventory`
+
+Reads several Firebase project targets and returns:
+
+- `targets`: configured brand/environment targets
+- `projects`: one normalized project inventory per successful template read
+- `keys`: unique key inventory across projects, including observed value types
+  and missing projects
+- `failures`: per-project read failures when `continue_on_error` is `True`
+
+Remote Config values are normalized into the supported value types:
+
+- `BOOLEAN`
+- `JSON`
+- `NUMBER`
+- `STRING`
+- `UNKNOWN`

--- a/docs/plugins/firebase/overview.md
+++ b/docs/plugins/firebase/overview.md
@@ -1,20 +1,40 @@
 # Firebase Plugin
 
-The Firebase plugin provides ADC-backed access to Firebase Remote Config from
-Titan workflows.
+The Firebase plugin provides read-only Firebase Remote Config access from Titan
+workflows.
 
-PR1 is intentionally read-only and single-project: it validates a personal
-Google Cloud Application Default Credentials session and reads a Remote Config
-template for an explicit Firebase project ID.
+It validates Firebase authentication, reads Remote Config templates, and can
+build a normalized key inventory across several brand/environment projects.
 
 ## Requirements
 
-- `gcloud` installed in `PATH`
-- A personal ADC login:
+Use one of these authentication sources:
+
+1. Browser-based Google OAuth through Titan, using a configured Google OAuth
+   desktop client ID. This stores an access token, refresh token, expiry, and
+   scopes in Titan's OAuth token store.
+2. A short-lived OAuth access token in `FIREBASE_ACCESS_TOKEN`.
+3. A short-lived OAuth access token saved manually. The `firebase_login` prompt
+   stores manual tokens in Titan's OAuth token store as a temporary fallback.
+   Legacy keys `firebase_access_token` and `<project>_firebase_access_token`
+   may still exist from older versions; those keys are still read by the OAuth
+   manager.
+4. A personal Google Cloud Application Default Credentials login:
 
 ```bash
 gcloud auth application-default login
 ```
+
+One token can read several Firebase projects when the authenticated identity has
+Remote Config permissions on each project.
+
+Titan resolves Firebase credentials through the shared OAuth manager. That layer
+is asynchronous-ready, emits provider-neutral events, stores one token-set blob
+per credential, and uses credential-scoped locks before refresh/login
+operations. Browser-based Google OAuth tokens include `expires_at` and a
+`refresh_token`, so Titan refreshes them before requests when they are near
+expiry. Manually pasted access tokens do not include expiry metadata, so replace
+them when Firebase rejects them as expired.
 
 The plugin does not use service account files, shared keys, `firebase-admin`, or
 the Firebase CLI.
@@ -29,16 +49,84 @@ enabled = true
 
 [plugins.firebase.config]
 default_project = "my-firebase-project"
+default_environment = "prod"
 api_base_url = "https://firebaseremoteconfig.googleapis.com/v1"
 request_timeout = 30
+oauth_client_id = "your-google-oauth-desktop-client-id"
+# Prefer storing oauth_client_secret in Titan keyring through the wizard.
+oauth_redirect_port = 0
+oauth_timeout = 180
+oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 ```
+
+`oauth_client_id` should be a Google OAuth client configured with application
+type `Desktop app`. This client ID identifies Titan CLI as the installed tool
+running the login flow; it is not the Firebase iOS, Android, or web app client.
+Titan uses Authorization Code with PKCE and can store the Desktop app
+`oauth_client_secret` in Titan's keyring when Google requires it during token
+exchange. `oauth_redirect_port = 0` lets Titan choose a free `127.0.0.1`
+loopback port for the callback.
+
+Titan resolves OAuth client credentials as an atomic pair: project-specific
+keyring values, explicit plugin config values, then generic Firebase keyring
+values. When the generic wizard stores the client ID in config and the client
+secret in the project keyring, Titan treats those as one configured pair. It
+does not combine a project-specific saved client ID with a different config
+secret, because Google's token endpoint rejects mismatched Desktop app
+credentials.
+
+The browser OAuth default uses `https://www.googleapis.com/auth/cloud-platform`
+because Google accepts it in the user consent flow and the Firebase Remote
+Config REST API lists it as an accepted authorization scope. The narrower
+`https://www.googleapis.com/auth/firebase.remoteconfig` scope is still valid for
+Remote Config API calls, but Google may reject it during interactive user
+consent with `invalid_scope`.
+
+Do not store `access_token` manually in `.titan/config.toml`. Prefer configuring
+`oauth_client_id` and running `firebase_login` so Titan opens Google login and
+stores a refreshable credential. Use manual access tokens only as a temporary
+fallback, or set `FIREBASE_ACCESS_TOKEN` only for the current shell session.
+
+When `firebase_login` runs interactively and no token is available, it opens the
+browser for Google login if `oauth_client_id` is configured. If browser OAuth is
+not configured yet, it asks for the Google OAuth Desktop app client ID and
+client secret, saves them in the user keyring, opens Google login, and stores a
+refreshable credential. If a saved refresh token fails, Titan deletes that stale
+token and reauthorizes interactively instead of keeping the workflow stuck on
+the old credential. Manual access tokens are only the final fallback.
 
 `default_project` is optional. If it is not configured, workflows must pass a
 `project_id` parameter to `firebase_remoteconfig_get`.
 
-`brand_projects` exists in the schema as a placeholder for PR2. Multibrand
-project resolution should reuse the existing Crashlytics brand mapping rather
-than duplicate project IDs in this plugin config.
+For multibrand inventories, prefer explicit project targets:
+
+```toml
+[[plugins.firebase.config.projects]]
+brand = "yoigo"
+environment = "prod"
+project_id = "yoigo-prod-project"
+
+[[plugins.firebase.config.projects]]
+brand = "masmovil"
+environment = "prod"
+project_id = "masmovil-prod-project"
+```
+
+The compact `brand_projects` mapping is also supported. By default it is read as
+`environment -> brand -> project_id`:
+
+```toml
+[plugins.firebase.config.brand_projects.prod]
+yoigo = "yoigo-prod-project"
+masmovil = "masmovil-prod-project"
+```
+
+If your source data is `brand -> environment -> project_id`, set:
+
+```toml
+[plugins.firebase.config]
+brand_projects_layout = "brand_environment"
+```
 
 ## Entry Point
 

--- a/docs/plugins/firebase/overview.md
+++ b/docs/plugins/firebase/overview.md
@@ -1,0 +1,48 @@
+# Firebase Plugin
+
+The Firebase plugin provides ADC-backed access to Firebase Remote Config from
+Titan workflows.
+
+PR1 is intentionally read-only and single-project: it validates a personal
+Google Cloud Application Default Credentials session and reads a Remote Config
+template for an explicit Firebase project ID.
+
+## Requirements
+
+- `gcloud` installed in `PATH`
+- A personal ADC login:
+
+```bash
+gcloud auth application-default login
+```
+
+The plugin does not use service account files, shared keys, `firebase-admin`, or
+the Firebase CLI.
+
+## Configuration
+
+Enable the plugin in `.titan/config.toml`:
+
+```toml
+[plugins.firebase]
+enabled = true
+
+[plugins.firebase.config]
+default_project = "my-firebase-project"
+api_base_url = "https://firebaseremoteconfig.googleapis.com/v1"
+request_timeout = 30
+```
+
+`default_project` is optional. If it is not configured, workflows must pass a
+`project_id` parameter to `firebase_remoteconfig_get`.
+
+`brand_projects` exists in the schema as a placeholder for PR2. Multibrand
+project resolution should reuse the existing Crashlytics brand mapping rather
+than duplicate project IDs in this plugin config.
+
+## Entry Point
+
+```toml
+[tool.poetry.plugins."titan.plugins"]
+firebase = "titan_plugin_firebase.plugin:FirebasePlugin"
+```

--- a/docs/plugins/firebase/workflow-steps.md
+++ b/docs/plugins/firebase/workflow-steps.md
@@ -179,7 +179,7 @@ How to read these contracts:
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
     | `Success` | `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version` | If the Remote Config template is read successfully. |
-    | `Error` | - | If Firebase is unavailable, no project ID is provided, or the API request fails. |
+    | `Error` | - | If Firebase is unavailable, no project ID is provided, the API request fails, or the template payload is malformed. |
 
 
 ??? info "`firebase_remoteconfig_inventory`"

--- a/docs/plugins/firebase/workflow-steps.md
+++ b/docs/plugins/firebase/workflow-steps.md
@@ -1,0 +1,157 @@
+# Firebase Workflow Steps
+
+Firebase exposes authentication and read-only Remote Config steps through
+`FirebasePlugin.get_steps()`.
+
+For full contract details for every public step, including documented inputs,
+outputs, and return behavior, see the [detailed step reference](../generated/firebase-step-reference.md).
+
+## Authentication
+
+- `firebase_login`: validate that the current user has a Google Cloud ADC
+  session and show the ADC login command when it is missing.
+- `firebase_status`: report the current Firebase ADC authentication status.
+
+## Remote Config
+
+- `firebase_remoteconfig_get`: read one project's Remote Config template,
+  storing the template JSON, version payload, and ETag for later steps.
+
+<!-- BEGIN GENERATED STEP CONTRACTS -->
+## Detailed Step Contracts
+
+The summaries above show what each firebase step is for. The sections below show the documented contract for each public step: what it expects from `ctx.data`, what it saves back, and what result types it may return.
+
+Expand a step to see its workflow usage, required context, inputs, outputs, and result behavior.
+
+How to read these contracts:
+
+- `Inputs (from ctx.data)` = values the step expects before it runs.
+- `Outputs (saved to ctx.data)` = metadata keys saved for later steps when the step returns `Success` or `Skip`.
+- `Returns` = the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate payload.
+
+### Authentication
+
+??? info "`firebase_login`"
+    Validate that the current user has a Firebase ADC session.
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: firebase
+      step: firebase_login
+    ```
+
+    **Available to later steps:** `firebase_account`, `firebase_login_command`
+
+    **Requires**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `ctx.firebase` | - | An initialized FirebaseClient. |
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+    | `firebase_login_command` | str | Command the user can run to create an ADC session. |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
+    | `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
+    | `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+
+
+??? info "`firebase_status`"
+    Report the current Firebase ADC authentication status.
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: firebase
+      step: firebase_status
+    ```
+
+    **Available to later steps:** `firebase_account`, `firebase_login_command`
+
+    **Requires**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `ctx.firebase` | - | An initialized FirebaseClient. |
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+    | `firebase_login_command` | str | Command the user can run to create an ADC session. |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
+    | `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
+    | `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+
+
+### Remote Config
+
+??? info "`firebase_remoteconfig_get`"
+    Read a Firebase Remote Config template for one project.
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: firebase
+      step: firebase_remoteconfig_get
+    ```
+
+    **Available to later steps:** `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version`
+
+    **Requires**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `ctx.firebase` | - | An initialized FirebaseClient. |
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `project_id` | str, optional | Firebase project ID to read. |
+    | `firebase_project_id` | str, optional | Alternate project ID key from a previous step. |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `firebase_project_id` | str | Firebase project ID used for the request. |
+    | `firebase_remoteconfig_template` | dict | Remote Config template JSON payload. |
+    | `firebase_remoteconfig_etag` | Optional[str] | ETag returned by Firebase for later publishing. |
+    | `firebase_remoteconfig_version` | Optional[dict] | Remote Config template version payload. |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version` | If the Remote Config template is read successfully. |
+    | `Error` | - | If Firebase is unavailable, no project ID is provided, or the API request fails. |
+<!-- END GENERATED STEP CONTRACTS -->

--- a/docs/plugins/firebase/workflow-steps.md
+++ b/docs/plugins/firebase/workflow-steps.md
@@ -60,7 +60,7 @@ How to read these contracts:
 
     **Used by built-in workflows:** `list-remoteconfig-keys`
 
-    **Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
+    **Available to later steps:** `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
     **Requires**
 
@@ -79,7 +79,8 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+    | `firebase_account` | Optional[str] | Reserved until Firebase token identity can be resolved; currently None. |
+    | `firebase_auth_source` | Optional[str] | Safe source label for the token Titan will use. |
     | `firebase_login_command` | str | Command the user can run to create an ADC session. |
     | `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
     | `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
@@ -88,9 +89,9 @@ How to read these contracts:
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+    | `Success` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
     | `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
-    | `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
+    | `Skip` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 
 ??? info "`firebase_status`"
@@ -103,7 +104,7 @@ How to read these contracts:
       step: firebase_status
     ```
 
-    **Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
+    **Available to later steps:** `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
     **Requires**
 
@@ -122,7 +123,8 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+    | `firebase_account` | Optional[str] | Reserved until Firebase token identity can be resolved; currently None. |
+    | `firebase_auth_source` | Optional[str] | Safe source label for the token Titan will use. |
     | `firebase_login_command` | str | Command the user can run to create an ADC session. |
     | `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
     | `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
@@ -131,9 +133,9 @@ How to read these contracts:
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+    | `Success` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
     | `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
-    | `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
+    | `Skip` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 
 ### Remote Config

--- a/docs/plugins/firebase/workflow-steps.md
+++ b/docs/plugins/firebase/workflow-steps.md
@@ -8,14 +8,30 @@ outputs, and return behavior, see the [detailed step reference](../generated/fir
 
 ## Authentication
 
-- `firebase_login`: validate that the current user has a Google Cloud ADC
-  session and show the ADC login command when it is missing.
-- `firebase_status`: report the current Firebase ADC authentication status.
+- `firebase_login`: validate that Firebase OAuth authentication is available
+  through Titan's OAuth token store, legacy keyring/plugin configuration,
+  `FIREBASE_ACCESS_TOKEN`, or ADC. When auth is missing, it opens Google OAuth
+  if `oauth_client_id` is configured. If browser OAuth is not configured yet,
+  it asks for the Google OAuth Desktop app client ID and client secret, then
+  saves them in the user keyring. Manual access tokens are only the final
+  fallback.
+- `firebase_status`: report the current Firebase authentication status.
 
 ## Remote Config
 
 - `firebase_remoteconfig_get`: read one project's Remote Config template,
   storing the template JSON, version payload, and ETag for later steps.
+- `firebase_remoteconfig_inventory`: read configured brand/environment projects
+  and store a normalized inventory of all Remote Config keys.
+
+If Firebase rejects the resolved OAuth credential with `401`, Remote Config
+steps invalidate that token source, request fresh auth through the same
+provider-neutral login flow, and retry once.
+
+If Google accepts the browser callback but rejects token exchange with
+`client_secret is missing` or `client secret is invalid`, `firebase_login` asks
+for the Client ID and Client Secret from the same Google OAuth Desktop app
+client and retries authorization.
 
 <!-- BEGIN GENERATED STEP CONTRACTS -->
 ## Detailed Step Contracts
@@ -33,7 +49,7 @@ How to read these contracts:
 ### Authentication
 
 ??? info "`firebase_login`"
-    Validate that the current user has a Firebase ADC session.
+    Validate that the current user has Firebase OAuth authentication.
 
     **Workflow usage**
 
@@ -42,7 +58,9 @@ How to read these contracts:
       step: firebase_login
     ```
 
-    **Available to later steps:** `firebase_account`, `firebase_login_command`
+    **Used by built-in workflows:** `list-remoteconfig-keys`
+
+    **Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
     **Requires**
 
@@ -54,7 +72,8 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+    | `fail_on_missing_auth` | bool, optional | Return Error when auth is missing. Defaults to True. |
+    | `prompt_for_missing_auth` | bool, optional | Prompt for Google OAuth setup/login when auth is missing. Defaults to True. |
 
     **Outputs (saved to ctx.data)**
 
@@ -62,18 +81,20 @@ How to read these contracts:
     |------|------|-------------|
     | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
     | `firebase_login_command` | str | Command the user can run to create an ADC session. |
+    | `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
+    | `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
 
     **Returns**
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
-    | `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
-    | `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+    | `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+    | `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
+    | `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 
 ??? info "`firebase_status`"
-    Report the current Firebase ADC authentication status.
+    Report the current Firebase OAuth authentication status.
 
     **Workflow usage**
 
@@ -82,7 +103,7 @@ How to read these contracts:
       step: firebase_status
     ```
 
-    **Available to later steps:** `firebase_account`, `firebase_login_command`
+    **Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
     **Requires**
 
@@ -94,7 +115,8 @@ How to read these contracts:
 
     | Name | Type | Description |
     |------|------|-------------|
-    | `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+    | `fail_on_missing_auth` | bool, optional | Return Error when auth is missing. Defaults to True. |
+    | `prompt_for_missing_auth` | bool, optional | Prompt for Google OAuth setup/login when auth is missing. Defaults to False. |
 
     **Outputs (saved to ctx.data)**
 
@@ -102,14 +124,16 @@ How to read these contracts:
     |------|------|-------------|
     | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
     | `firebase_login_command` | str | Command the user can run to create an ADC session. |
+    | `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
+    | `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
 
     **Returns**
 
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
-    | `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
-    | `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
-    | `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+    | `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+    | `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
+    | `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 
 ### Remote Config
@@ -154,4 +178,57 @@ How to read these contracts:
     |--------|-----------------------|-------------|
     | `Success` | `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version` | If the Remote Config template is read successfully. |
     | `Error` | - | If Firebase is unavailable, no project ID is provided, or the API request fails. |
+
+
+??? info "`firebase_remoteconfig_inventory`"
+    Build a key inventory across configured Firebase Remote Config projects.
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: firebase
+      step: firebase_remoteconfig_inventory
+    ```
+
+    **Used by built-in workflows:** `list-remoteconfig-keys`
+
+    **Available to later steps:** `firebase_remoteconfig_inventory`, `firebase_remoteconfig_keys`, `firebase_remoteconfig_targets`, `firebase_remoteconfig_project_count`, `firebase_remoteconfig_key_count`, `firebase_remoteconfig_failures`
+
+    **Requires**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `ctx.firebase` | - | An initialized FirebaseClient. |
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `project_targets` | list[dict], optional | Explicit Firebase project targets. |
+    | `firebase_project_targets` | list[dict], optional | Alternate explicit target key. |
+    | `projects` | list[dict|str], optional | Firebase project targets or project IDs. |
+    | `brand_projects` | dict, optional | Brand/environment project mapping override. |
+    | `brand` | str, optional | Single brand filter. |
+    | `brands` | list[str]|str, optional | Brand filter list or comma-separated string. |
+    | `environment` | str, optional | Single environment filter. |
+    | `environments` | list[str]|str, optional | Environment filter list or comma-separated string. |
+    | `continue_on_error` | bool, optional | Continue when one project read fails. Defaults to True. |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `firebase_remoteconfig_inventory` | dict | Aggregated inventory payload. |
+    | `firebase_remoteconfig_keys` | list[dict] | Unique key inventory rows. |
+    | `firebase_remoteconfig_targets` | list[dict] | Project targets that were requested. |
+    | `firebase_remoteconfig_project_count` | int | Number of projects read successfully. |
+    | `firebase_remoteconfig_key_count` | int | Number of unique keys found. |
+    | `firebase_remoteconfig_failures` | list[dict] | Project read failures, when any. |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `firebase_remoteconfig_inventory`, `firebase_remoteconfig_keys`, `firebase_remoteconfig_targets`, `firebase_remoteconfig_project_count`, `firebase_remoteconfig_key_count`, `firebase_remoteconfig_failures` | If at least one project is read and key inventory is built. |
+    | `Error` | - | If Firebase is unavailable, no targets are configured, or all project reads fail. |
 <!-- END GENERATED STEP CONTRACTS -->

--- a/docs/plugins/generated/firebase-step-reference.md
+++ b/docs/plugins/generated/firebase-step-reference.md
@@ -23,7 +23,7 @@ Validate that the current user has Firebase OAuth authentication.
 
 **Used by built-in workflows:** `list-remoteconfig-keys`
 
-**Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
+**Available to later steps:** `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
 **Requires**
 
@@ -42,7 +42,8 @@ Validate that the current user has Firebase OAuth authentication.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+| `firebase_account` | Optional[str] | Reserved until Firebase token identity can be resolved; currently None. |
+| `firebase_auth_source` | Optional[str] | Safe source label for the token Titan will use. |
 | `firebase_login_command` | str | Command the user can run to create an ADC session. |
 | `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
 | `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
@@ -51,9 +52,9 @@ Validate that the current user has Firebase OAuth authentication.
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+| `Success` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
 | `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
-| `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
+| `Skip` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 ### `firebase_status`
 
@@ -72,7 +73,7 @@ Report the current Firebase OAuth authentication status.
   step: firebase_status
 ```
 
-**Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
+**Available to later steps:** `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
 **Requires**
 
@@ -91,7 +92,8 @@ Report the current Firebase OAuth authentication status.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+| `firebase_account` | Optional[str] | Reserved until Firebase token identity can be resolved; currently None. |
+| `firebase_auth_source` | Optional[str] | Safe source label for the token Titan will use. |
 | `firebase_login_command` | str | Command the user can run to create an ADC session. |
 | `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
 | `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
@@ -100,9 +102,9 @@ Report the current Firebase OAuth authentication status.
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+| `Success` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
 | `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
-| `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
+| `Skip` | `firebase_account`, `firebase_auth_source`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 ## Remote Config
 

--- a/docs/plugins/generated/firebase-step-reference.md
+++ b/docs/plugins/generated/firebase-step-reference.md
@@ -154,7 +154,7 @@ Read a Firebase Remote Config template for one project.
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
 | `Success` | `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version` | If the Remote Config template is read successfully. |
-| `Error` | - | If Firebase is unavailable, no project ID is provided, or the API request fails. |
+| `Error` | - | If Firebase is unavailable, no project ID is provided, the API request fails, or the template payload is malformed. |
 
 ### `firebase_remoteconfig_inventory`
 

--- a/docs/plugins/generated/firebase-step-reference.md
+++ b/docs/plugins/generated/firebase-step-reference.md
@@ -1,0 +1,147 @@
+# Firebase Step Reference
+
+This page is generated from the public step inventory and shows the documented workflow contract for each public step.
+
+## Authentication
+
+### `firebase_login`
+
+Validate that the current user has a Firebase ADC session.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: firebase
+  step: firebase_login
+```
+
+**Available to later steps:** `firebase_account`, `firebase_login_command`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.firebase` | - | An initialized FirebaseClient. |
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+| `firebase_login_command` | str | Command the user can run to create an ADC session. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
+| `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
+| `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+
+### `firebase_status`
+
+Report the current Firebase ADC authentication status.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: firebase
+  step: firebase_status
+```
+
+**Available to later steps:** `firebase_account`, `firebase_login_command`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.firebase` | - | An initialized FirebaseClient. |
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
+| `firebase_login_command` | str | Command the user can run to create an ADC session. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
+| `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
+| `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+
+## Remote Config
+
+### `firebase_remoteconfig_get`
+
+Read a Firebase Remote Config template for one project.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: firebase
+  step: firebase_remoteconfig_get
+```
+
+**Available to later steps:** `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.firebase` | - | An initialized FirebaseClient. |
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `project_id` | str, optional | Firebase project ID to read. |
+| `firebase_project_id` | str, optional | Alternate project ID key from a previous step. |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `firebase_project_id` | str | Firebase project ID used for the request. |
+| `firebase_remoteconfig_template` | dict | Remote Config template JSON payload. |
+| `firebase_remoteconfig_etag` | Optional[str] | ETag returned by Firebase for later publishing. |
+| `firebase_remoteconfig_version` | Optional[dict] | Remote Config template version payload. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version` | If the Remote Config template is read successfully. |
+| `Error` | - | If Firebase is unavailable, no project ID is provided, or the API request fails. |

--- a/docs/plugins/generated/firebase-step-reference.md
+++ b/docs/plugins/generated/firebase-step-reference.md
@@ -6,7 +6,7 @@ This page is generated from the public step inventory and shows the documented w
 
 ### `firebase_login`
 
-Validate that the current user has a Firebase ADC session.
+Validate that the current user has Firebase OAuth authentication.
 
 **How to read this contract**
 
@@ -21,7 +21,9 @@ Validate that the current user has a Firebase ADC session.
   step: firebase_login
 ```
 
-**Available to later steps:** `firebase_account`, `firebase_login_command`
+**Used by built-in workflows:** `list-remoteconfig-keys`
+
+**Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
 **Requires**
 
@@ -33,7 +35,8 @@ Validate that the current user has a Firebase ADC session.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+| `fail_on_missing_auth` | bool, optional | Return Error when auth is missing. Defaults to True. |
+| `prompt_for_missing_auth` | bool, optional | Prompt for Google OAuth setup/login when auth is missing. Defaults to True. |
 
 **Outputs (saved to ctx.data)**
 
@@ -41,18 +44,20 @@ Validate that the current user has a Firebase ADC session.
 |------|------|-------------|
 | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
 | `firebase_login_command` | str | Command the user can run to create an ADC session. |
+| `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
+| `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
 
 **Returns**
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
-| `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
-| `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+| `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+| `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
+| `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 ### `firebase_status`
 
-Report the current Firebase ADC authentication status.
+Report the current Firebase OAuth authentication status.
 
 **How to read this contract**
 
@@ -67,7 +72,7 @@ Report the current Firebase ADC authentication status.
   step: firebase_status
 ```
 
-**Available to later steps:** `firebase_account`, `firebase_login_command`
+**Available to later steps:** `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed`
 
 **Requires**
 
@@ -79,7 +84,8 @@ Report the current Firebase ADC authentication status.
 
 | Name | Type | Description |
 |------|------|-------------|
-| `fail_on_missing_auth` | bool, optional | Return Error when ADC is missing. Defaults to True. |
+| `fail_on_missing_auth` | bool, optional | Return Error when auth is missing. Defaults to True. |
+| `prompt_for_missing_auth` | bool, optional | Prompt for Google OAuth setup/login when auth is missing. Defaults to False. |
 
 **Outputs (saved to ctx.data)**
 
@@ -87,14 +93,16 @@ Report the current Firebase ADC authentication status.
 |------|------|-------------|
 | `firebase_account` | Optional[str] | Active gcloud account reported by `gcloud auth list`. |
 | `firebase_login_command` | str | Command the user can run to create an ADC session. |
+| `firebase_access_token_saved` | bool | Whether this step saved a token to Titan's OAuth token store. |
+| `firebase_oauth_login_completed` | bool | Whether this step completed browser OAuth login. |
 
 **Returns**
 
 | Result | Saved for later steps | Description |
 |--------|-----------------------|-------------|
-| `Success` | `firebase_account`, `firebase_login_command` | If gcloud ADC is available. |
-| `Error` | - | If Firebase client or ADC auth is missing and fail_on_missing_auth is True. |
-| `Skip` | `firebase_account`, `firebase_login_command` | If ADC auth is missing and fail_on_missing_auth is False. |
+| `Success` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If Firebase OAuth auth is available. |
+| `Error` | - | If Firebase client or auth is missing and fail_on_missing_auth is True. |
+| `Skip` | `firebase_account`, `firebase_login_command`, `firebase_access_token_saved`, `firebase_oauth_login_completed` | If auth is missing and fail_on_missing_auth is False. |
 
 ## Remote Config
 
@@ -145,3 +153,62 @@ Read a Firebase Remote Config template for one project.
 |--------|-----------------------|-------------|
 | `Success` | `firebase_project_id`, `firebase_remoteconfig_template`, `firebase_remoteconfig_etag`, `firebase_remoteconfig_version` | If the Remote Config template is read successfully. |
 | `Error` | - | If Firebase is unavailable, no project ID is provided, or the API request fails. |
+
+### `firebase_remoteconfig_inventory`
+
+Build a key inventory across configured Firebase Remote Config projects.
+
+**How to read this contract**
+
+- `Inputs (from ctx.data)` shows what the step expects before it runs.
+- `Outputs (saved to ctx.data)` shows the metadata keys later steps can read after `Success` or `Skip`.
+- `Returns` describes the workflow result type (`Success`, `Skip`, `Error`, `Exit`), not a separate function return payload.
+
+**Workflow usage**
+
+```yaml
+- plugin: firebase
+  step: firebase_remoteconfig_inventory
+```
+
+**Used by built-in workflows:** `list-remoteconfig-keys`
+
+**Available to later steps:** `firebase_remoteconfig_inventory`, `firebase_remoteconfig_keys`, `firebase_remoteconfig_targets`, `firebase_remoteconfig_project_count`, `firebase_remoteconfig_key_count`, `firebase_remoteconfig_failures`
+
+**Requires**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `ctx.firebase` | - | An initialized FirebaseClient. |
+
+**Inputs (from ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `project_targets` | list[dict], optional | Explicit Firebase project targets. |
+| `firebase_project_targets` | list[dict], optional | Alternate explicit target key. |
+| `projects` | list[dict|str], optional | Firebase project targets or project IDs. |
+| `brand_projects` | dict, optional | Brand/environment project mapping override. |
+| `brand` | str, optional | Single brand filter. |
+| `brands` | list[str]|str, optional | Brand filter list or comma-separated string. |
+| `environment` | str, optional | Single environment filter. |
+| `environments` | list[str]|str, optional | Environment filter list or comma-separated string. |
+| `continue_on_error` | bool, optional | Continue when one project read fails. Defaults to True. |
+
+**Outputs (saved to ctx.data)**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `firebase_remoteconfig_inventory` | dict | Aggregated inventory payload. |
+| `firebase_remoteconfig_keys` | list[dict] | Unique key inventory rows. |
+| `firebase_remoteconfig_targets` | list[dict] | Project targets that were requested. |
+| `firebase_remoteconfig_project_count` | int | Number of projects read successfully. |
+| `firebase_remoteconfig_key_count` | int | Number of unique keys found. |
+| `firebase_remoteconfig_failures` | list[dict] | Project read failures, when any. |
+
+**Returns**
+
+| Result | Saved for later steps | Description |
+|--------|-----------------------|-------------|
+| `Success` | `firebase_remoteconfig_inventory`, `firebase_remoteconfig_keys`, `firebase_remoteconfig_targets`, `firebase_remoteconfig_project_count`, `firebase_remoteconfig_key_count`, `firebase_remoteconfig_failures` | If at least one project is read and key inventory is built. |
+| `Error` | - | If Firebase is unavailable, no targets are configured, or all project reads fail. |

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -11,13 +11,14 @@ plugin clients directly and compose workflows from reusable public steps.
 
 ## Official plugins
 
-Titan ships with four official plugins:
+Titan ships with five official plugins:
 
 | Plugin | Description |
 |--------|-------------|
 | **git** | Smart commits, branch management, AI-powered commit messages |
 | **github** | Create PRs with AI descriptions, manage issues, code reviews |
 | **jira** | Search issues, AI-powered analysis, workflow automation |
+| **firebase** | ADC-backed Firebase Remote Config access |
 | **slack** | Personal Slack auth, workspace summaries, and reusable Slack workflow steps |
 
 Enable them per project in `.titan/config.toml`:
@@ -30,6 +31,9 @@ enabled = true
 enabled = true
 
 [plugins.jira]
+enabled = true
+
+[plugins.firebase]
 enabled = true
 
 [plugins.slack]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,11 @@ nav:
       - Client API: plugins/jira/client-api.md
       - Workflow Steps: plugins/jira/workflow-steps.md
       - Built-in Workflows: plugins/jira/built-in-workflows.md
+    - Firebase:
+      - Overview: plugins/firebase/overview.md
+      - Client API: plugins/firebase/client-api.md
+      - Workflow Steps: plugins/firebase/workflow-steps.md
+      - Built-in Workflows: plugins/firebase/built-in-workflows.md
     - Slack:
       - Overview: plugins/slack/overview.md
       - Client API: plugins/slack/client-api.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - Workflows: concepts/workflows.md
     - Workflow Steps: concepts/workflow-steps.md
     - Textual in Steps: concepts/textual-steps.md
+    - OAuth Manager: concepts/oauth-manager.md
     - AI Integration: concepts/ai-integration.md
   - Plugins:
     - Overview: plugins/index.md

--- a/plugins/titan-plugin-firebase/README.md
+++ b/plugins/titan-plugin-firebase/README.md
@@ -2,18 +2,56 @@
 
 Firebase integration for Titan CLI workflows.
 
-PR1 provides individual authentication through Google Cloud Application Default
-Credentials (ADC) and read-only Firebase Remote Config access for one explicit
-Firebase project.
+The plugin provides read-only Firebase Remote Config access for one project or
+for several brand/environment projects.
 
 ## Requirements
 
-- `gcloud` installed and available in `PATH`
-- A personal ADC session:
+Use one authentication source:
+
+- Browser-based Google OAuth through Titan with a configured Google OAuth
+  desktop client ID. Titan stores the refreshable credential in its OAuth token
+  store.
+- Short-lived OAuth access token in `FIREBASE_ACCESS_TOKEN`
+- Short-lived OAuth access token saved manually. The `firebase_login` prompt
+  saves manual tokens to the OAuth token store as a temporary fallback.
+- A personal Google Cloud ADC session:
 
 ```bash
 gcloud auth application-default login
 ```
+
+One token can read several Firebase projects when the authenticated identity has
+Remote Config permissions on each project. Manually pasted access tokens expire,
+so refresh or replace them when Firebase starts returning `401`.
+When a Remote Config request receives `401`, the workflow invalidates the
+resolved token source, asks for fresh auth, and retries the request once.
+
+Firebase credentials are resolved through Titan's shared OAuth manager.
+Provider-backed Google OAuth stores `access_token`, `refresh_token`,
+`expires_at`, and scopes, so Titan refreshes before requests if the token is near
+expiry. The manual-token bridge cannot know expiry in advance because pasted
+access tokens do not include that metadata.
+
+The plugin configuration wizard presents Google OAuth first. If a workflow runs
+without `oauth_client_id`, Titan asks for a Google OAuth client ID, saves it in
+the user keyring with the Desktop app client secret, opens Google login, and
+reuses the refreshable credential on later runs. If a saved refresh token fails,
+Titan deletes that stale token and reauthorizes interactively. Pasting an access
+token is the last fallback.
+
+Use an OAuth client with application type `Desktop app` for Titan CLI. That
+credential identifies the local tool that opens Google login and receives the
+`127.0.0.1` loopback callback; it is separate from the Firebase iOS, Android, or
+web app clients. Google may also require the Client Secret generated for that
+same Desktop app client during token exchange; Titan stores it in keyring.
+
+Titan resolves OAuth client credentials as an atomic pair: project-specific
+keyring values, explicit plugin config values, then generic Firebase keyring
+values. When the generic wizard stores the client ID in config and the client
+secret in the project keyring, Titan treats those as one configured pair. It
+does not combine a project-specific saved client ID with a different config
+secret.
 
 No service account files or shared credentials are stored by this plugin.
 
@@ -28,22 +66,42 @@ enabled = true
 [plugins.firebase.config]
 # Optional project used by firebase_remoteconfig_get when no project_id is passed.
 default_project = "my-firebase-project"
+default_environment = "prod"
 
 # Optional overrides.
 api_base_url = "https://firebaseremoteconfig.googleapis.com/v1"
 request_timeout = 30
+oauth_client_id = "your-google-oauth-desktop-client-id"
+# Prefer storing oauth_client_secret in Titan keyring through the wizard.
+oauth_redirect_port = 0
+oauth_timeout = 180
+oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+[[plugins.firebase.config.projects]]
+brand = "yoigo"
+environment = "prod"
+project_id = "yoigo-prod-project"
+
+[[plugins.firebase.config.projects]]
+brand = "masmovil"
+environment = "prod"
+project_id = "masmovil-prod-project"
 ```
 
-`brand_projects` is intentionally empty in PR1. The multibrand workflow planned
-for PR2 will reuse the existing Crashlytics brand mapping instead of duplicating
-project IDs here.
+`brand_projects` is also supported for compact project maps. By default it is
+read as `environment -> brand -> project_id`.
 
 ## Public Steps
 
-- `firebase_login`: checks that ADC is available and shows the login command
-  when it is not.
-- `firebase_status`: reports the current ADC/gcloud status.
+- `firebase_login`: checks that Firebase OAuth auth is available, opens Google
+  login when `oauth_client_id` is configured, and falls back to a manual token
+  prompt when browser OAuth is not configured.
+- `firebase_status`: reports the current Firebase auth status.
 - `firebase_remoteconfig_get`: reads the Remote Config template for one
   Firebase project and saves the template, version and ETag in `ctx.data`.
+- `firebase_remoteconfig_inventory`: reads configured brand/environment
+  projects and saves a normalized inventory of all Remote Config keys.
 
-Remote Config access uses the REST API with the ADC bearer token.
+Remote Config access uses the REST API with an OAuth bearer token. If Firebase
+rejects the selected token, Remote Config steps invalidate that source, prompt
+for fresh auth, and retry once.

--- a/plugins/titan-plugin-firebase/README.md
+++ b/plugins/titan-plugin-firebase/README.md
@@ -1,0 +1,49 @@
+# Titan Firebase Plugin
+
+Firebase integration for Titan CLI workflows.
+
+PR1 provides individual authentication through Google Cloud Application Default
+Credentials (ADC) and read-only Firebase Remote Config access for one explicit
+Firebase project.
+
+## Requirements
+
+- `gcloud` installed and available in `PATH`
+- A personal ADC session:
+
+```bash
+gcloud auth application-default login
+```
+
+No service account files or shared credentials are stored by this plugin.
+
+## Configuration
+
+Titan configuration uses the standard `[plugins.<name>]` layout:
+
+```toml
+[plugins.firebase]
+enabled = true
+
+[plugins.firebase.config]
+# Optional project used by firebase_remoteconfig_get when no project_id is passed.
+default_project = "my-firebase-project"
+
+# Optional overrides.
+api_base_url = "https://firebaseremoteconfig.googleapis.com/v1"
+request_timeout = 30
+```
+
+`brand_projects` is intentionally empty in PR1. The multibrand workflow planned
+for PR2 will reuse the existing Crashlytics brand mapping instead of duplicating
+project IDs here.
+
+## Public Steps
+
+- `firebase_login`: checks that ADC is available and shows the login command
+  when it is not.
+- `firebase_status`: reports the current ADC/gcloud status.
+- `firebase_remoteconfig_get`: reads the Remote Config template for one
+  Firebase project and saves the template, version and ETag in `ctx.data`.
+
+Remote Config access uses the REST API with the ADC bearer token.

--- a/plugins/titan-plugin-firebase/pyproject.toml
+++ b/plugins/titan-plugin-firebase/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "titan-plugin-firebase"
+version = "0.1.0"
+description = "Firebase plugin for Titan CLI"
+authors = ["MasOrange Apps Team <apps-management-stores@masorange.es>"]
+packages = [{include = "titan_plugin_firebase"}]
+
+[tool.poetry.dependencies]
+python = ">=3.10"
+titan-cli = ">=0.6.0"
+requests = ">=2.31.0,<3.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.plugins."titan.plugins"]
+firebase = "titan_plugin_firebase.plugin:FirebasePlugin"

--- a/plugins/titan-plugin-firebase/tests/__init__.py
+++ b/plugins/titan-plugin-firebase/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for titan-plugin-firebase."""

--- a/plugins/titan-plugin-firebase/tests/test_auth.py
+++ b/plugins/titan-plugin-firebase/tests/test_auth.py
@@ -1,0 +1,70 @@
+from subprocess import CompletedProcess, TimeoutExpired
+from unittest.mock import MagicMock
+
+from titan_plugin_firebase import auth
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> CompletedProcess:
+    return CompletedProcess(args=["gcloud"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_is_gcloud_installed_when_version_succeeds(monkeypatch) -> None:
+    run = MagicMock(return_value=_completed())
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    assert auth.is_gcloud_installed() is True
+    assert run.call_args.args[0] == ["gcloud", "--version"]
+
+
+def test_is_gcloud_installed_returns_false_when_missing(monkeypatch) -> None:
+    run = MagicMock(side_effect=FileNotFoundError)
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    assert auth.is_gcloud_installed() is False
+
+
+def test_get_active_account_returns_account(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auth.subprocess,
+        "run",
+        MagicMock(return_value=_completed("user@example.com\n")),
+    )
+
+    assert auth.get_active_account() == "user@example.com"
+
+
+def test_get_active_account_returns_none_on_failure(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auth.subprocess,
+        "run",
+        MagicMock(return_value=_completed("", returncode=1)),
+    )
+
+    assert auth.get_active_account() is None
+
+
+def test_get_adc_access_token_returns_token(monkeypatch) -> None:
+    run = MagicMock(return_value=_completed("ya29.token\n"))
+    monkeypatch.setattr(auth.subprocess, "run", run)
+
+    assert auth.get_adc_access_token() == "ya29.token"
+    assert run.call_args.args[0] == [
+        "gcloud",
+        "auth",
+        "application-default",
+        "print-access-token",
+    ]
+
+
+def test_get_adc_access_token_returns_none_on_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auth.subprocess,
+        "run",
+        MagicMock(side_effect=TimeoutExpired(cmd="gcloud", timeout=10)),
+    )
+
+    assert auth.get_adc_access_token() is None
+
+
+def test_adc_login_hint_returns_exact_command() -> None:
+    assert auth.adc_login_hint() == "gcloud auth application-default login"

--- a/plugins/titan-plugin-firebase/tests/test_client.py
+++ b/plugins/titan-plugin-firebase/tests/test_client.py
@@ -348,6 +348,34 @@ def test_get_remote_config_requires_adc(monkeypatch) -> None:
         client.get_remote_config("demo-project")
 
 
+@pytest.mark.parametrize(
+    "project_id",
+    [
+        "demo/project",
+        "demo-project?alt=json",
+        "demo-project#fragment",
+        "Demo-project",
+        "demo-",
+        "short",
+    ],
+)
+def test_get_remote_config_rejects_invalid_project_id(
+    monkeypatch,
+    project_id: str,
+) -> None:
+    client = _client()
+    get_adc_access_token = MagicMock(return_value="token")
+    request_get = MagicMock()
+    monkeypatch.setattr(client, "get_adc_access_token", get_adc_access_token)
+    monkeypatch.setattr("titan_plugin_firebase.client.requests.get", request_get)
+
+    with pytest.raises(FirebaseClientError, match="valid Google Cloud project ID"):
+        client.get_remote_config(project_id)
+
+    get_adc_access_token.assert_not_called()
+    request_get.assert_not_called()
+
+
 def test_get_remote_config_rejects_non_object_json(monkeypatch) -> None:
     client = _client()
     monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value="token"))

--- a/plugins/titan-plugin-firebase/tests/test_client.py
+++ b/plugins/titan-plugin-firebase/tests/test_client.py
@@ -1,0 +1,148 @@
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from titan_plugin_firebase.client import FirebaseClient
+from titan_plugin_firebase.config import FirebasePluginConfig
+from titan_plugin_firebase.exceptions import FirebaseClientError
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+    ):
+        self.status_code = status_code
+        self._payload = payload
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+def _client() -> FirebaseClient:
+    return FirebaseClient(FirebasePluginConfig())
+
+
+def test_config_defaults_and_overrides() -> None:
+    default = FirebasePluginConfig()
+    overridden = FirebasePluginConfig(
+        default_project=" demo ",
+        api_base_url="https://example.com/firebase/",
+        request_timeout=5,
+        brand_projects={"android": {"orange": "orange-app"}},
+    )
+
+    assert default.default_project is None
+    assert default.request_timeout == 30
+    assert overridden.default_project == "demo"
+    assert overridden.api_base_url == "https://example.com/firebase"
+    assert overridden.brand_projects["android"]["orange"] == "orange-app"
+
+
+def test_is_available_requires_gcloud_and_adc(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.auth.is_gcloud_installed",
+        MagicMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.auth.get_adc_access_token",
+        MagicMock(return_value="token"),
+    )
+
+    assert client.is_available() is True
+
+
+def test_is_available_returns_false_without_adc(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.auth.is_gcloud_installed",
+        MagicMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.auth.get_adc_access_token",
+        MagicMock(return_value=None),
+    )
+
+    assert client.is_available() is False
+
+
+def test_get_remote_config_success(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value="token"))
+    response = FakeResponse(
+        200,
+        payload={"parameters": {}, "version": {"versionNumber": "12"}},
+        headers={"ETag": "etag-123"},
+    )
+    get = MagicMock(return_value=response)
+    monkeypatch.setattr("titan_plugin_firebase.client.requests.get", get)
+
+    template = client.get_remote_config("demo-project")
+
+    assert template.project_id == "demo-project"
+    assert template.etag == "etag-123"
+    assert template.version == {"versionNumber": "12"}
+    get.assert_called_once_with(
+        "https://firebaseremoteconfig.googleapis.com/v1/projects/demo-project/remoteConfig",
+        headers={"Authorization": "Bearer token"},
+        timeout=30,
+    )
+
+
+def test_get_remote_config_requires_adc(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value=None))
+
+    with pytest.raises(FirebaseClientError, match="application-default login"):
+        client.get_remote_config("demo-project")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (401, "rejected or expired"),
+        (403, "permission denied"),
+        (404, "not found"),
+    ],
+)
+def test_get_remote_config_maps_common_http_errors(
+    monkeypatch,
+    status_code: int,
+    expected: str,
+) -> None:
+    client = _client()
+    monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value="token"))
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.requests.get",
+        MagicMock(
+            return_value=FakeResponse(
+                status_code,
+                payload={"error": {"message": "firebase said no"}},
+            )
+        ),
+    )
+
+    with pytest.raises(FirebaseClientError, match=expected):
+        client.get_remote_config("demo-project")
+
+
+def test_get_remote_config_wraps_request_errors(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value="token"))
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.requests.get",
+        MagicMock(side_effect=requests.Timeout("slow")),
+    )
+
+    with pytest.raises(FirebaseClientError, match="request failed"):
+        client.get_remote_config("demo-project")

--- a/plugins/titan-plugin-firebase/tests/test_client.py
+++ b/plugins/titan-plugin-firebase/tests/test_client.py
@@ -1,12 +1,22 @@
+import json
+import time
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 import requests
 
-from titan_plugin_firebase.client import FirebaseClient
+from titan_cli.core.oauth import OAuthLockManager, OAuthManager, OAuthTokenSet
+from titan_plugin_firebase.client import (
+    FirebaseClient,
+    OAUTH_CLIENT_ID_SECRET_KEY,
+    OAUTH_CLIENT_SECRET_KEY,
+)
 from titan_plugin_firebase.config import FirebasePluginConfig
-from titan_plugin_firebase.exceptions import FirebaseClientError
+from titan_plugin_firebase.exceptions import (
+    FirebaseAuthRejectedError,
+    FirebaseClientError,
+)
 
 
 class FakeResponse:
@@ -28,23 +38,58 @@ class FakeResponse:
         return self._payload
 
 
-def _client() -> FirebaseClient:
-    return FirebaseClient(FirebasePluginConfig())
+@pytest.fixture(autouse=True)
+def _clear_env_token(monkeypatch) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+
+
+def _client(
+    secrets: MagicMock | None = None,
+    project_name: str | None = None,
+    oauth_manager: OAuthManager | None = None,
+) -> FirebaseClient:
+    return FirebaseClient(
+        FirebasePluginConfig(),
+        secrets=secrets,
+        project_name=project_name,
+        oauth_manager=oauth_manager,
+    )
 
 
 def test_config_defaults_and_overrides() -> None:
     default = FirebasePluginConfig()
     overridden = FirebasePluginConfig(
         default_project=" demo ",
+        default_environment=" prod ",
         api_base_url="https://example.com/firebase/",
         request_timeout=5,
+        oauth_client_id=" google-client-id ",
+        oauth_client_secret=" google-client-secret ",
+        oauth_redirect_port=8766,
+        oauth_timeout=90,
+        projects=[{"brand": "orange", "project_id": "orange-prod"}],
         brand_projects={"android": {"orange": "orange-app"}},
     )
 
     assert default.default_project is None
+    assert default.access_token is None
     assert default.request_timeout == 30
+    assert default.access_token_env_var == "FIREBASE_ACCESS_TOKEN"
+    assert default.oauth_client_id is None
+    assert default.oauth_redirect_port == 0
+    assert default.oauth_timeout == 180
+    assert default.oauth_scopes == [
+        "https://www.googleapis.com/auth/cloud-platform"
+    ]
     assert overridden.default_project == "demo"
+    assert overridden.default_environment == "prod"
     assert overridden.api_base_url == "https://example.com/firebase"
+    assert overridden.request_timeout == 5
+    assert overridden.oauth_client_id == "google-client-id"
+    assert overridden.oauth_client_secret == "google-client-secret"
+    assert overridden.oauth_redirect_port == 8766
+    assert overridden.oauth_timeout == 90
+    assert overridden.projects[0].project_id == "orange-prod"
     assert overridden.brand_projects["android"]["orange"] == "orange-app"
 
 
@@ -76,6 +121,198 @@ def test_is_available_returns_false_without_adc(monkeypatch) -> None:
     assert client.is_available() is False
 
 
+def test_is_available_accepts_env_access_token(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setenv("FIREBASE_ACCESS_TOKEN", "env-token")
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.auth.get_adc_access_token",
+        MagicMock(return_value=None),
+    )
+
+    assert client.is_available() is True
+    assert client.get_access_token() == "env-token"
+
+
+def test_is_available_accepts_keyring_access_token(monkeypatch) -> None:
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_access_token": " saved-token ",
+    }.get(key)
+    client = _client(secrets=secrets, project_name="demo")
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.auth.get_adc_access_token",
+        MagicMock(return_value=None),
+    )
+
+    assert client.is_available() is True
+    assert client.get_access_token() == "saved-token"
+    assert (
+        client.get_access_token_source_label()
+        == "keyring:demo_firebase_access_token"
+    )
+
+
+def test_is_available_returns_false_when_refresh_fails(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = MagicMock()
+    secrets.get.return_value = None
+
+    class BrokenRefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            raise RuntimeError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token="fresh-refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    oauth_manager = OAuthManager(
+        secrets,
+        providers={"google": BrokenRefreshProvider()},
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+    client = _client(
+        secrets=secrets,
+        project_name="demo",
+        oauth_manager=oauth_manager,
+    )
+    oauth_manager.token_store.write(
+        client.build_oauth_request(),
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="revoked-refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    assert client.is_available() is False
+    assert client.get_access_token(interactive=True) == "fresh-token"
+
+
+def test_get_access_token_prefers_env_over_keyring(monkeypatch) -> None:
+    secrets = MagicMock()
+    secrets.get.return_value = "saved-token"
+    client = _client(secrets=secrets, project_name="demo")
+    monkeypatch.setenv("FIREBASE_ACCESS_TOKEN", "env-token")
+
+    assert client.get_access_token() == "env-token"
+    assert client.get_access_token_source_label() == "FIREBASE_ACCESS_TOKEN"
+
+
+def test_save_access_token_uses_oauth_token_store_blob(tmp_path) -> None:
+    secrets = MagicMock()
+    oauth_manager = OAuthManager(
+        secrets,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+    client = _client(
+        secrets=secrets,
+        project_name="demo",
+        oauth_manager=oauth_manager,
+    )
+    expected_key = client.oauth_manager.token_store.build_secret_key(
+        client.build_oauth_request()
+    )
+
+    client.save_access_token(" token-value ")
+
+    secrets.set.assert_called_once()
+    secret_key, secret_value = secrets.set.call_args.args
+    assert secret_key == expected_key
+    assert json.loads(secret_value)["access_token"] == "token-value"
+    assert secrets.set.call_args.kwargs == {"scope": "user"}
+
+
+def test_save_oauth_client_id_persists_and_configures_google_provider() -> None:
+    secrets = MagicMock()
+    client = _client(secrets=secrets, project_name="demo")
+
+    client.save_oauth_client_id(
+        " google-client-id ",
+        client_secret=" google-client-secret ",
+    )
+
+    assert client.config.oauth_client_id == "google-client-id"
+    assert client.config.oauth_client_secret == "google-client-secret"
+    assert "google" in client.oauth_manager.providers
+    assert secrets.set.call_args_list[0].args == (
+        f"demo_{OAUTH_CLIENT_ID_SECRET_KEY}",
+        "google-client-id",
+    )
+    assert secrets.set.call_args_list[1].args == (
+        OAUTH_CLIENT_ID_SECRET_KEY,
+        "google-client-id",
+    )
+    assert secrets.set.call_args_list[2].args == (
+        f"demo_{OAUTH_CLIENT_SECRET_KEY}",
+        "google-client-secret",
+    )
+    assert secrets.set.call_args_list[3].args == (
+        OAUTH_CLIENT_SECRET_KEY,
+        "google-client-secret",
+    )
+
+
+def test_configure_google_oauth_clears_stale_secret_when_client_id_changes() -> None:
+    secrets = MagicMock()
+    client = _client(secrets=secrets, project_name="demo")
+    client.config = client.config.model_copy(
+        update={
+            "oauth_client_id": "old-client-id",
+            "oauth_client_secret": "old-client-secret",
+        }
+    )
+
+    client.configure_google_oauth("new-client-id")
+
+    assert client.config.oauth_client_id == "new-client-id"
+    assert client.config.oauth_client_secret is None
+    assert client.oauth_manager.providers["google"].flow.client_secret is None
+
+
+def test_save_oauth_client_id_without_secret_deletes_stale_secret_keys() -> None:
+    secrets = MagicMock()
+    client = _client(secrets=secrets, project_name="demo")
+    client.config = client.config.model_copy(
+        update={
+            "oauth_client_id": "old-client-id",
+            "oauth_client_secret": "old-client-secret",
+        }
+    )
+
+    client.save_oauth_client_id("new-client-id")
+
+    assert client.config.oauth_client_id == "new-client-id"
+    assert client.config.oauth_client_secret is None
+    assert secrets.delete.call_args_list[0].args == (
+        f"demo_{OAUTH_CLIENT_SECRET_KEY}",
+    )
+    assert secrets.delete.call_args_list[1].args == (OAUTH_CLIENT_SECRET_KEY,)
+
+
+def test_delete_oauth_client_id_clears_keyring_and_runtime_provider() -> None:
+    secrets = MagicMock()
+    client = _client(secrets=secrets, project_name="demo")
+    client.save_oauth_client_id("google-client-id", client_secret="google-secret")
+
+    assert client.delete_oauth_client_id() is True
+
+    assert client.config.oauth_client_id is None
+    assert client.config.oauth_client_secret is None
+    assert "google" not in client.oauth_manager.providers
+    assert secrets.delete.call_args_list[0].args == (
+        f"demo_{OAUTH_CLIENT_ID_SECRET_KEY}",
+    )
+    assert secrets.delete.call_args_list[1].args == (OAUTH_CLIENT_ID_SECRET_KEY,)
+    assert secrets.delete.call_args_list[2].args == (
+        f"demo_{OAUTH_CLIENT_SECRET_KEY}",
+    )
+    assert secrets.delete.call_args_list[3].args == (OAUTH_CLIENT_SECRET_KEY,)
+    assert secrets.delete.call_args_list[0].kwargs == {"scope": "user"}
+
+
 def test_get_remote_config_success(monkeypatch) -> None:
     client = _client()
     monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value="token"))
@@ -93,8 +330,12 @@ def test_get_remote_config_success(monkeypatch) -> None:
     assert template.etag == "etag-123"
     assert template.version == {"versionNumber": "12"}
     get.assert_called_once_with(
-        "https://firebaseremoteconfig.googleapis.com/v1/projects/demo-project/remoteConfig",
-        headers={"Authorization": "Bearer token"},
+        "https://firebaseremoteconfig.googleapis.com/v1/projects/"
+        "demo-project/remoteConfig",
+        headers={
+            "Authorization": "Bearer token",
+            "x-goog-user-project": "demo-project",
+        },
         timeout=30,
     )
 
@@ -134,6 +375,49 @@ def test_get_remote_config_maps_common_http_errors(
 
     with pytest.raises(FirebaseClientError, match=expected):
         client.get_remote_config("demo-project")
+
+
+def test_get_remote_config_401_keeps_rejected_auth_source(monkeypatch) -> None:
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_access_token": " saved-token ",
+    }.get(key)
+    client = _client(secrets=secrets, project_name="demo")
+    monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value=None))
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.requests.get",
+        MagicMock(
+            return_value=FakeResponse(
+                401,
+                payload={"error": {"message": "invalid credentials"}},
+            )
+        ),
+    )
+
+    with pytest.raises(FirebaseAuthRejectedError) as raised:
+        client.get_remote_config("demo-project")
+
+    assert raised.value.auth_source == "keyring:demo_firebase_access_token"
+
+
+def test_invalidate_access_token_source_deletes_legacy_keyring_token() -> None:
+    secrets = MagicMock()
+    client = _client(secrets=secrets, project_name="demo")
+
+    assert (
+        client.invalidate_access_token_source(
+            "keyring:demo_firebase_access_token",
+        )
+        is True
+    )
+
+    secrets.delete.assert_called_once_with(
+        "demo_firebase_access_token",
+        scope="user",
+    )
+    assert "demo_firebase_access_token" not in (
+        client.build_oauth_request().legacy_secret_keys
+    )
 
 
 def test_get_remote_config_wraps_request_errors(monkeypatch) -> None:

--- a/plugins/titan-plugin-firebase/tests/test_client.py
+++ b/plugins/titan-plugin-firebase/tests/test_client.py
@@ -23,7 +23,7 @@ class FakeResponse:
     def __init__(
         self,
         status_code: int,
-        payload: dict[str, Any] | None = None,
+        payload: Any = None,
         headers: dict[str, str] | None = None,
         text: str = "",
     ):
@@ -32,7 +32,7 @@ class FakeResponse:
         self.headers = headers or {}
         self.text = text
 
-    def json(self) -> dict[str, Any]:
+    def json(self) -> Any:
         if self._payload is None:
             raise ValueError("no json")
         return self._payload
@@ -345,6 +345,18 @@ def test_get_remote_config_requires_adc(monkeypatch) -> None:
     monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value=None))
 
     with pytest.raises(FirebaseClientError, match="application-default login"):
+        client.get_remote_config("demo-project")
+
+
+def test_get_remote_config_rejects_non_object_json(monkeypatch) -> None:
+    client = _client()
+    monkeypatch.setattr(client, "get_adc_access_token", MagicMock(return_value="token"))
+    monkeypatch.setattr(
+        "titan_plugin_firebase.client.requests.get",
+        MagicMock(return_value=FakeResponse(200, payload=["not", "a", "template"])),
+    )
+
+    with pytest.raises(FirebaseClientError, match="JSON was not an object"):
         client.get_remote_config("demo-project")
 
 

--- a/plugins/titan-plugin-firebase/tests/test_models.py
+++ b/plugins/titan-plugin-firebase/tests/test_models.py
@@ -1,0 +1,45 @@
+from titan_plugin_firebase.models import (
+    RemoteConfigValueType,
+    build_parameter_inventory,
+    infer_remote_config_value_type,
+)
+
+
+def test_infer_remote_config_value_types() -> None:
+    assert infer_remote_config_value_type("true") == RemoteConfigValueType.BOOLEAN
+    assert infer_remote_config_value_type('{"enabled": true}') == RemoteConfigValueType.JSON
+    assert infer_remote_config_value_type("[1, 2]") == RemoteConfigValueType.JSON
+    assert infer_remote_config_value_type("42") == RemoteConfigValueType.NUMBER
+    assert infer_remote_config_value_type("hello") == RemoteConfigValueType.STRING
+
+
+def test_build_parameter_inventory_uses_declared_json_type() -> None:
+    parameter = build_parameter_inventory(
+        "feature_payload",
+        {
+            "description": "Feature payload",
+            "valueType": "JSON",
+            "defaultValue": {"value": '{"enabled": true}'},
+            "conditionalValues": {
+                "beta_users": {"value": '{"enabled": false}'},
+            },
+        },
+    )
+
+    assert parameter.value_type == RemoteConfigValueType.JSON
+    assert parameter.default_value.parsed_value == {"enabled": True}
+    assert parameter.conditional_values["beta_users"].parsed_value == {
+        "enabled": False
+    }
+
+
+def test_build_parameter_inventory_infers_boolean_type() -> None:
+    parameter = build_parameter_inventory(
+        "feature_enabled",
+        {"defaultValue": {"value": "false"}},
+    )
+
+    assert parameter.declared_value_type == RemoteConfigValueType.UNKNOWN
+    assert parameter.inferred_value_type == RemoteConfigValueType.BOOLEAN
+    assert parameter.value_type == RemoteConfigValueType.BOOLEAN
+    assert parameter.default_value.parsed_value is False

--- a/plugins/titan-plugin-firebase/tests/test_oauth.py
+++ b/plugins/titan-plugin-firebase/tests/test_oauth.py
@@ -1,12 +1,15 @@
+import asyncio
 from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from titan_cli.core.oauth import OAuthRequest, OAuthTokenSet
 from titan_plugin_firebase.oauth import (
     AUTHORIZE_URL,
     TOKEN_URL,
     GoogleOAuthError,
     GoogleOAuthFlow,
+    GoogleOAuthProvider,
     GoogleOAuthSession,
     _resolve_callback_response,
 )
@@ -238,6 +241,7 @@ def test_google_oauth_refresh_access_token_keeps_existing_refresh_token() -> Non
 
     assert result.access_token == "fresh"
     assert result.refresh_token is None
+    assert result.granted_scopes is None
     assert requests_module.post_calls[0][1] == {
         "client_id": "client-id",
         "grant_type": "refresh_token",
@@ -264,3 +268,69 @@ def test_google_oauth_refresh_access_token_sends_client_secret_when_configured()
     flow.refresh_access_token("refresh")
 
     assert requests_module.post_calls[0][1]["client_secret"] == "client-secret"
+
+
+def test_google_oauth_provider_refresh_preserves_scopes_when_response_omits_scope() -> None:
+    requests_module = FakeRequests(
+        FakeResponse(
+            {
+                "access_token": "fresh",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            }
+        )
+    )
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        scopes=["new-scope"],
+        requests_module=requests_module,
+    )
+    provider = GoogleOAuthProvider(flow)
+    request = OAuthRequest(
+        provider="google",
+        connection_id="firebase:demo",
+        scopes=["new-scope"],
+    )
+    token_set = OAuthTokenSet(
+        access_token="old",
+        refresh_token="refresh",
+        scopes=["old-scope"],
+    )
+
+    refreshed = asyncio.run(provider.refresh(request, token_set, sink=None))
+
+    assert refreshed.access_token == "fresh"
+    assert refreshed.refresh_token == "refresh"
+    assert refreshed.scopes == ("old-scope",)
+
+
+def test_google_oauth_provider_refresh_uses_returned_scopes_when_present() -> None:
+    requests_module = FakeRequests(
+        FakeResponse(
+            {
+                "access_token": "fresh",
+                "scope": "returned-scope",
+            }
+        )
+    )
+    provider = GoogleOAuthProvider(
+        GoogleOAuthFlow(
+            client_id="client-id",
+            scopes=["new-scope"],
+            requests_module=requests_module,
+        )
+    )
+    request = OAuthRequest(
+        provider="google",
+        connection_id="firebase:demo",
+        scopes=["new-scope"],
+    )
+    token_set = OAuthTokenSet(
+        access_token="old",
+        refresh_token="refresh",
+        scopes=["old-scope"],
+    )
+
+    refreshed = asyncio.run(provider.refresh(request, token_set, sink=None))
+
+    assert refreshed.scopes == ("returned-scope",)

--- a/plugins/titan-plugin-firebase/tests/test_oauth.py
+++ b/plugins/titan-plugin-firebase/tests/test_oauth.py
@@ -8,6 +8,7 @@ from titan_plugin_firebase.oauth import (
     GoogleOAuthError,
     GoogleOAuthFlow,
     GoogleOAuthSession,
+    _resolve_callback_response,
 )
 
 
@@ -50,6 +51,78 @@ def test_google_oauth_authorize_url_requests_offline_access() -> None:
     assert query["access_type"] == ["offline"]
     assert query["prompt"] == ["consent"]
     assert query["code_challenge_method"] == ["S256"]
+
+
+def test_google_oauth_callback_ignores_requests_without_expected_state() -> None:
+    callback_data = {}
+
+    status, _body, completed = _resolve_callback_response(
+        callback_data,
+        code="",
+        state="",
+        error="",
+        expected_state="expected-state",
+    )
+    assert status == 400
+    assert completed is False
+    assert callback_data == {}
+
+    status, _body, completed = _resolve_callback_response(
+        callback_data,
+        code="wrong-code",
+        state="wrong-state",
+        error="",
+        expected_state="expected-state",
+    )
+    assert status == 400
+    assert completed is False
+    assert callback_data == {}
+
+    status, _body, completed = _resolve_callback_response(
+        callback_data,
+        code="",
+        state="expected-state",
+        error="",
+        expected_state="expected-state",
+    )
+    assert status == 400
+    assert completed is False
+    assert callback_data == {}
+
+    status, _body, completed = _resolve_callback_response(
+        callback_data,
+        code="good-code",
+        state="expected-state",
+        error="",
+        expected_state="expected-state",
+    )
+    assert status == 200
+    assert completed is True
+    assert callback_data == {
+        "code": "good-code",
+        "state": "expected-state",
+        "error": "",
+    }
+
+
+def test_google_oauth_callback_accepts_provider_error_with_expected_state() -> None:
+    callback_data = {}
+
+    status, _body, completed = _resolve_callback_response(
+        callback_data,
+        code="",
+        state="expected-state",
+        error="access_denied",
+        expected_state="expected-state",
+    )
+
+    assert status == 200
+    assert completed is True
+    assert callback_data == {
+        "code": "",
+        "state": "expected-state",
+        "error": "access_denied",
+    }
 
 
 def test_google_oauth_exchange_code_requires_refresh_token() -> None:

--- a/plugins/titan-plugin-firebase/tests/test_oauth.py
+++ b/plugins/titan-plugin-firebase/tests/test_oauth.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from titan_cli.core.oauth import OAuthRequest, OAuthTokenSet
+from titan_cli.core.oauth import OAuthRequest, OAuthTokenInvalidError, OAuthTokenSet
 from titan_plugin_firebase.oauth import (
     AUTHORIZE_URL,
     TOKEN_URL,
@@ -249,7 +249,7 @@ def test_google_oauth_refresh_access_token_keeps_existing_refresh_token() -> Non
     }
 
 
-def test_google_oauth_refresh_access_token_sends_client_secret_when_configured() -> None:
+def test_google_oauth_refresh_sends_client_secret_when_configured() -> None:
     requests_module = FakeRequests(
         FakeResponse(
             {
@@ -270,7 +270,25 @@ def test_google_oauth_refresh_access_token_sends_client_secret_when_configured()
     assert requests_module.post_calls[0][1]["client_secret"] == "client-secret"
 
 
-def test_google_oauth_provider_refresh_preserves_scopes_when_response_omits_scope() -> None:
+def test_google_oauth_refresh_access_token_marks_invalid_grant() -> None:
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        requests_module=FakeRequests(
+            FakeResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Token has been expired or revoked.",
+                },
+                status_code=400,
+            )
+        ),
+    )
+
+    with pytest.raises(OAuthTokenInvalidError, match="invalid or revoked"):
+        flow.refresh_access_token("refresh")
+
+
+def test_google_oauth_provider_refresh_preserves_omitted_scope() -> None:
     requests_module = FakeRequests(
         FakeResponse(
             {

--- a/plugins/titan-plugin-firebase/tests/test_oauth.py
+++ b/plugins/titan-plugin-firebase/tests/test_oauth.py
@@ -7,11 +7,15 @@ from titan_cli.core.oauth import OAuthRequest, OAuthTokenInvalidError, OAuthToke
 from titan_plugin_firebase.oauth import (
     AUTHORIZE_URL,
     TOKEN_URL,
+    GoogleOAuthAuthorizeParams,
     GoogleOAuthError,
     GoogleOAuthFlow,
     GoogleOAuthProvider,
     GoogleOAuthSession,
+    GoogleOAuthTokenExchangeRequest,
+    GoogleOAuthTokenRefreshRequest,
     _resolve_callback_response,
+    build_loopback_redirect_uri,
 )
 
 
@@ -54,6 +58,58 @@ def test_google_oauth_authorize_url_requests_offline_access() -> None:
     assert query["access_type"] == ["offline"]
     assert query["prompt"] == ["consent"]
     assert query["code_challenge_method"] == ["S256"]
+    assert query["include_granted_scopes"] == ["true"]
+
+
+def test_google_oauth_authorize_params_model_encodes_protocol_defaults() -> None:
+    params = GoogleOAuthAuthorizeParams(
+        client_id="client-id",
+        redirect_uri="http://127.0.0.1:8766",
+        scopes=["scope-a", "scope-b"],
+        state="state",
+        code_challenge="challenge",
+    )
+
+    query = parse_qs(params.to_query_string())
+
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["scope-a scope-b"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["access_type"] == ["offline"]
+
+
+def test_google_oauth_loopback_redirect_uri_uses_constant_host() -> None:
+    assert build_loopback_redirect_uri(8766) == "http://127.0.0.1:8766"
+
+
+def test_google_oauth_token_request_models_build_form_data() -> None:
+    exchange = GoogleOAuthTokenExchangeRequest(
+        client_id="client-id",
+        code="code",
+        code_verifier="verifier",
+        redirect_uri="http://127.0.0.1:8766",
+        client_secret="secret",
+    )
+    refresh = GoogleOAuthTokenRefreshRequest(
+        client_id="client-id",
+        refresh_token="refresh",
+        client_secret="secret",
+    )
+
+    assert exchange.as_form_data() == {
+        "client_id": "client-id",
+        "code": "code",
+        "code_verifier": "verifier",
+        "grant_type": "authorization_code",
+        "redirect_uri": "http://127.0.0.1:8766",
+        "client_secret": "secret",
+    }
+    assert refresh.as_form_data() == {
+        "client_id": "client-id",
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh",
+        "client_secret": "secret",
+    }
 
 
 def test_google_oauth_callback_ignores_requests_without_expected_state() -> None:

--- a/plugins/titan-plugin-firebase/tests/test_oauth.py
+++ b/plugins/titan-plugin-firebase/tests/test_oauth.py
@@ -1,0 +1,193 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from titan_plugin_firebase.oauth import (
+    AUTHORIZE_URL,
+    TOKEN_URL,
+    GoogleOAuthError,
+    GoogleOAuthFlow,
+    GoogleOAuthSession,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeRequests:
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
+        self.post_calls = []
+
+    def post(self, url: str, data: dict, timeout: int):
+        self.post_calls.append((url, data, timeout))
+        return self.response
+
+
+def test_google_oauth_authorize_url_requests_offline_access() -> None:
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        redirect_port=8766,
+        scopes=["scope-a", "scope-b"],
+    )
+    session = GoogleOAuthSession(state="state", code_verifier="verifier")
+
+    authorize_url = flow.build_authorize_url(session)
+
+    parsed = urlparse(authorize_url)
+    query = parse_qs(parsed.query)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == AUTHORIZE_URL
+    assert query["client_id"] == ["client-id"]
+    assert query["redirect_uri"] == ["http://127.0.0.1:8766"]
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["scope-a scope-b"]
+    assert query["access_type"] == ["offline"]
+    assert query["prompt"] == ["consent"]
+    assert query["code_challenge_method"] == ["S256"]
+
+
+def test_google_oauth_exchange_code_requires_refresh_token() -> None:
+    requests_module = FakeRequests(
+        FakeResponse(
+            {
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+                "scope": "scope-a scope-b",
+            }
+        )
+    )
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        redirect_port=8766,
+        scopes=["scope-a"],
+        requests_module=requests_module,
+    )
+
+    result = flow.exchange_code("code", "verifier")
+
+    assert result.access_token == "access"
+    assert result.refresh_token == "refresh"
+    assert result.expires_in == 3600
+    assert result.granted_scopes == ["scope-a", "scope-b"]
+    assert requests_module.post_calls == [
+        (
+            TOKEN_URL,
+            {
+                "client_id": "client-id",
+                "code": "code",
+                "code_verifier": "verifier",
+                "grant_type": "authorization_code",
+                "redirect_uri": "http://127.0.0.1:8766",
+            },
+            30,
+        )
+    ]
+
+
+def test_google_oauth_exchange_code_sends_client_secret_when_configured() -> None:
+    requests_module = FakeRequests(
+        FakeResponse(
+            {
+                "access_token": "access",
+                "refresh_token": "refresh",
+            }
+        )
+    )
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        client_secret="client-secret",
+        redirect_port=8766,
+        requests_module=requests_module,
+    )
+
+    flow.exchange_code("code", "verifier")
+
+    assert requests_module.post_calls[0][1]["client_secret"] == "client-secret"
+
+
+def test_google_oauth_exchange_code_errors_without_refresh_token() -> None:
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        redirect_port=8766,
+        requests_module=FakeRequests(FakeResponse({"access_token": "access"})),
+    )
+
+    with pytest.raises(GoogleOAuthError, match="refresh token"):
+        flow.exchange_code("code", "verifier")
+
+
+def test_google_oauth_exchange_code_explains_web_client_secret_error() -> None:
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        redirect_port=8766,
+        requests_module=FakeRequests(
+            FakeResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "client_secret is missing.",
+                },
+                status_code=400,
+            )
+        ),
+    )
+
+    with pytest.raises(GoogleOAuthError) as raised:
+        flow.exchange_code("code", "verifier")
+
+    assert "Desktop app" in str(raised.value)
+
+
+def test_google_oauth_refresh_access_token_keeps_existing_refresh_token() -> None:
+    requests_module = FakeRequests(
+        FakeResponse(
+            {
+                "access_token": "fresh",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            }
+        )
+    )
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        redirect_port=8766,
+        requests_module=requests_module,
+    )
+
+    result = flow.refresh_access_token("refresh")
+
+    assert result.access_token == "fresh"
+    assert result.refresh_token is None
+    assert requests_module.post_calls[0][1] == {
+        "client_id": "client-id",
+        "grant_type": "refresh_token",
+        "refresh_token": "refresh",
+    }
+
+
+def test_google_oauth_refresh_access_token_sends_client_secret_when_configured() -> None:
+    requests_module = FakeRequests(
+        FakeResponse(
+            {
+                "access_token": "fresh",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            }
+        )
+    )
+    flow = GoogleOAuthFlow(
+        client_id="client-id",
+        client_secret="client-secret",
+        requests_module=requests_module,
+    )
+
+    flow.refresh_access_token("refresh")
+
+    assert requests_module.post_calls[0][1]["client_secret"] == "client-secret"

--- a/plugins/titan-plugin-firebase/tests/test_plugin.py
+++ b/plugins/titan-plugin-firebase/tests/test_plugin.py
@@ -1,0 +1,57 @@
+from unittest.mock import MagicMock
+
+from titan_plugin_firebase.client import FirebaseClient
+from titan_plugin_firebase.plugin import FirebasePlugin
+
+
+def test_firebase_plugin_basic_properties() -> None:
+    plugin = FirebasePlugin()
+
+    assert plugin.name == "firebase"
+    assert plugin.version == "0.1.0"
+    assert plugin.dependencies == []
+    assert "Firebase" in plugin.description
+
+
+def test_firebase_plugin_exposes_public_steps() -> None:
+    plugin = FirebasePlugin()
+
+    assert set(plugin.get_steps()) == {
+        "firebase_login",
+        "firebase_status",
+        "firebase_remoteconfig_get",
+    }
+
+
+def test_firebase_plugin_exposes_config_schema() -> None:
+    plugin = FirebasePlugin()
+
+    schema = plugin.get_config_schema()
+
+    assert "default_project" in schema["properties"]
+    assert "api_base_url" in schema["properties"]
+    assert "brand_projects" in schema["properties"]
+
+
+def test_firebase_plugin_initialize_builds_client() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.config.plugins = {
+        "firebase": MagicMock(config={"default_project": "demo-project"})
+    }
+
+    plugin.initialize(config, MagicMock())
+
+    client = plugin.get_client()
+    assert isinstance(client, FirebaseClient)
+    assert client.config.default_project == "demo-project"
+
+
+def test_firebase_plugin_is_available_delegates_to_client(monkeypatch) -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.config.plugins = {"firebase": MagicMock(config={})}
+    plugin.initialize(config, MagicMock())
+    monkeypatch.setattr(plugin.get_client(), "is_available", MagicMock(return_value=True))
+
+    assert plugin.is_available() is True

--- a/plugins/titan-plugin-firebase/tests/test_plugin.py
+++ b/plugins/titan-plugin-firebase/tests/test_plugin.py
@@ -1,3 +1,5 @@
+import importlib
+import sys
 from unittest.mock import MagicMock
 
 from titan_plugin_firebase.client import FirebaseClient
@@ -20,7 +22,20 @@ def test_firebase_plugin_exposes_public_steps() -> None:
         "firebase_login",
         "firebase_status",
         "firebase_remoteconfig_get",
+        "firebase_remoteconfig_inventory",
     }
+
+
+def test_firebase_steps_package_exports_are_lazy() -> None:
+    for module_name in list(sys.modules):
+        if module_name.startswith("titan_plugin_firebase.steps"):
+            sys.modules.pop(module_name)
+
+    steps_package = importlib.import_module("titan_plugin_firebase.steps")
+
+    assert "titan_plugin_firebase.steps.login_step" not in sys.modules
+    assert callable(steps_package.execute_firebase_login_step)
+    assert "titan_plugin_firebase.steps.login_step" in sys.modules
 
 
 def test_firebase_plugin_exposes_config_schema() -> None:
@@ -28,23 +43,223 @@ def test_firebase_plugin_exposes_config_schema() -> None:
 
     schema = plugin.get_config_schema()
 
+    assert "access_token" in schema["properties"]
     assert "default_project" in schema["properties"]
+    assert "projects" in schema["properties"]
+    assert "default_environment" in schema["properties"]
     assert "api_base_url" in schema["properties"]
+    assert "oauth_client_id" in schema["properties"]
+    assert "oauth_client_secret" in schema["properties"]
+    assert "oauth_redirect_port" in schema["properties"]
+    assert "oauth_timeout" in schema["properties"]
+    assert "oauth_scopes" in schema["properties"]
     assert "brand_projects" in schema["properties"]
+    assert "access_token" not in schema.get("required", [])
+    assert list(schema["properties"])[0] == "oauth_client_id"
+    assert list(schema["properties"])[1] == "oauth_client_secret"
+    assert schema["properties"]["oauth_client_secret"]["format"] == "password"
+    assert schema["properties"]["access_token"]["ui_hidden"] is True
+
+
+def test_firebase_plugin_exposes_workflows_path() -> None:
+    plugin = FirebasePlugin()
+
+    assert plugin.workflows_path is not None
+    assert plugin.workflows_path.name == "workflows"
 
 
 def test_firebase_plugin_initialize_builds_client() -> None:
     plugin = FirebasePlugin()
     config = MagicMock()
+    config.get_project_name.return_value = "demo"
     config.config.plugins = {
         "firebase": MagicMock(config={"default_project": "demo-project"})
     }
+    secrets = MagicMock()
 
-    plugin.initialize(config, MagicMock())
+    plugin.initialize(config, secrets)
 
     client = plugin.get_client()
     assert isinstance(client, FirebaseClient)
     assert client.config.default_project == "demo-project"
+    assert client.secrets == secrets
+    assert client.project_name == "demo"
+    assert client.oauth_manager is not None
+
+
+def test_firebase_plugin_initialize_registers_google_oauth_provider() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(
+            config={
+                "oauth_client_id": "google-client-id",
+                "oauth_client_secret": "google-client-secret",
+                "oauth_redirect_port": 8766,
+                "oauth_timeout": 60,
+            }
+        )
+    }
+    secrets = MagicMock()
+
+    plugin.initialize(config, secrets)
+
+    client = plugin.get_client()
+    assert "google" in client.oauth_manager.providers
+    assert client.oauth_manager.providers["google"].flow.client_secret == (
+        "google-client-secret"
+    )
+
+
+def test_firebase_plugin_initialize_uses_saved_oauth_client_id() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {"firebase": MagicMock(config={})}
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_oauth_client_id": "saved-google-client-id",
+        "demo_firebase_oauth_client_secret": "saved-google-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    client = plugin.get_client()
+    assert client.config.oauth_client_id == "saved-google-client-id"
+    assert client.config.oauth_client_secret == "saved-google-client-secret"
+    assert "google" in client.oauth_manager.providers
+
+
+def test_firebase_plugin_project_saved_oauth_client_id_overrides_config_value() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(
+            config={
+                "oauth_client_id": "old-config-client-id",
+                "oauth_client_secret": "old-config-client-secret",
+            }
+        )
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_oauth_client_id": "saved-google-client-id",
+        "demo_firebase_oauth_client_secret": "saved-google-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "saved-google-client-id"
+    assert plugin.get_client().config.oauth_client_secret == (
+        "saved-google-client-secret"
+    )
+
+
+def test_firebase_plugin_does_not_mix_project_saved_id_with_config_secret() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(
+            config={
+                "oauth_client_id": "config-client-id",
+                "oauth_client_secret": "config-client-secret",
+            }
+        )
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_oauth_client_id": "saved-google-client-id",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "saved-google-client-id"
+    assert plugin.get_client().config.oauth_client_secret is None
+
+
+def test_firebase_plugin_pairs_config_id_with_project_secret_from_wizard() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(config={"oauth_client_id": "config-client-id"})
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_oauth_client_secret": "wizard-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "config-client-id"
+    assert plugin.get_client().config.oauth_client_secret == "wizard-client-secret"
+
+
+def test_firebase_plugin_config_oauth_client_id_overrides_generic_saved_value() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(
+            config={
+                "oauth_client_id": "config-client-id",
+                "oauth_client_secret": "config-client-secret",
+            }
+        )
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "firebase_oauth_client_id": "generic-saved-client-id",
+        "firebase_oauth_client_secret": "generic-saved-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "config-client-id"
+    assert plugin.get_client().config.oauth_client_secret == "config-client-secret"
+
+
+def test_firebase_plugin_does_not_mix_config_id_with_different_generic_secret() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(config={"oauth_client_id": "config-client-id"})
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "firebase_oauth_client_id": "generic-saved-client-id",
+        "firebase_oauth_client_secret": "generic-saved-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "config-client-id"
+    assert plugin.get_client().config.oauth_client_secret is None
+
+
+def test_firebase_plugin_reuses_generic_secret_only_for_same_config_id() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(config={"oauth_client_id": "same-client-id"})
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "firebase_oauth_client_id": "same-client-id",
+        "firebase_oauth_client_secret": "generic-saved-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "same-client-id"
+    assert plugin.get_client().config.oauth_client_secret == (
+        "generic-saved-client-secret"
+    )
 
 
 def test_firebase_plugin_is_available_delegates_to_client(monkeypatch) -> None:
@@ -52,6 +267,10 @@ def test_firebase_plugin_is_available_delegates_to_client(monkeypatch) -> None:
     config = MagicMock()
     config.config.plugins = {"firebase": MagicMock(config={})}
     plugin.initialize(config, MagicMock())
-    monkeypatch.setattr(plugin.get_client(), "is_available", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        plugin.get_client(),
+        "is_available",
+        MagicMock(return_value=True),
+    )
 
     assert plugin.is_available() is True

--- a/plugins/titan-plugin-firebase/tests/test_plugin.py
+++ b/plugins/titan-plugin-firebase/tests/test_plugin.py
@@ -262,7 +262,9 @@ def test_firebase_plugin_reuses_generic_secret_only_for_same_config_id() -> None
     )
 
 
-def test_firebase_plugin_is_available_delegates_to_client(monkeypatch) -> None:
+def test_firebase_plugin_is_available_when_client_is_initialized(
+    monkeypatch,
+) -> None:
     plugin = FirebasePlugin()
     config = MagicMock()
     config.config.plugins = {"firebase": MagicMock(config={})}
@@ -270,7 +272,13 @@ def test_firebase_plugin_is_available_delegates_to_client(monkeypatch) -> None:
     monkeypatch.setattr(
         plugin.get_client(),
         "is_available",
-        MagicMock(return_value=True),
+        MagicMock(return_value=False),
     )
 
     assert plugin.is_available() is True
+
+
+def test_firebase_plugin_is_not_available_before_initialize() -> None:
+    plugin = FirebasePlugin()
+
+    assert plugin.is_available() is False

--- a/plugins/titan-plugin-firebase/tests/test_plugin.py
+++ b/plugins/titan-plugin-firebase/tests/test_plugin.py
@@ -180,7 +180,7 @@ def test_firebase_plugin_does_not_mix_project_saved_id_with_config_secret() -> N
     assert plugin.get_client().config.oauth_client_secret is None
 
 
-def test_firebase_plugin_pairs_config_id_with_project_secret_from_wizard() -> None:
+def test_firebase_plugin_does_not_pair_config_id_with_project_secret() -> None:
     plugin = FirebasePlugin()
     config = MagicMock()
     config.get_project_name.return_value = "demo"
@@ -195,7 +195,28 @@ def test_firebase_plugin_pairs_config_id_with_project_secret_from_wizard() -> No
     plugin.initialize(config, secrets)
 
     assert plugin.get_client().config.oauth_client_id == "config-client-id"
-    assert plugin.get_client().config.oauth_client_secret == "wizard-client-secret"
+    assert plugin.get_client().config.oauth_client_secret is None
+
+
+def test_firebase_plugin_pairs_project_saved_id_with_project_secret() -> None:
+    plugin = FirebasePlugin()
+    config = MagicMock()
+    config.get_project_name.return_value = "demo"
+    config.config.plugins = {
+        "firebase": MagicMock(config={"oauth_client_id": "config-client-id"})
+    }
+    secrets = MagicMock()
+    secrets.get.side_effect = lambda key: {
+        "demo_firebase_oauth_client_id": "saved-google-client-id",
+        "demo_firebase_oauth_client_secret": "saved-google-client-secret",
+    }.get(key)
+
+    plugin.initialize(config, secrets)
+
+    assert plugin.get_client().config.oauth_client_id == "saved-google-client-id"
+    assert (
+        plugin.get_client().config.oauth_client_secret == "saved-google-client-secret"
+    )
 
 
 def test_firebase_plugin_config_oauth_client_id_overrides_generic_saved_value() -> None:

--- a/plugins/titan-plugin-firebase/tests/test_remoteconfig_inventory.py
+++ b/plugins/titan-plugin-firebase/tests/test_remoteconfig_inventory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from titan_plugin_firebase.client import RemoteConfigTemplate
 from titan_plugin_firebase.config import FirebasePluginConfig
 from titan_plugin_firebase.exceptions import FirebaseClientError
@@ -143,3 +145,70 @@ def test_build_remote_config_inventory_collects_failures() -> None:
     assert inventory.project_count == 1
     assert len(inventory.failures) == 1
     assert inventory.failures[0].target.project_id == "masmovil-prod"
+
+
+def test_build_remote_config_inventory_collects_template_normalization_failures() -> None:
+    target_config = FirebasePluginConfig(
+        projects=[
+            {"brand": "yoigo", "environment": "prod", "project_id": "yoigo-prod"},
+            {
+                "brand": "masmovil",
+                "environment": "prod",
+                "project_id": "masmovil-prod",
+            },
+        ]
+    )
+    targets = resolve_project_targets(target_config)
+    client = FakeInventoryClient(
+        {
+            "yoigo-prod": RemoteConfigTemplate(
+                project_id="yoigo-prod",
+                etag="etag-a",
+                template={"parameters": {"feature_enabled": {}}},
+            ),
+            "masmovil-prod": RemoteConfigTemplate(
+                project_id="masmovil-prod",
+                etag="etag-b",
+                template={
+                    "parameters": {
+                        "broken_parameter": {
+                            "defaultValue": ["not", "an", "object"],
+                        },
+                    },
+                },
+            ),
+        }
+    )
+
+    inventory = build_remote_config_inventory(client, targets)
+
+    assert inventory.project_count == 1
+    assert len(inventory.failures) == 1
+    assert inventory.failures[0].target.project_id == "masmovil-prod"
+    assert "broken_parameter" in inventory.failures[0].message
+    assert "could not be normalized" in inventory.failures[0].message
+
+
+def test_build_remote_config_inventory_raises_template_normalization_failure() -> None:
+    target_config = FirebasePluginConfig(
+        projects=[
+            {
+                "brand": "masmovil",
+                "environment": "prod",
+                "project_id": "masmovil-prod",
+            },
+        ]
+    )
+    targets = resolve_project_targets(target_config)
+    client = FakeInventoryClient(
+        {
+            "masmovil-prod": RemoteConfigTemplate(
+                project_id="masmovil-prod",
+                etag="etag-b",
+                template={"parameters": ["not", "an", "object"]},
+            ),
+        }
+    )
+
+    with pytest.raises(FirebaseClientError, match="parameters must be"):
+        build_remote_config_inventory(client, targets, continue_on_error=False)

--- a/plugins/titan-plugin-firebase/tests/test_remoteconfig_inventory.py
+++ b/plugins/titan-plugin-firebase/tests/test_remoteconfig_inventory.py
@@ -60,6 +60,47 @@ def test_resolve_project_targets_from_brand_environment_mapping() -> None:
     assert targets[0].project_id == "yoigo-prod"
 
 
+def test_resolve_project_targets_filters_environment_aliases() -> None:
+    config = FirebasePluginConfig(
+        environments=[
+            {"name": "production", "aliases": ["prod", "live"]},
+            {"name": "staging", "aliases": ["pre"]},
+        ],
+        brand_projects={
+            "production": {"yoigo": "yoigo-prod"},
+            "staging": {"yoigo": "yoigo-pre"},
+        },
+    )
+
+    targets = resolve_project_targets(config, environments="prod")
+
+    assert len(targets) == 1
+    assert targets[0].environment == "production"
+    assert targets[0].project_id == "yoigo-prod"
+    assert targets[0].label == "production/yoigo"
+
+
+def test_resolve_project_targets_normalizes_target_environment_aliases() -> None:
+    config = FirebasePluginConfig(
+        environments=[
+            {"name": "production", "aliases": ["prod"]},
+        ],
+        projects=[
+            {
+                "brand": "yoigo",
+                "environment": "prod",
+                "project_id": "yoigo-prod",
+            },
+        ],
+    )
+
+    targets = resolve_project_targets(config)
+
+    assert len(targets) == 1
+    assert targets[0].environment == "production"
+    assert targets[0].label == "production/yoigo"
+
+
 def test_build_remote_config_inventory_aggregates_keys_and_types() -> None:
     target_config = FirebasePluginConfig(
         projects=[

--- a/plugins/titan-plugin-firebase/tests/test_remoteconfig_inventory.py
+++ b/plugins/titan-plugin-firebase/tests/test_remoteconfig_inventory.py
@@ -1,0 +1,145 @@
+from titan_plugin_firebase.client import RemoteConfigTemplate
+from titan_plugin_firebase.config import FirebasePluginConfig
+from titan_plugin_firebase.exceptions import FirebaseClientError
+from titan_plugin_firebase.models import RemoteConfigValueType
+from titan_plugin_firebase.operations.remoteconfig_inventory import (
+    build_remote_config_inventory,
+    resolve_project_targets,
+)
+
+
+class FakeInventoryClient:
+    def __init__(
+        self,
+        templates: dict[str, RemoteConfigTemplate],
+        failures: dict[str, str] | None = None,
+    ):
+        self.templates = templates
+        self.failures = failures or {}
+
+    def get_remote_config(self, project_id: str) -> RemoteConfigTemplate:
+        if project_id in self.failures:
+            raise FirebaseClientError(self.failures[project_id])
+        return self.templates[project_id]
+
+
+def test_resolve_project_targets_from_environment_brand_mapping() -> None:
+    config = FirebasePluginConfig(
+        brand_projects={
+            "prod": {
+                "yoigo": "yoigo-prod",
+                "masmovil": {"project_id": "masmovil-prod", "platform": "ios"},
+            }
+        }
+    )
+
+    targets = resolve_project_targets(config)
+
+    assert [target.project_id for target in targets] == [
+        "yoigo-prod",
+        "masmovil-prod",
+    ]
+    assert targets[1].brand == "masmovil"
+    assert targets[0].environment == "prod"
+    assert targets[1].platform == "ios"
+
+
+def test_resolve_project_targets_from_brand_environment_mapping() -> None:
+    config = FirebasePluginConfig(
+        brand_projects_layout="brand_environment",
+        brand_projects={"yoigo": {"pre": "yoigo-pre", "prod": "yoigo-prod"}},
+    )
+
+    targets = resolve_project_targets(config, environments="prod")
+
+    assert len(targets) == 1
+    assert targets[0].brand == "yoigo"
+    assert targets[0].environment == "prod"
+    assert targets[0].project_id == "yoigo-prod"
+
+
+def test_build_remote_config_inventory_aggregates_keys_and_types() -> None:
+    target_config = FirebasePluginConfig(
+        projects=[
+            {"brand": "yoigo", "environment": "prod", "project_id": "yoigo-prod"},
+            {
+                "brand": "masmovil",
+                "environment": "prod",
+                "project_id": "masmovil-prod",
+            },
+        ]
+    )
+    targets = resolve_project_targets(target_config)
+    client = FakeInventoryClient(
+        {
+            "yoigo-prod": RemoteConfigTemplate(
+                project_id="yoigo-prod",
+                etag="etag-a",
+                template={
+                    "version": {"versionNumber": "11"},
+                    "parameters": {
+                        "feature_enabled": {
+                            "valueType": "BOOLEAN",
+                            "defaultValue": {"value": "true"},
+                        },
+                        "welcome_text": {"defaultValue": {"value": "hola"}},
+                    },
+                },
+            ),
+            "masmovil-prod": RemoteConfigTemplate(
+                project_id="masmovil-prod",
+                etag="etag-b",
+                template={
+                    "version": {"versionNumber": "22"},
+                    "parameters": {
+                        "feature_enabled": {
+                            "valueType": "JSON",
+                            "defaultValue": {"value": '{"enabled": true}'},
+                        },
+                    },
+                },
+            ),
+        }
+    )
+
+    inventory = build_remote_config_inventory(client, targets)
+    keys = {key.key: key for key in inventory.keys}
+
+    assert inventory.project_count == 2
+    assert inventory.key_count == 2
+    assert keys["feature_enabled"].has_type_mismatch is True
+    assert keys["feature_enabled"].observed_types == [
+        RemoteConfigValueType.BOOLEAN,
+        RemoteConfigValueType.JSON,
+    ]
+    assert keys["welcome_text"].projects_missing == ["prod/masmovil (masmovil-prod)"]
+
+
+def test_build_remote_config_inventory_collects_failures() -> None:
+    target_config = FirebasePluginConfig(
+        projects=[
+            {"brand": "yoigo", "environment": "prod", "project_id": "yoigo-prod"},
+            {
+                "brand": "masmovil",
+                "environment": "prod",
+                "project_id": "masmovil-prod",
+            },
+        ]
+    )
+    targets = resolve_project_targets(target_config)
+    client = FakeInventoryClient(
+        {
+            "yoigo-prod": RemoteConfigTemplate(
+                project_id="yoigo-prod",
+                etag="etag-a",
+                template={"parameters": {"feature_enabled": {}}},
+            )
+        },
+        failures={"masmovil-prod": "permission denied"},
+    )
+
+    inventory = build_remote_config_inventory(client, targets)
+
+    assert inventory.project_count == 1
+    assert len(inventory.failures) == 1
+    assert inventory.failures[0].target.project_id == "masmovil-prod"

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -134,6 +134,33 @@ def test_firebase_login_prompts_client_pair_when_google_rejects_secret() -> None
     assert any("client secret" in msg.lower() for msg in warning_messages)
 
 
+def test_firebase_login_blank_replacement_client_id_uses_manual_token() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        default_project="default-project",
+        oauth_client_id="stale-client-id",
+    )
+    client.is_available.side_effect = [False, True]
+    client.get_access_token.side_effect = FirebaseClientError(
+        "Firebase OAuth credential resolution failed: "
+        "Google OAuth exchange failed: The provided client secret is invalid."
+    )
+    client.get_access_token_source_label.return_value = "Titan OAuth token store"
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_text.return_value = " "
+    ctx.textual.ask_password.return_value = " ya29.manual-token "
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_access_token_saved"] is True
+    assert result.metadata["firebase_oauth_login_completed"] is False
+    client.get_access_token.assert_called_once()
+    client.save_oauth_client_id.assert_not_called()
+    client.save_access_token.assert_called_once_with("ya29.manual-token")
+    ctx.textual.ask_text.assert_called_once()
+
+
 def test_firebase_login_prompts_and_saves_token_when_auth_missing() -> None:
     client = _firebase_client()
     client.is_available.side_effect = [False, True]

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -3,16 +3,29 @@ from unittest.mock import MagicMock
 from titan_cli.engine import Error, Skip, Success, WorkflowContext
 from titan_plugin_firebase.client import RemoteConfigTemplate
 from titan_plugin_firebase.config import FirebasePluginConfig
-from titan_plugin_firebase.exceptions import FirebaseClientError
+from titan_plugin_firebase.exceptions import (
+    FirebaseAuthRejectedError,
+    FirebaseClientError,
+)
+from titan_plugin_firebase.models import (
+    FirebaseProjectTarget,
+    RemoteConfigInventory,
+    RemoteConfigKeyInventory,
+    RemoteConfigProjectInventory,
+)
 from titan_plugin_firebase.steps import (
     execute_firebase_login_step,
     execute_firebase_remoteconfig_get_step,
+    execute_firebase_remoteconfig_inventory_step,
     execute_firebase_status_step,
 )
 
 
 def _ctx(firebase=None, data=None) -> WorkflowContext:
-    ctx = WorkflowContext(secrets=MagicMock(), textual=MagicMock(), firebase=firebase)
+    textual = MagicMock()
+    textual.ask_text.return_value = None
+    textual.ask_password.return_value = None
+    ctx = WorkflowContext(secrets=MagicMock(), textual=textual, firebase=firebase)
     ctx.data.update(data or {})
     return ctx
 
@@ -25,6 +38,19 @@ def _firebase_client() -> MagicMock:
     return client
 
 
+def _save_oauth_client_id_mock(client: MagicMock):
+    """Return a mock side effect that enables OAuth on fake Firebase clients."""
+    def _save(client_id: str, client_secret: str | None = None) -> None:
+        client.config = client.config.model_copy(
+            update={
+                "oauth_client_id": client_id,
+                "oauth_client_secret": client_secret,
+            }
+        )
+
+    return _save
+
+
 def test_firebase_login_success() -> None:
     client = _firebase_client()
     client.is_available.return_value = True
@@ -34,9 +60,112 @@ def test_firebase_login_success() -> None:
 
     assert isinstance(result, Success)
     assert result.metadata["firebase_account"] == "user@example.com"
+    assert result.metadata["firebase_access_token_saved"] is False
+    assert result.metadata["firebase_oauth_login_completed"] is False
 
 
-def test_firebase_login_errors_when_auth_missing_by_default() -> None:
+def test_firebase_login_uses_google_oauth_when_configured() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        default_project="default-project",
+        oauth_client_id="google-client-id",
+    )
+    client.is_available.side_effect = [False, True]
+    client.get_access_token.return_value = "oauth-token"
+    client.get_access_token_source_label.return_value = "Titan OAuth token store"
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_access_token_saved"] is True
+    assert result.metadata["firebase_oauth_login_completed"] is True
+    client.get_access_token.assert_called_once()
+    assert client.get_access_token.call_args.kwargs["interactive"] is True
+    ctx.textual.ask_password.assert_not_called()
+
+
+def test_firebase_login_prompts_client_pair_when_google_rejects_secret() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        default_project="default-project",
+        oauth_client_id="stale-client-id",
+    )
+    client.is_available.side_effect = [False, True]
+    client.get_access_token.side_effect = [
+        FirebaseClientError(
+            "Firebase OAuth credential resolution failed: "
+            "Google OAuth exchange failed: The provided client secret is invalid."
+        ),
+        "oauth-token",
+    ]
+    client.get_access_token_source_label.return_value = "Titan OAuth token store"
+    client.save_oauth_client_id.side_effect = _save_oauth_client_id_mock(client)
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_text.return_value = " desktop-client-id "
+    ctx.textual.ask_password.return_value = " desktop-client-secret "
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_oauth_login_completed"] is True
+    client.delete_oauth_client_id.assert_not_called()
+    client.save_oauth_client_id.assert_called_once_with(
+        "desktop-client-id",
+        client_secret="desktop-client-secret",
+    )
+    assert client.get_access_token.call_count == 2
+    ctx.textual.ask_text.assert_called_once()
+    ctx.textual.ask_password.assert_called_once()
+    warning_messages = [
+        call.args[0] for call in ctx.textual.warning_text.call_args_list
+    ]
+    assert any("client secret" in msg.lower() for msg in warning_messages)
+
+
+def test_firebase_login_prompts_and_saves_token_when_auth_missing() -> None:
+    client = _firebase_client()
+    client.is_available.side_effect = [False, True]
+    client.get_access_token_source_label.return_value = (
+        "keyring:ragnarok-ios_firebase_access_token"
+    )
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_password.return_value = " ya29.token "
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_access_token_saved"] is True
+    assert result.metadata["firebase_oauth_login_completed"] is False
+    client.save_access_token.assert_called_once_with("ya29.token")
+    ctx.textual.ask_password.assert_called_once()
+
+
+def test_firebase_login_prompts_oauth_client_id_before_manual_token() -> None:
+    client = _firebase_client()
+    client.is_available.side_effect = [False, True]
+    client.get_access_token.return_value = "oauth-token"
+    client.get_access_token_source_label.return_value = "Titan OAuth token store"
+    client.save_oauth_client_id.side_effect = _save_oauth_client_id_mock(client)
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_text.return_value = " google-client-id "
+    ctx.textual.ask_password.return_value = " google-client-secret "
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_access_token_saved"] is True
+    assert result.metadata["firebase_oauth_login_completed"] is True
+    client.save_oauth_client_id.assert_called_once_with(
+        "google-client-id",
+        client_secret="google-client-secret",
+    )
+    client.get_access_token.assert_called_once()
+    assert client.get_access_token.call_args.kwargs["interactive"] is True
+    ctx.textual.ask_password.assert_called_once()
+
+
+def test_firebase_login_errors_when_auth_missing_and_token_not_entered() -> None:
     client = _firebase_client()
     client.is_available.return_value = False
     ctx = _ctx(firebase=client)
@@ -46,6 +175,18 @@ def test_firebase_login_errors_when_auth_missing_by_default() -> None:
     assert isinstance(result, Error)
     assert "application-default login" in result.message
     assert result.recoverable is True
+    ctx.textual.ask_password.assert_called_once()
+
+
+def test_firebase_status_does_not_prompt_by_default() -> None:
+    client = _firebase_client()
+    client.is_available.return_value = False
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_status_step(ctx)
+
+    assert isinstance(result, Error)
+    ctx.textual.ask_password.assert_not_called()
 
 
 def test_firebase_status_skips_when_auth_missing_and_configured() -> None:
@@ -59,6 +200,8 @@ def test_firebase_status_skips_when_auth_missing_and_configured() -> None:
     assert result.metadata["firebase_login_command"] == (
         "gcloud auth application-default login"
     )
+    assert result.metadata["firebase_access_token_saved"] is False
+    assert result.metadata["firebase_oauth_login_completed"] is False
 
 
 def test_remoteconfig_get_uses_project_id() -> None:
@@ -114,3 +257,202 @@ def test_remoteconfig_get_maps_client_error() -> None:
 
     assert isinstance(result, Error)
     assert "permission denied" in result.message
+
+
+def test_remoteconfig_get_reauthenticates_once_after_rejected_token() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        default_project="default-project",
+        oauth_client_id="google-client-id",
+    )
+    client.get_remote_config.side_effect = [
+        FirebaseAuthRejectedError(
+            "expired token",
+            auth_source="keyring:ragnarok-ios_firebase_access_token",
+        ),
+        RemoteConfigTemplate(
+            project_id="demo-project",
+            template={"parameters": {}},
+            etag="etag-9",
+        ),
+    ]
+    client.invalidate_access_token_source.return_value = True
+    client.get_access_token.return_value = "fresh-token"
+    client.is_available.return_value = True
+    ctx = _ctx(firebase=client, data={"project_id": "demo-project"})
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_remoteconfig_etag"] == "etag-9"
+    assert client.get_remote_config.call_count == 2
+    client.invalidate_access_token_source.assert_called_once_with(
+        "keyring:ragnarok-ios_firebase_access_token"
+    )
+    assert client.get_access_token.call_args.kwargs["interactive"] is True
+
+
+def test_remoteconfig_inventory_uses_configured_targets() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        projects=[
+            {
+                "brand": "yoigo",
+                "environment": "prod",
+                "project_id": "yoigo-prod",
+            }
+        ]
+    )
+    target = FirebaseProjectTarget(
+        brand="yoigo",
+        environment="prod",
+        project_id="yoigo-prod",
+    )
+    client.get_remote_config_inventory.return_value = RemoteConfigInventory(
+        targets=[target],
+        projects=[RemoteConfigProjectInventory(target=target, parameter_count=1)],
+        keys=[RemoteConfigKeyInventory(key="feature_enabled")],
+    )
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_remoteconfig_project_count"] == 1
+    assert result.metadata["firebase_remoteconfig_key_count"] == 1
+    assert result.metadata["firebase_remoteconfig_keys"][0]["key"] == "feature_enabled"
+    ctx.textual.table.assert_called_once()
+    targets_arg = client.get_remote_config_inventory.call_args.args[0]
+    assert targets_arg[0].project_id == "yoigo-prod"
+
+
+def test_remoteconfig_inventory_errors_without_targets() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig()
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "No Firebase project targets" in result.message
+
+
+def test_remoteconfig_inventory_errors_when_all_projects_fail() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(projects=["yoigo-prod"])
+    target = FirebaseProjectTarget(project_id="yoigo-prod")
+    client.get_remote_config_inventory.return_value = RemoteConfigInventory(
+        targets=[target],
+        failures=[],
+    )
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "could be read" in result.message
+
+
+def test_remoteconfig_inventory_reauthenticates_once_after_rejected_token() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        oauth_client_id="google-client-id",
+        projects=["yoigo-prod"],
+    )
+    target = FirebaseProjectTarget(project_id="yoigo-prod")
+    inventory = RemoteConfigInventory(
+        targets=[target],
+        projects=[RemoteConfigProjectInventory(target=target, parameter_count=1)],
+        keys=[RemoteConfigKeyInventory(key="feature_enabled")],
+    )
+    client.get_remote_config_inventory.side_effect = [
+        FirebaseAuthRejectedError(
+            "expired token",
+            auth_source="keyring:ragnarok-ios_firebase_access_token",
+        ),
+        inventory,
+    ]
+    client.invalidate_access_token_source.return_value = True
+    client.get_access_token.return_value = "fresh-token"
+    client.is_available.return_value = True
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_remoteconfig_key_count"] == 1
+    assert client.get_remote_config_inventory.call_count == 2
+    client.invalidate_access_token_source.assert_called_once_with(
+        "keyring:ragnarok-ios_firebase_access_token"
+    )
+    assert client.get_access_token.call_args.kwargs["interactive"] is True
+
+
+def test_remoteconfig_inventory_prompts_manual_when_oauth_missing() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(projects=["yoigo-prod"])
+    target = FirebaseProjectTarget(project_id="yoigo-prod")
+    inventory = RemoteConfigInventory(
+        targets=[target],
+        projects=[RemoteConfigProjectInventory(target=target, parameter_count=1)],
+        keys=[RemoteConfigKeyInventory(key="feature_enabled")],
+    )
+    client.get_remote_config_inventory.side_effect = [
+        FirebaseAuthRejectedError(
+            "expired token",
+            auth_source="keyring:ragnarok-ios_firebase_access_token",
+        ),
+        inventory,
+    ]
+    client.invalidate_access_token_source.return_value = True
+    client.is_available.return_value = True
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_password.return_value = "fresh-manual-token"
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Success)
+    assert client.get_remote_config_inventory.call_count == 2
+    client.get_access_token.assert_not_called()
+    client.save_access_token.assert_called_once_with("fresh-manual-token")
+    warning_messages = [
+        call.args[0] for call in ctx.textual.warning_text.call_args_list
+    ]
+    assert "Saved Firebase auth was rejected." in warning_messages
+    assert any("browser OAuth is not configured" in msg for msg in warning_messages)
+
+
+def test_remoteconfig_inventory_prompts_oauth_client_id_after_rejected_token() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(projects=["yoigo-prod"])
+    target = FirebaseProjectTarget(project_id="yoigo-prod")
+    inventory = RemoteConfigInventory(
+        targets=[target],
+        projects=[RemoteConfigProjectInventory(target=target, parameter_count=1)],
+        keys=[RemoteConfigKeyInventory(key="feature_enabled")],
+    )
+    client.get_remote_config_inventory.side_effect = [
+        FirebaseAuthRejectedError(
+            "expired token",
+            auth_source="keyring:ragnarok-ios_firebase_access_token",
+        ),
+        inventory,
+    ]
+    client.invalidate_access_token_source.return_value = True
+    client.get_access_token.return_value = "fresh-token"
+    client.is_available.return_value = True
+    client.save_oauth_client_id.side_effect = _save_oauth_client_id_mock(client)
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_text.return_value = "google-client-id"
+    ctx.textual.ask_password.return_value = "google-client-secret"
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Success)
+    assert client.get_remote_config_inventory.call_count == 2
+    client.save_oauth_client_id.assert_called_once_with(
+        "google-client-id",
+        client_secret="google-client-secret",
+    )
+    assert client.get_access_token.call_args.kwargs["interactive"] is True
+    ctx.textual.ask_password.assert_called_once()

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock
+
+from titan_cli.engine import Error, Skip, Success, WorkflowContext
+from titan_plugin_firebase.client import RemoteConfigTemplate
+from titan_plugin_firebase.config import FirebasePluginConfig
+from titan_plugin_firebase.exceptions import FirebaseClientError
+from titan_plugin_firebase.steps import (
+    execute_firebase_login_step,
+    execute_firebase_remoteconfig_get_step,
+    execute_firebase_status_step,
+)
+
+
+def _ctx(firebase=None, data=None) -> WorkflowContext:
+    ctx = WorkflowContext(secrets=MagicMock(), textual=MagicMock(), firebase=firebase)
+    ctx.data.update(data or {})
+    return ctx
+
+
+def _firebase_client() -> MagicMock:
+    client = MagicMock()
+    client.config = FirebasePluginConfig(default_project="default-project")
+    client.get_active_account.return_value = "user@example.com"
+    client.get_login_command.return_value = "gcloud auth application-default login"
+    return client
+
+
+def test_firebase_login_success() -> None:
+    client = _firebase_client()
+    client.is_available.return_value = True
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_account"] == "user@example.com"
+
+
+def test_firebase_login_errors_when_auth_missing_by_default() -> None:
+    client = _firebase_client()
+    client.is_available.return_value = False
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "application-default login" in result.message
+    assert result.recoverable is True
+
+
+def test_firebase_status_skips_when_auth_missing_and_configured() -> None:
+    client = _firebase_client()
+    client.is_available.return_value = False
+    ctx = _ctx(firebase=client, data={"fail_on_missing_auth": False})
+
+    result = execute_firebase_status_step(ctx)
+
+    assert isinstance(result, Skip)
+    assert result.metadata["firebase_login_command"] == (
+        "gcloud auth application-default login"
+    )
+
+
+def test_remoteconfig_get_uses_project_id() -> None:
+    client = _firebase_client()
+    client.get_remote_config.return_value = RemoteConfigTemplate(
+        project_id="demo-project",
+        template={"version": {"versionNumber": "7"}, "parameters": {}},
+        etag="etag-7",
+    )
+    ctx = _ctx(firebase=client, data={"project_id": "demo-project"})
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_project_id"] == "demo-project"
+    assert result.metadata["firebase_remoteconfig_etag"] == "etag-7"
+    assert result.metadata["firebase_remoteconfig_version"] == {"versionNumber": "7"}
+    client.get_remote_config.assert_called_once_with("demo-project")
+
+
+def test_remoteconfig_get_uses_default_project() -> None:
+    client = _firebase_client()
+    client.get_remote_config.return_value = RemoteConfigTemplate(
+        project_id="default-project",
+        template={},
+        etag=None,
+    )
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Success)
+    client.get_remote_config.assert_called_once_with("default-project")
+
+
+def test_remoteconfig_get_errors_without_project() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig()
+    ctx = _ctx(firebase=client)
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "project_id is required" in result.message
+
+
+def test_remoteconfig_get_maps_client_error() -> None:
+    client = _firebase_client()
+    client.get_remote_config.side_effect = FirebaseClientError("permission denied")
+    ctx = _ctx(firebase=client, data={"project_id": "demo-project"})
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "permission denied" in result.message

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from titan_cli.engine import Error, Skip, Success, WorkflowContext
 from titan_plugin_firebase.client import RemoteConfigTemplate
 from titan_plugin_firebase.config import FirebasePluginConfig
@@ -54,14 +56,20 @@ def _save_oauth_client_id_mock(client: MagicMock):
 def test_firebase_login_success() -> None:
     client = _firebase_client()
     client.is_available.return_value = True
+    client.get_access_token_source_label.return_value = "gcloud ADC"
     ctx = _ctx(firebase=client)
 
     result = execute_firebase_login_step(ctx)
 
     assert isinstance(result, Success)
-    assert result.metadata["firebase_account"] == "user@example.com"
+    assert result.metadata["firebase_account"] is None
+    assert result.metadata["firebase_auth_source"] == "gcloud ADC"
     assert result.metadata["firebase_access_token_saved"] is False
     assert result.metadata["firebase_oauth_login_completed"] is False
+    client.get_active_account.assert_not_called()
+    ctx.textual.success_text.assert_called_with(
+        "Firebase auth available via gcloud ADC"
+    )
 
 
 def test_firebase_login_uses_google_oauth_when_configured() -> None:
@@ -78,6 +86,8 @@ def test_firebase_login_uses_google_oauth_when_configured() -> None:
     result = execute_firebase_login_step(ctx)
 
     assert isinstance(result, Success)
+    assert result.metadata["firebase_account"] is None
+    assert result.metadata["firebase_auth_source"] == "Titan OAuth token store"
     assert result.metadata["firebase_access_token_saved"] is True
     assert result.metadata["firebase_oauth_login_completed"] is True
     client.get_access_token.assert_called_once()
@@ -197,11 +207,62 @@ def test_firebase_status_skips_when_auth_missing_and_configured() -> None:
     result = execute_firebase_status_step(ctx)
 
     assert isinstance(result, Skip)
+    assert result.metadata["firebase_account"] is None
+    assert result.metadata["firebase_auth_source"] is None
     assert result.metadata["firebase_login_command"] == (
         "gcloud auth application-default login"
     )
     assert result.metadata["firebase_access_token_saved"] is False
     assert result.metadata["firebase_oauth_login_completed"] is False
+
+
+def test_firebase_status_parses_serialized_false_flag() -> None:
+    client = _firebase_client()
+    client.is_available.return_value = False
+    ctx = _ctx(firebase=client, data={"fail_on_missing_auth": "false"})
+
+    result = execute_firebase_status_step(ctx)
+
+    assert isinstance(result, Skip)
+    assert result.metadata["firebase_access_token_saved"] is False
+
+
+def test_firebase_login_parses_serialized_prompt_false_flag() -> None:
+    client = _firebase_client()
+    client.is_available.return_value = False
+    ctx = _ctx(
+        firebase=client,
+        data={
+            "prompt_for_missing_auth": "false",
+            "fail_on_missing_auth": False,
+        },
+    )
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Skip)
+    ctx.textual.ask_text.assert_not_called()
+    ctx.textual.ask_password.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "flag_value",
+    [
+        None,
+        "eventually",
+        [],
+    ],
+)
+def test_firebase_status_rejects_invalid_missing_auth_flag(flag_value) -> None:
+    client = _firebase_client()
+    client.is_available.return_value = False
+    ctx = _ctx(firebase=client, data={"fail_on_missing_auth": flag_value})
+
+    result = execute_firebase_status_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "fail_on_missing_auth must be a boolean" in result.message
+    client.is_available.assert_not_called()
 
 
 def test_remoteconfig_get_uses_project_id() -> None:

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -320,6 +320,57 @@ def test_remoteconfig_get_maps_client_error() -> None:
     assert "permission denied" in result.message
 
 
+def test_remoteconfig_get_rejects_non_object_template() -> None:
+    client = _firebase_client()
+    client.get_remote_config.return_value = RemoteConfigTemplate(
+        project_id="demo-project",
+        template=["not", "an", "object"],
+        etag="etag-7",
+    )
+    ctx = _ctx(firebase=client, data={"project_id": "demo-project"})
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "template must be a JSON object" in result.message
+    ctx.textual.success_text.assert_not_called()
+    ctx.textual.end_step.assert_called_with("error")
+
+
+def test_remoteconfig_get_rejects_non_object_version() -> None:
+    client = _firebase_client()
+    client.get_remote_config.return_value = RemoteConfigTemplate(
+        project_id="demo-project",
+        template={"version": ["not", "an", "object"], "parameters": {}},
+        etag="etag-7",
+    )
+    ctx = _ctx(firebase=client, data={"project_id": "demo-project"})
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "version must be a JSON object" in result.message
+    ctx.textual.success_text.assert_not_called()
+    ctx.textual.end_step.assert_called_with("error")
+
+
+def test_remoteconfig_get_rejects_invalid_version_number_shape() -> None:
+    client = _firebase_client()
+    client.get_remote_config.return_value = RemoteConfigTemplate(
+        project_id="demo-project",
+        template={"version": {"versionNumber": ["7"]}, "parameters": {}},
+        etag="etag-7",
+    )
+    ctx = _ctx(firebase=client, data={"project_id": "demo-project"})
+
+    result = execute_firebase_remoteconfig_get_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "version.versionNumber must be a string or integer" in result.message
+    ctx.textual.success_text.assert_not_called()
+    ctx.textual.end_step.assert_called_with("error")
+
+
 def test_remoteconfig_get_reauthenticates_once_after_rejected_token() -> None:
     client = _firebase_client()
     client.config = FirebasePluginConfig(

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -523,6 +523,24 @@ def test_remoteconfig_inventory_errors_without_targets() -> None:
     assert "No Firebase project targets" in result.message
 
 
+def test_remoteconfig_inventory_errors_for_invalid_target_data() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig()
+    ctx = _ctx(
+        firebase=client,
+        data={"project_targets": [{"project_id": " "}]},
+    )
+
+    result = execute_firebase_remoteconfig_inventory_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "Invalid Firebase project targets" in result.message
+    assert result.recoverable is True
+    client.get_remote_config_inventory.assert_not_called()
+    ctx.textual.error_text.assert_called_once()
+    ctx.textual.end_step.assert_called_with("error")
+
+
 def test_remoteconfig_inventory_errors_when_all_projects_fail() -> None:
     client = _firebase_client()
     client.config = FirebasePluginConfig(projects=["yoigo-prod"])

--- a/plugins/titan-plugin-firebase/tests/test_steps.py
+++ b/plugins/titan-plugin-firebase/tests/test_steps.py
@@ -42,6 +42,7 @@ def _firebase_client() -> MagicMock:
 
 def _save_oauth_client_id_mock(client: MagicMock):
     """Return a mock side effect that enables OAuth on fake Firebase clients."""
+
     def _save(client_id: str, client_secret: str | None = None) -> None:
         client.config = client.config.model_copy(
             update={
@@ -173,6 +174,52 @@ def test_firebase_login_prompts_oauth_client_id_before_manual_token() -> None:
     client.get_access_token.assert_called_once()
     assert client.get_access_token.call_args.kwargs["interactive"] is True
     ctx.textual.ask_password.assert_called_once()
+
+
+def test_firebase_login_falls_back_to_manual_token_after_oauth_failure() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        default_project="default-project",
+        oauth_client_id="google-client-id",
+    )
+    client.is_available.side_effect = [False, False, True]
+    client.get_access_token.side_effect = FirebaseClientError(
+        "Firebase Google OAuth login failed: callback timed out"
+    )
+    client.get_access_token_source_label.return_value = "Titan OAuth token store"
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_password.return_value = " ya29.manual-token "
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Success)
+    assert result.metadata["firebase_access_token_saved"] is True
+    assert result.metadata["firebase_oauth_login_completed"] is False
+    client.get_access_token.assert_called_once()
+    assert client.get_access_token.call_args.kwargs["interactive"] is True
+    client.save_access_token.assert_called_once_with("ya29.manual-token")
+    warning_messages = [
+        call.args[0] for call in ctx.textual.warning_text.call_args_list
+    ]
+    assert any("did not complete" in msg for msg in warning_messages)
+
+
+def test_firebase_login_aborts_on_unexpected_oauth_failure() -> None:
+    client = _firebase_client()
+    client.config = FirebasePluginConfig(
+        default_project="default-project",
+        oauth_client_id="google-client-id",
+    )
+    client.is_available.return_value = False
+    client.get_access_token.side_effect = RuntimeError("unexpected crash")
+    ctx = _ctx(firebase=client)
+    ctx.textual.ask_password.return_value = " ya29.manual-token "
+
+    result = execute_firebase_login_step(ctx)
+
+    assert isinstance(result, Error)
+    assert "Firebase Google OAuth login failed" in result.message
+    client.save_access_token.assert_not_called()
 
 
 def test_firebase_login_errors_when_auth_missing_and_token_not_entered() -> None:

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/__init__.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/__init__.py
@@ -1,0 +1,12 @@
+"""Firebase plugin for Titan CLI."""
+
+from .client import FirebaseClient, RemoteConfigTemplate
+from .config import FirebasePluginConfig
+from .plugin import FirebasePlugin
+
+__all__ = [
+    "FirebaseClient",
+    "FirebasePlugin",
+    "FirebasePluginConfig",
+    "RemoteConfigTemplate",
+]

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/auth.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/auth.py
@@ -1,0 +1,76 @@
+"""Google Cloud ADC helpers for the Firebase plugin."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Optional
+
+
+ADC_LOGIN_COMMAND = "gcloud auth application-default login"
+
+
+def is_gcloud_installed() -> bool:
+    """Return whether the gcloud CLI is installed and runnable."""
+    try:
+        result = subprocess.run(
+            ["gcloud", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+    return result.returncode == 0
+
+
+def get_active_account() -> Optional[str]:
+    """Return the active gcloud account email, if one is configured."""
+    try:
+        result = subprocess.run(
+            [
+                "gcloud",
+                "auth",
+                "list",
+                "--filter=status:ACTIVE",
+                "--format=value(account)",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    account = result.stdout.strip()
+    return account or None
+
+
+def get_adc_access_token() -> Optional[str]:
+    """Return an ADC access token from gcloud, if the user is logged in."""
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "application-default", "print-access-token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    token = result.stdout.strip()
+    return token or None
+
+
+def adc_login_hint() -> str:
+    """Return the command users should run to create a personal ADC session."""
+    return ADC_LOGIN_COMMAND

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
+import re
 from typing import Any, Optional, Sequence
 
 import requests
@@ -28,6 +29,7 @@ from .models import FirebaseProjectTarget, RemoteConfigInventory
 ACCESS_TOKEN_SECRET_KEY = "firebase_access_token"
 OAUTH_CLIENT_ID_SECRET_KEY = "firebase_oauth_client_id"
 OAUTH_CLIENT_SECRET_KEY = "firebase_oauth_client_secret"
+GOOGLE_CLOUD_PROJECT_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
 
 
 @dataclass(frozen=True)
@@ -378,6 +380,19 @@ class FirebaseClient:
             "gcloud ADC",
         }
 
+    def _normalize_project_id(self, project_id: str) -> str:
+        """Normalize and validate a Google Cloud project ID."""
+        normalized_project_id = project_id.strip() if project_id else ""
+        if not normalized_project_id:
+            raise FirebaseClientError("Firebase project_id is required.")
+        if not GOOGLE_CLOUD_PROJECT_ID_PATTERN.fullmatch(normalized_project_id):
+            raise FirebaseClientError(
+                "Firebase project_id must be a valid Google Cloud project ID "
+                "(6-30 lowercase letters, digits, or hyphens; starts with a "
+                "letter and does not end with a hyphen)."
+            )
+        return normalized_project_id
+
     def get_remote_config(self, project_id: str) -> RemoteConfigTemplate:
         """
         Read a Firebase Remote Config template for one project.
@@ -391,9 +406,7 @@ class FirebaseClient:
         Raises:
             FirebaseClientError: If auth is missing or the API request fails.
         """
-        normalized_project_id = project_id.strip() if project_id else ""
-        if not normalized_project_id:
-            raise FirebaseClientError("Firebase project_id is required.")
+        normalized_project_id = self._normalize_project_id(project_id)
 
         token, auth_source = self.resolve_access_token()
         if not token:

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
@@ -1,0 +1,150 @@
+"""Firebase client for ADC-backed Remote Config REST operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+
+from . import auth
+from .config import FirebasePluginConfig
+from .exceptions import FirebaseClientError
+
+
+@dataclass(frozen=True)
+class RemoteConfigTemplate:
+    """Remote Config template returned by Firebase."""
+
+    project_id: str
+    template: dict[str, Any]
+    etag: Optional[str]
+
+    @property
+    def version(self) -> Any:
+        """Return the Remote Config template version payload, when present."""
+        return self.template.get("version")
+
+
+class FirebaseClient:
+    """Client facade for Firebase Remote Config operations."""
+
+    def __init__(self, config: FirebasePluginConfig):
+        """Initialize the Firebase client with validated plugin config."""
+        self.config = config
+
+    def is_gcloud_installed(self) -> bool:
+        """Return whether the gcloud CLI is installed."""
+        return auth.is_gcloud_installed()
+
+    def get_active_account(self) -> Optional[str]:
+        """Return the active gcloud account, if one is configured."""
+        return auth.get_active_account()
+
+    def get_adc_access_token(self) -> Optional[str]:
+        """Return the current ADC bearer token, if available."""
+        return auth.get_adc_access_token()
+
+    def get_login_command(self) -> str:
+        """Return the command users should run to create an ADC session."""
+        return auth.adc_login_hint()
+
+    def is_available(self) -> bool:
+        """Return whether gcloud and ADC are available for Firebase requests."""
+        return self.is_gcloud_installed() and bool(self.get_adc_access_token())
+
+    def get_remote_config(self, project_id: str) -> RemoteConfigTemplate:
+        """
+        Read a Firebase Remote Config template for one project.
+
+        Args:
+            project_id: Firebase project ID.
+
+        Returns:
+            RemoteConfigTemplate containing the JSON template and ETag.
+
+        Raises:
+            FirebaseClientError: If ADC is missing or the API request fails.
+        """
+        normalized_project_id = project_id.strip() if project_id else ""
+        if not normalized_project_id:
+            raise FirebaseClientError("Firebase project_id is required.")
+
+        token = self.get_adc_access_token()
+        if not token:
+            raise FirebaseClientError(
+                "Firebase ADC token not available. Run: "
+                f"{self.get_login_command()}"
+            )
+
+        url = (
+            f"{self.config.api_base_url}/projects/"
+            f"{normalized_project_id}/remoteConfig"
+        )
+        headers = {"Authorization": f"Bearer {token}"}
+
+        try:
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=self.config.request_timeout,
+            )
+        except requests.RequestException as exc:
+            raise FirebaseClientError(
+                f"Firebase Remote Config request failed: {exc}"
+            ) from exc
+
+        if response.status_code == 200:
+            try:
+                template = response.json()
+            except ValueError as exc:
+                raise FirebaseClientError(
+                    "Firebase Remote Config response was not valid JSON."
+                ) from exc
+
+            return RemoteConfigTemplate(
+                project_id=normalized_project_id,
+                template=template,
+                etag=response.headers.get("ETag"),
+            )
+
+        detail = self._extract_error_detail(response)
+        if response.status_code == 401:
+            raise FirebaseClientError(
+                "Firebase ADC token was rejected or expired. Run: "
+                f"{self.get_login_command()}. {detail}"
+            )
+        if response.status_code == 403:
+            raise FirebaseClientError(
+                "Firebase Remote Config permission denied for project "
+                f"'{normalized_project_id}'. {detail}"
+            )
+        if response.status_code == 404:
+            raise FirebaseClientError(
+                "Firebase Remote Config project or template not found for "
+                f"'{normalized_project_id}'. {detail}"
+            )
+
+        raise FirebaseClientError(
+            "Firebase Remote Config request failed with status "
+            f"{response.status_code}. {detail}"
+        )
+
+    def _extract_error_detail(self, response: requests.Response) -> str:
+        """Extract a concise error detail from a Firebase HTTP response."""
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                message = error.get("message")
+                if message:
+                    return str(message)
+            if error:
+                return str(error)
+
+        text = (response.text or "").strip()
+        return text or "No response detail provided."

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
@@ -431,6 +431,10 @@ class FirebaseClient:
                 raise FirebaseClientError(
                     "Firebase Remote Config response was not valid JSON."
                 ) from exc
+            if not isinstance(template, dict):
+                raise FirebaseClientError(
+                    "Firebase Remote Config response JSON was not an object."
+                )
 
             return RemoteConfigTemplate(
                 project_id=normalized_project_id,

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/client.py
@@ -1,15 +1,33 @@
-"""Firebase client for ADC-backed Remote Config REST operations."""
+"""Firebase client for OAuth-backed Remote Config REST operations."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+import os
+from typing import Any, Optional, Sequence
 
 import requests
 
+from titan_cli.core.oauth import (
+    OAuthAuthenticationRequired,
+    OAuthCredential,
+    OAuthError,
+    OAuthEventSink,
+    OAuthManager,
+    OAuthProviderNotFound,
+    OAuthRequest,
+    OAuthTokenSet,
+)
+from titan_cli.core.secrets import ScopeType, SecretManager
+
 from . import auth
 from .config import FirebasePluginConfig
-from .exceptions import FirebaseClientError
+from .exceptions import FirebaseAuthRejectedError, FirebaseClientError
+from .models import FirebaseProjectTarget, RemoteConfigInventory
+
+ACCESS_TOKEN_SECRET_KEY = "firebase_access_token"
+OAUTH_CLIENT_ID_SECRET_KEY = "firebase_oauth_client_id"
+OAUTH_CLIENT_SECRET_KEY = "firebase_oauth_client_secret"
 
 
 @dataclass(frozen=True)
@@ -29,9 +47,21 @@ class RemoteConfigTemplate:
 class FirebaseClient:
     """Client facade for Firebase Remote Config operations."""
 
-    def __init__(self, config: FirebasePluginConfig):
+    def __init__(
+        self,
+        config: FirebasePluginConfig,
+        secrets: Optional[SecretManager] = None,
+        project_name: Optional[str] = None,
+        oauth_manager: Optional[OAuthManager] = None,
+    ):
         """Initialize the Firebase client with validated plugin config."""
         self.config = config
+        self.secrets = secrets
+        self.project_name = project_name
+        self.oauth_manager = oauth_manager or (
+            OAuthManager(secrets) if secrets is not None else None
+        )
+        self._ignored_access_token_sources: set[str] = set()
 
     def is_gcloud_installed(self) -> bool:
         """Return whether the gcloud CLI is installed."""
@@ -45,13 +75,308 @@ class FirebaseClient:
         """Return the current ADC bearer token, if available."""
         return auth.get_adc_access_token()
 
+    def build_oauth_request(self, *, interactive: bool = False) -> OAuthRequest:
+        """Build the OAuth request used by Titan's credential manager."""
+        connection_suffix = self.project_name or "default"
+        access_token_env_var = self.config.access_token_env_var
+        if access_token_env_var in self._ignored_access_token_sources:
+            access_token_env_var = None
+
+        legacy_secret_keys = [
+            key
+            for key in self.get_access_token_secret_keys()
+            if f"keyring:{key}" not in self._ignored_access_token_sources
+        ]
+        return OAuthRequest(
+            provider="google",
+            connection_id=f"firebase:{connection_suffix}",
+            scopes=self.config.oauth_scopes,
+            interactive=interactive,
+            access_token_env_var=access_token_env_var,
+            legacy_secret_keys=legacy_secret_keys,
+            subject=self.project_name,
+        )
+
+    def get_oauth_credential(
+        self,
+        *,
+        sink: Optional[OAuthEventSink] = None,
+        interactive: bool = False,
+    ) -> Optional[OAuthCredential]:
+        """Return a Titan-managed OAuth credential, if one is available."""
+        if not self.oauth_manager:
+            return None
+
+        try:
+            return self.oauth_manager.get_credential_blocking(
+                self.build_oauth_request(interactive=interactive),
+                sink=sink,
+            )
+        except (OAuthAuthenticationRequired, OAuthProviderNotFound):
+            return None
+        except OAuthError as exc:
+            raise FirebaseClientError(
+                f"Firebase OAuth credential resolution failed: {exc}"
+            ) from exc
+
+    def resolve_access_token(
+        self,
+        *,
+        sink: Optional[OAuthEventSink] = None,
+        interactive: bool = False,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Return the access token and safe source label Titan will use."""
+        credential = self.get_oauth_credential(sink=sink, interactive=interactive)
+        if credential:
+            return credential.access_token, credential.source
+
+        access_token_env_var = self.config.access_token_env_var
+        if (
+            access_token_env_var
+            and access_token_env_var not in self._ignored_access_token_sources
+        ):
+            env_token = os.environ.get(access_token_env_var)
+            if env_token and env_token.strip():
+                return env_token.strip(), access_token_env_var
+
+        if (
+            self.config.access_token
+            and "Firebase plugin access_token" not in self._ignored_access_token_sources
+        ):
+            return self.config.access_token, "Firebase plugin access_token"
+
+        if "gcloud ADC" not in self._ignored_access_token_sources:
+            adc_token = self.get_adc_access_token()
+            if adc_token:
+                return adc_token, "gcloud ADC"
+
+        return None, None
+
+    def get_access_token(
+        self,
+        *,
+        sink: Optional[OAuthEventSink] = None,
+        interactive: bool = False,
+    ) -> Optional[str]:
+        """Return an OAuth access token via OAuthManager, config, then gcloud ADC."""
+        token, _source = self.resolve_access_token(
+            sink=sink,
+            interactive=interactive,
+        )
+        return token
+
+    def get_access_token_secret_keys(self) -> list[str]:
+        """Return keyring keys checked for saved Firebase access tokens."""
+        keys = []
+        if self.project_name:
+            keys.append(f"{self.project_name}_{ACCESS_TOKEN_SECRET_KEY}")
+        keys.append(ACCESS_TOKEN_SECRET_KEY)
+        return keys
+
+    def get_oauth_client_id_secret_keys(self) -> list[str]:
+        """Return keyring keys checked for saved Google OAuth client IDs."""
+        keys = []
+        if self.project_name:
+            keys.append(f"{self.project_name}_{OAUTH_CLIENT_ID_SECRET_KEY}")
+        keys.append(OAUTH_CLIENT_ID_SECRET_KEY)
+        return keys
+
+    def get_oauth_client_secret_secret_keys(self) -> list[str]:
+        """Return keyring keys checked for saved Google OAuth client secrets."""
+        keys = []
+        if self.project_name:
+            keys.append(f"{self.project_name}_{OAUTH_CLIENT_SECRET_KEY}")
+        keys.append(OAUTH_CLIENT_SECRET_KEY)
+        return keys
+
+    def configure_google_oauth(
+        self,
+        client_id: str,
+        client_secret: str | None = None,
+    ) -> None:
+        """Configure browser-based Google OAuth for this client session."""
+        normalized = client_id.strip() if client_id else ""
+        if not normalized:
+            raise FirebaseClientError("Google OAuth client ID is required.")
+
+        current_client_id = self.config.oauth_client_id
+        normalized_secret = (
+            client_secret.strip()
+            if isinstance(client_secret, str) and client_secret.strip()
+            else (
+                self.config.oauth_client_secret
+                if current_client_id == normalized
+                else None
+            )
+        )
+
+        from .oauth import GoogleOAuthFlow, GoogleOAuthProvider
+
+        self.config = self.config.model_copy(
+            update={
+                "oauth_client_id": normalized,
+                "oauth_client_secret": normalized_secret,
+            }
+        )
+        if not self.oauth_manager:
+            if not self.secrets:
+                raise FirebaseClientError("Titan SecretManager is not available.")
+            self.oauth_manager = OAuthManager(self.secrets)
+
+        self.oauth_manager.providers["google"] = GoogleOAuthProvider(
+            GoogleOAuthFlow(
+                client_id=normalized,
+                client_secret=normalized_secret,
+                redirect_port=self.config.oauth_redirect_port,
+                scopes=self.config.oauth_scopes,
+                timeout=self.config.oauth_timeout,
+                token_request_timeout=self.config.request_timeout,
+            )
+        )
+
+    def save_oauth_client_id(
+        self,
+        client_id: str,
+        client_secret: str | None = None,
+        scope: ScopeType = "user",
+    ) -> None:
+        """Persist a Google OAuth client ID and enable browser login."""
+        if not self.secrets:
+            raise FirebaseClientError("Titan SecretManager is not available.")
+
+        normalized = client_id.strip() if client_id else ""
+        if not normalized:
+            raise FirebaseClientError("Google OAuth client ID is required.")
+        normalized_secret = (
+            client_secret.strip()
+            if isinstance(client_secret, str) and client_secret.strip()
+            else None
+        )
+
+        keys = [OAUTH_CLIENT_ID_SECRET_KEY]
+        if self.project_name:
+            keys.insert(0, f"{self.project_name}_{OAUTH_CLIENT_ID_SECRET_KEY}")
+
+        for key in keys:
+            self.secrets.set(key, normalized, scope=scope)
+        if normalized_secret:
+            secret_keys = [OAUTH_CLIENT_SECRET_KEY]
+            if self.project_name:
+                secret_keys.insert(0, f"{self.project_name}_{OAUTH_CLIENT_SECRET_KEY}")
+            for key in secret_keys:
+                self.secrets.set(key, normalized_secret, scope=scope)
+        else:
+            for key in self.get_oauth_client_secret_secret_keys():
+                self.secrets.delete(key, scope=scope)
+
+        self.configure_google_oauth(normalized, client_secret=normalized_secret)
+
+    def delete_oauth_client_id(self, scope: ScopeType = "user") -> bool:
+        """Delete saved Google OAuth client IDs and clear runtime OAuth config."""
+        deleted = False
+        if self.secrets:
+            for key in (
+                self.get_oauth_client_id_secret_keys()
+                + self.get_oauth_client_secret_secret_keys()
+            ):
+                self.secrets.delete(key, scope=scope)
+                deleted = True
+
+        self.config = self.config.model_copy(
+            update={"oauth_client_id": None, "oauth_client_secret": None}
+        )
+        if self.oauth_manager:
+            self.oauth_manager.providers.pop("google", None)
+        return deleted
+
+    def save_access_token(self, token: str, scope: ScopeType = "user") -> None:
+        """Persist a Firebase access token using Titan's OAuth token store."""
+        normalized = token.strip() if token else ""
+        if not normalized:
+            raise FirebaseClientError("Firebase access token is required.")
+        if not self.secrets:
+            raise FirebaseClientError("Titan SecretManager is not available.")
+        if not self.oauth_manager:
+            raise FirebaseClientError("Titan OAuthManager is not available.")
+
+        try:
+            self.oauth_manager.save_token_set_blocking(
+                self.build_oauth_request(),
+                OAuthTokenSet(
+                    access_token=normalized,
+                    scopes=self.config.oauth_scopes,
+                    metadata={"provider": "firebase", "kind": "manual_access_token"},
+                ),
+                scope=scope,
+            )
+        except OAuthError as exc:
+            raise FirebaseClientError(
+                f"Could not save Firebase access token: {exc}"
+            ) from exc
+
+    def get_access_token_source_label(self) -> Optional[str]:
+        """Return a safe label for the currently resolved auth source."""
+        _token, source = self.resolve_access_token()
+        if source:
+            if source == self.config.access_token_env_var:
+                return self.config.access_token_env_var
+            if source.startswith("keyring:"):
+                return source
+            if source in {
+                "oauth-cache",
+                "oauth-refresh",
+                "oauth-login",
+            }:
+                return "Titan OAuth token store"
+            return source
+
+        return None
+
     def get_login_command(self) -> str:
         """Return the command users should run to create an ADC session."""
         return auth.adc_login_hint()
 
-    def is_available(self) -> bool:
-        """Return whether gcloud and ADC are available for Firebase requests."""
-        return self.is_gcloud_installed() and bool(self.get_adc_access_token())
+    def is_available(self, *, sink: Optional[OAuthEventSink] = None) -> bool:
+        """Return whether an OAuth token is available for Firebase requests."""
+        try:
+            return bool(self.get_access_token(sink=sink))
+        except FirebaseClientError:
+            return False
+
+    def invalidate_access_token_source(
+        self,
+        source: Optional[str],
+        *,
+        scope: ScopeType = "user",
+    ) -> bool:
+        """Invalidate one rejected auth source for the current client session."""
+        if not source:
+            return False
+
+        self._ignored_access_token_sources.add(source)
+
+        if source.startswith("keyring:") and self.secrets:
+            key = source.removeprefix("keyring:")
+            self.secrets.delete(key, scope=scope)
+            return True
+
+        if source in {"oauth-cache", "oauth-refresh", "oauth-login"}:
+            if self.oauth_manager:
+                try:
+                    self.oauth_manager.token_store.delete(
+                        self.build_oauth_request(),
+                        scope=scope,
+                    )
+                    return True
+                except OAuthError:
+                    return False
+            return False
+
+        return source in {
+            self.config.access_token_env_var,
+            "Firebase plugin access_token",
+            "gcloud ADC",
+        }
 
     def get_remote_config(self, project_id: str) -> RemoteConfigTemplate:
         """
@@ -64,24 +389,29 @@ class FirebaseClient:
             RemoteConfigTemplate containing the JSON template and ETag.
 
         Raises:
-            FirebaseClientError: If ADC is missing or the API request fails.
+            FirebaseClientError: If auth is missing or the API request fails.
         """
         normalized_project_id = project_id.strip() if project_id else ""
         if not normalized_project_id:
             raise FirebaseClientError("Firebase project_id is required.")
 
-        token = self.get_adc_access_token()
+        token, auth_source = self.resolve_access_token()
         if not token:
             raise FirebaseClientError(
-                "Firebase ADC token not available. Run: "
-                f"{self.get_login_command()}"
+                "Firebase OAuth token not available. Configure Firebase "
+                "oauth_client_id, set "
+                f"{self.config.access_token_env_var}, paste a temporary access "
+                f"token, or run: {self.get_login_command()}"
             )
 
         url = (
             f"{self.config.api_base_url}/projects/"
             f"{normalized_project_id}/remoteConfig"
         )
-        headers = {"Authorization": f"Bearer {token}"}
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "x-goog-user-project": normalized_project_id,
+        }
 
         try:
             response = requests.get(
@@ -110,9 +440,11 @@ class FirebaseClient:
 
         detail = self._extract_error_detail(response)
         if response.status_code == 401:
-            raise FirebaseClientError(
-                "Firebase ADC token was rejected or expired. Run: "
-                f"{self.get_login_command()}. {detail}"
+            raise FirebaseAuthRejectedError(
+                "Firebase OAuth token was rejected or expired. Refresh the saved "
+                f"token, update {self.config.access_token_env_var}, or run: "
+                f"{self.get_login_command()}. {detail}",
+                auth_source=auth_source,
             )
         if response.status_code == 403:
             raise FirebaseClientError(
@@ -128,6 +460,34 @@ class FirebaseClient:
         raise FirebaseClientError(
             "Firebase Remote Config request failed with status "
             f"{response.status_code}. {detail}"
+        )
+
+    def get_remote_config_inventory(
+        self,
+        targets: Sequence[FirebaseProjectTarget],
+        *,
+        continue_on_error: bool = True,
+    ) -> RemoteConfigInventory:
+        """
+        Build a Remote Config key inventory across Firebase project targets.
+
+        Args:
+            targets: Firebase project targets to read.
+            continue_on_error: Keep reading later projects when one project fails.
+
+        Returns:
+            RemoteConfigInventory with per-project parameters and aggregated keys.
+
+        Raises:
+            FirebaseClientError: If no targets are configured or a project read fails
+                while continue_on_error is False.
+        """
+        from .operations.remoteconfig_inventory import build_remote_config_inventory
+
+        return build_remote_config_inventory(
+            client=self,
+            targets=targets,
+            continue_on_error=continue_on_error,
         )
 
     def _extract_error_detail(self, response: requests.Response) -> str:

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/config.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/config.py
@@ -2,17 +2,47 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, Field, field_validator
+
+from .models import FirebaseEnvironment, FirebaseProjectTarget
 
 
 class FirebasePluginConfig(BaseModel):
     """Configuration for Firebase plugin access."""
 
+    access_token: Optional[str] = Field(
+        None,
+        description=(
+            "Short-lived Firebase/Google OAuth access token. The Titan plugin "
+            "configuration wizard stores this value in keyring, not config.toml."
+        ),
+        json_schema_extra={
+            "format": "password",
+            "ui_hidden": True,
+        },
+    )
     default_project: Optional[str] = Field(
         None,
         description="Default Firebase project ID for single-project operations.",
+        json_schema_extra={"config_scope": "project"},
+    )
+    default_environment: Optional[str] = Field(
+        None,
+        description="Default environment applied to project targets without one.",
+        json_schema_extra={"config_scope": "project"},
+    )
+    environments: list[FirebaseEnvironment] = Field(
+        default_factory=list,
+        description="Known logical Firebase environments.",
+        json_schema_extra={"config_scope": "project"},
+    )
+    projects: list[FirebaseProjectTarget] = Field(
+        default_factory=list,
+        description=(
+            "Explicit Firebase project targets to read in multibrand workflows."
+        ),
         json_schema_extra={"config_scope": "project"},
     )
     api_base_url: str = Field(
@@ -26,9 +56,72 @@ class FirebasePluginConfig(BaseModel):
         description="HTTP request timeout in seconds.",
         json_schema_extra={"config_scope": "global"},
     )
+    access_token_env_var: str = Field(
+        "FIREBASE_ACCESS_TOKEN",
+        description=(
+            "Environment variable containing a short-lived OAuth access token. "
+            "Used before falling back to gcloud ADC."
+        ),
+        json_schema_extra={"config_scope": "global"},
+    )
+    oauth_client_id: Optional[str] = Field(
+        None,
+        description=(
+            "Google OAuth desktop client ID used for browser-based Firebase login. "
+            "Titan stores this value in keyring when configured interactively."
+        ),
+        json_schema_extra={"config_scope": "global"},
+    )
+    oauth_client_secret: Optional[str] = Field(
+        None,
+        description=(
+            "Google OAuth desktop client secret used when Google's token endpoint "
+            "requires it for the configured Desktop app client."
+        ),
+        json_schema_extra={
+            "config_scope": "global",
+            "format": "password",
+        },
+    )
+    oauth_redirect_port: int = Field(
+        0,
+        ge=0,
+        le=65535,
+        description=(
+            "Localhost port for Google OAuth callback. Use 0 to let Titan choose "
+            "a free port."
+        ),
+        json_schema_extra={"config_scope": "global"},
+    )
+    oauth_timeout: int = Field(
+        180,
+        ge=30,
+        description="Seconds to wait for the browser OAuth callback.",
+        json_schema_extra={"config_scope": "global"},
+    )
+    oauth_scopes: list[str] = Field(
+        default_factory=lambda: [
+            "https://www.googleapis.com/auth/cloud-platform",
+        ],
+        description=(
+            "OAuth scopes Titan will request when a provider-backed Google "
+            "OAuth flow is available."
+        ),
+        json_schema_extra={"config_scope": "global"},
+    )
     brand_projects: Dict[str, Any] = Field(
         default_factory=dict,
-        description="Reserved for PR2 multibrand project resolution.",
+        description=(
+            "Firebase project mapping by brand and environment. Defaults to "
+            "environment -> brand -> project_id."
+        ),
+        json_schema_extra={"config_scope": "project"},
+    )
+    brand_projects_layout: Literal["environment_brand", "brand_environment"] = Field(
+        "environment_brand",
+        description=(
+            "Shape used by brand_projects: environment_brand or brand_environment."
+        ),
         json_schema_extra={"config_scope": "project"},
     )
 
@@ -41,10 +134,68 @@ class FirebasePluginConfig(BaseModel):
             raise ValueError("api_base_url must start with http:// or https://")
         return stripped.rstrip("/")
 
-    @field_validator("default_project")
+    @field_validator("access_token_env_var")
+    @classmethod
+    def normalize_access_token_env_var(cls, value: str) -> str:
+        """Normalize the environment variable name used for OAuth access tokens."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("access_token_env_var is required")
+        return stripped
+
+    @field_validator("access_token")
+    @classmethod
+    def normalize_access_token(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize optional OAuth access token values."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @field_validator("oauth_scopes", mode="before")
+    @classmethod
+    def normalize_oauth_scopes(cls, value: Any) -> list[str]:
+        """Normalize optional OAuth scope values."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, list):
+            return value
+        return [
+            item.strip()
+            for item in value
+            if isinstance(item, str) and item.strip()
+        ]
+
+    @field_validator("projects", mode="before")
+    @classmethod
+    def normalize_projects(cls, value: Any) -> Any:
+        """Allow project targets to be declared as strings or objects."""
+        if value is None:
+            return []
+        if isinstance(value, (str, dict)):
+            value = [value]
+        if not isinstance(value, list):
+            return value
+
+        normalized = []
+        for item in value:
+            if isinstance(item, str):
+                normalized.append({"project_id": item, "brand": item})
+            else:
+                normalized.append(item)
+        return normalized
+
+    @field_validator(
+        "oauth_client_id",
+        "oauth_client_secret",
+        "default_project",
+        "default_environment",
+    )
     @classmethod
     def normalize_default_project(cls, value: Optional[str]) -> Optional[str]:
-        """Normalize optional default project values."""
+        """Normalize optional string config values."""
         if value is None:
             return None
         stripped = value.strip()

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/config.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/config.py
@@ -1,0 +1,51 @@
+"""Configuration model for the Firebase plugin."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class FirebasePluginConfig(BaseModel):
+    """Configuration for Firebase plugin access."""
+
+    default_project: Optional[str] = Field(
+        None,
+        description="Default Firebase project ID for single-project operations.",
+        json_schema_extra={"config_scope": "project"},
+    )
+    api_base_url: str = Field(
+        "https://firebaseremoteconfig.googleapis.com/v1",
+        description="Firebase Remote Config REST API base URL.",
+        json_schema_extra={"config_scope": "global"},
+    )
+    request_timeout: int = Field(
+        30,
+        ge=1,
+        description="HTTP request timeout in seconds.",
+        json_schema_extra={"config_scope": "global"},
+    )
+    brand_projects: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Reserved for PR2 multibrand project resolution.",
+        json_schema_extra={"config_scope": "project"},
+    )
+
+    @field_validator("api_base_url")
+    @classmethod
+    def normalize_api_base_url(cls, value: str) -> str:
+        """Normalize the API base URL used by the REST client."""
+        stripped = value.strip()
+        if not stripped.startswith(("http://", "https://")):
+            raise ValueError("api_base_url must start with http:// or https://")
+        return stripped.rstrip("/")
+
+    @field_validator("default_project")
+    @classmethod
+    def normalize_default_project(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize optional default project values."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/exceptions.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/exceptions.py
@@ -7,3 +7,11 @@ class FirebaseConfigurationError(Exception):
 
 class FirebaseClientError(Exception):
     """Raised when Firebase client operations fail."""
+
+
+class FirebaseAuthRejectedError(FirebaseClientError):
+    """Raised when Firebase rejects the resolved OAuth credential."""
+
+    def __init__(self, message: str, *, auth_source: str | None = None) -> None:
+        super().__init__(message)
+        self.auth_source = auth_source

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/exceptions.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/exceptions.py
@@ -1,0 +1,9 @@
+"""Firebase plugin exceptions."""
+
+
+class FirebaseConfigurationError(Exception):
+    """Raised when Firebase plugin configuration is invalid."""
+
+
+class FirebaseClientError(Exception):
+    """Raised when Firebase client operations fail."""

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/models.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/models.py
@@ -1,0 +1,365 @@
+"""Domain models for Firebase Remote Config inventory."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class RemoteConfigValueType(str, Enum):
+    """Supported Firebase Remote Config parameter value types."""
+
+    BOOLEAN = "BOOLEAN"
+    JSON = "JSON"
+    NUMBER = "NUMBER"
+    STRING = "STRING"
+    UNKNOWN = "UNKNOWN"
+
+
+class FirebaseEnvironment(BaseModel):
+    """A logical Firebase environment such as dev, pre, staging, or prod."""
+
+    name: str = Field(..., description="Stable environment identifier.")
+    display_name: Optional[str] = Field(
+        None,
+        description="Human-friendly environment label.",
+    )
+    aliases: list[str] = Field(
+        default_factory=list,
+        description="Alternate names accepted for this environment.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        """Normalize environment identifiers."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("environment name is required")
+        return stripped
+
+
+class FirebaseProjectTarget(BaseModel):
+    """A Firebase project resolved for one brand/environment target."""
+
+    project_id: str = Field(..., description="Firebase project ID.")
+    brand: Optional[str] = Field(None, description="Brand owning the project.")
+    environment: Optional[str] = Field(
+        None,
+        description="Logical environment for the project.",
+    )
+    platform: Optional[str] = Field(None, description="Optional app platform.")
+    label: Optional[str] = Field(None, description="Optional display label.")
+
+    @field_validator("project_id")
+    @classmethod
+    def normalize_project_id(cls, value: str) -> str:
+        """Normalize Firebase project IDs."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("project_id is required")
+        return stripped
+
+    @field_validator("brand", "environment", "platform", "label")
+    @classmethod
+    def normalize_optional_text(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize optional target fields."""
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @model_validator(mode="after")
+    def default_brand_and_label(self) -> FirebaseProjectTarget:
+        """Default missing display metadata from the project ID."""
+        if self.brand is None:
+            self.brand = self.project_id
+        if self.label is None:
+            parts = [self.environment, self.brand, self.platform]
+            self.label = "/".join(part for part in parts if part) or self.project_id
+        return self
+
+    def reference(self) -> str:
+        """Return a stable user-facing target reference."""
+        if self.label:
+            return f"{self.label} ({self.project_id})"
+        return self.project_id
+
+
+class RemoteConfigParameterValue(BaseModel):
+    """Raw Remote Config parameter value payload."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    value: Optional[str] = Field(None, description="Raw string value.")
+    use_in_app_default: bool = Field(
+        False,
+        alias="useInAppDefault",
+        description="Whether apps should use their in-app default.",
+    )
+
+
+class RemoteConfigParameter(BaseModel):
+    """Raw Remote Config parameter payload."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    description: Optional[str] = Field(None, description="Parameter description.")
+    default_value: Optional[RemoteConfigParameterValue] = Field(
+        None,
+        alias="defaultValue",
+        description="Default value payload.",
+    )
+    conditional_values: dict[str, RemoteConfigParameterValue] = Field(
+        default_factory=dict,
+        alias="conditionalValues",
+        description="Conditional values keyed by Firebase condition name.",
+    )
+    value_type: RemoteConfigValueType = Field(
+        RemoteConfigValueType.UNKNOWN,
+        alias="valueType",
+        description="Remote Config declared value type, when present.",
+    )
+
+    @field_validator("value_type", mode="before")
+    @classmethod
+    def normalize_value_type(cls, value: Any) -> RemoteConfigValueType:
+        """Normalize unknown or absent Firebase value type names."""
+        return normalize_remote_config_value_type(value)
+
+    def raw_values(self) -> list[Optional[str]]:
+        """Return all raw values declared for this parameter."""
+        values: list[Optional[str]] = []
+        if self.default_value:
+            values.append(self.default_value.value)
+        values.extend(value.value for value in self.conditional_values.values())
+        return values
+
+
+class RemoteConfigTypedValue(BaseModel):
+    """A Remote Config value with inferred type and parsed representation."""
+
+    raw_value: Optional[str] = Field(None, description="Raw Remote Config value.")
+    parsed_value: Any = Field(None, description="Parsed value when supported.")
+    value_type: RemoteConfigValueType = Field(
+        RemoteConfigValueType.UNKNOWN,
+        description="Effective value type for this value.",
+    )
+    use_in_app_default: bool = Field(
+        False,
+        description="Whether apps should use their in-app default.",
+    )
+
+
+class RemoteConfigParameterInventory(BaseModel):
+    """Normalized inventory for one Remote Config parameter."""
+
+    key: str
+    description: Optional[str] = None
+    declared_value_type: RemoteConfigValueType = RemoteConfigValueType.UNKNOWN
+    inferred_value_type: RemoteConfigValueType = RemoteConfigValueType.UNKNOWN
+    value_type: RemoteConfigValueType = RemoteConfigValueType.UNKNOWN
+    default_value: Optional[RemoteConfigTypedValue] = None
+    conditional_values: dict[str, RemoteConfigTypedValue] = Field(default_factory=dict)
+    conditional_value_names: list[str] = Field(default_factory=list)
+
+
+class RemoteConfigKeyOccurrence(BaseModel):
+    """One key occurrence inside one Firebase project."""
+
+    key: str
+    project_id: str
+    brand: Optional[str] = None
+    environment: Optional[str] = None
+    platform: Optional[str] = None
+    target_label: Optional[str] = None
+    value_type: RemoteConfigValueType
+    declared_value_type: RemoteConfigValueType
+    inferred_value_type: RemoteConfigValueType
+    default_value: Optional[RemoteConfigTypedValue] = None
+    conditional_value_names: list[str] = Field(default_factory=list)
+    description: Optional[str] = None
+
+
+class RemoteConfigKeyInventory(BaseModel):
+    """Aggregated inventory for one key across Firebase projects."""
+
+    key: str
+    occurrences: list[RemoteConfigKeyOccurrence] = Field(default_factory=list)
+    projects_present: list[str] = Field(default_factory=list)
+    projects_missing: list[str] = Field(default_factory=list)
+    observed_types: list[RemoteConfigValueType] = Field(default_factory=list)
+    has_type_mismatch: bool = False
+
+
+class RemoteConfigProjectInventory(BaseModel):
+    """Remote Config inventory for one Firebase project target."""
+
+    target: FirebaseProjectTarget
+    etag: Optional[str] = None
+    version: Optional[dict[str, Any]] = None
+    version_number: Optional[str] = None
+    parameter_count: int = 0
+    parameters: dict[str, RemoteConfigParameterInventory] = Field(
+        default_factory=dict
+    )
+
+
+class RemoteConfigInventoryFailure(BaseModel):
+    """Failure collected while reading one Firebase project target."""
+
+    target: FirebaseProjectTarget
+    message: str
+
+
+class RemoteConfigInventory(BaseModel):
+    """Aggregated Remote Config inventory across Firebase project targets."""
+
+    targets: list[FirebaseProjectTarget] = Field(default_factory=list)
+    projects: list[RemoteConfigProjectInventory] = Field(default_factory=list)
+    keys: list[RemoteConfigKeyInventory] = Field(default_factory=list)
+    failures: list[RemoteConfigInventoryFailure] = Field(default_factory=list)
+
+    @property
+    def project_count(self) -> int:
+        """Return the number of projects read successfully."""
+        return len(self.projects)
+
+    @property
+    def key_count(self) -> int:
+        """Return the number of unique keys found."""
+        return len(self.keys)
+
+
+def normalize_remote_config_value_type(value: Any) -> RemoteConfigValueType:
+    """Normalize a Firebase value type into the local enum."""
+    if isinstance(value, RemoteConfigValueType):
+        return value
+    if value is None:
+        return RemoteConfigValueType.UNKNOWN
+
+    normalized = str(value).strip().upper()
+    if not normalized:
+        return RemoteConfigValueType.UNKNOWN
+
+    return RemoteConfigValueType.__members__.get(
+        normalized,
+        RemoteConfigValueType.UNKNOWN,
+    )
+
+
+def infer_remote_config_value_type(value: Optional[str]) -> RemoteConfigValueType:
+    """Infer the Remote Config value type from a raw string."""
+    if value is None:
+        return RemoteConfigValueType.UNKNOWN
+
+    stripped = value.strip()
+    if not stripped:
+        return RemoteConfigValueType.STRING
+
+    lowered = stripped.lower()
+    if lowered in {"true", "false"}:
+        return RemoteConfigValueType.BOOLEAN
+
+    if stripped.startswith(("{", "[")):
+        try:
+            parsed = json.loads(stripped)
+        except ValueError:
+            return RemoteConfigValueType.STRING
+        if isinstance(parsed, (dict, list)):
+            return RemoteConfigValueType.JSON
+
+    try:
+        float(stripped)
+    except ValueError:
+        return RemoteConfigValueType.STRING
+
+    return RemoteConfigValueType.NUMBER
+
+
+def parse_remote_config_value(
+    value: Optional[str],
+    value_type: RemoteConfigValueType,
+) -> Any:
+    """Parse a raw Remote Config value according to its effective type."""
+    if value is None:
+        return None
+
+    stripped = value.strip()
+    if value_type == RemoteConfigValueType.BOOLEAN:
+        lowered = stripped.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return value
+
+    if value_type == RemoteConfigValueType.JSON:
+        try:
+            return json.loads(stripped)
+        except ValueError:
+            return value
+
+    if value_type == RemoteConfigValueType.NUMBER:
+        try:
+            parsed = float(stripped)
+        except ValueError:
+            return value
+        if parsed.is_integer() and "." not in stripped and "e" not in stripped.lower():
+            return int(parsed)
+        return parsed
+
+    return value
+
+
+def build_parameter_inventory(
+    key: str,
+    payload: dict[str, Any],
+) -> RemoteConfigParameterInventory:
+    """Build a normalized parameter inventory item from a raw template payload."""
+    parameter = RemoteConfigParameter.model_validate(payload)
+    inferred_types = [
+        inferred
+        for raw_value in parameter.raw_values()
+        if (inferred := infer_remote_config_value_type(raw_value))
+        != RemoteConfigValueType.UNKNOWN
+    ]
+    inferred_value_type = (
+        inferred_types[0] if inferred_types else RemoteConfigValueType.UNKNOWN
+    )
+    value_type = (
+        parameter.value_type
+        if parameter.value_type != RemoteConfigValueType.UNKNOWN
+        else inferred_value_type
+    )
+
+    def _typed_value(
+        raw_value: RemoteConfigParameterValue,
+    ) -> RemoteConfigTypedValue:
+        return RemoteConfigTypedValue(
+            raw_value=raw_value.value,
+            parsed_value=parse_remote_config_value(raw_value.value, value_type),
+            value_type=value_type,
+            use_in_app_default=raw_value.use_in_app_default,
+        )
+
+    return RemoteConfigParameterInventory(
+        key=key,
+        description=parameter.description,
+        declared_value_type=parameter.value_type,
+        inferred_value_type=inferred_value_type,
+        value_type=value_type,
+        default_value=(
+            _typed_value(parameter.default_value)
+            if parameter.default_value is not None
+            else None
+        ),
+        conditional_values={
+            condition_name: _typed_value(raw_value)
+            for condition_name, raw_value in parameter.conditional_values.items()
+        },
+        conditional_value_names=sorted(parameter.conditional_values),
+    )

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
@@ -25,8 +25,30 @@ from titan_cli.core.oauth import (
 )
 
 
-AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
-TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_OAUTH_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token"
+AUTHORIZE_URL = GOOGLE_OAUTH_AUTHORIZE_URL
+TOKEN_URL = GOOGLE_OAUTH_TOKEN_URL
+
+LOOPBACK_HOST = "127.0.0.1"
+LOOPBACK_REDIRECT_URI_TEMPLATE = "http://{host}:{port}"
+CALLBACK_ACCEPTED_PATHS = ("", "/", "/google/callback")
+CALLBACK_SERVER_TIMEOUT_SECONDS = 0.5
+CALLBACK_THREAD_JOIN_TIMEOUT_SECONDS = 1
+
+OAUTH_RESPONSE_TYPE_CODE = "code"
+OAUTH_CODE_CHALLENGE_METHOD_S256 = "S256"
+OAUTH_ACCESS_TYPE_OFFLINE = "offline"
+OAUTH_PROMPT_CONSENT = "consent"
+OAUTH_INCLUDE_GRANTED_SCOPES = "true"
+OAUTH_GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
+OAUTH_GRANT_TYPE_REFRESH_TOKEN = "refresh_token"
+
+LOG_GOOGLE_OAUTH_AUTHORIZE_URL_BUILT = "google_oauth_authorize_url_built"
+LOG_GOOGLE_OAUTH_BROWSER_OPEN_FAILED = "google_oauth_browser_open_failed"
+LOG_GOOGLE_OAUTH_CALLBACK_LISTENER_STARTED = (
+    "google_oauth_callback_listener_started"
+)
 
 logger = get_logger(__name__)
 
@@ -115,12 +137,94 @@ class GoogleOAuthError(Exception):
     """Raised when Google OAuth cannot complete."""
 
 
+def build_loopback_redirect_uri(port: int) -> str:
+    """Return the Google OAuth loopback redirect URI for a local port."""
+    return LOOPBACK_REDIRECT_URI_TEMPLATE.format(
+        host=LOOPBACK_HOST,
+        port=port,
+    )
+
+
 @dataclass(frozen=True)
 class GoogleOAuthSession:
     """In-memory state for one Google OAuth PKCE flow."""
 
     state: str
     code_verifier: str
+
+
+@dataclass(frozen=True)
+class GoogleOAuthAuthorizeParams:
+    """Authorization request parameters for Google's browser OAuth endpoint."""
+
+    client_id: str
+    redirect_uri: str
+    scopes: Sequence[str]
+    state: str
+    code_challenge: str
+
+    def as_query_params(self) -> dict[str, str]:
+        """Return URL query parameters for Google's authorization endpoint."""
+        return {
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "response_type": OAUTH_RESPONSE_TYPE_CODE,
+            "scope": " ".join(self.scopes),
+            "state": self.state,
+            "code_challenge": self.code_challenge,
+            "code_challenge_method": OAUTH_CODE_CHALLENGE_METHOD_S256,
+            "access_type": OAUTH_ACCESS_TYPE_OFFLINE,
+            "prompt": OAUTH_PROMPT_CONSENT,
+            "include_granted_scopes": OAUTH_INCLUDE_GRANTED_SCOPES,
+        }
+
+    def to_query_string(self) -> str:
+        """Return encoded query parameters for Google's authorization endpoint."""
+        return urlencode(self.as_query_params())
+
+
+@dataclass(frozen=True)
+class GoogleOAuthTokenExchangeRequest:
+    """Token endpoint form data for exchanging an authorization code."""
+
+    client_id: str
+    code: str
+    code_verifier: str
+    redirect_uri: str
+    client_secret: str | None = None
+
+    def as_form_data(self) -> dict[str, str]:
+        """Return form data for Google's authorization-code exchange."""
+        data = {
+            "client_id": self.client_id,
+            "code": self.code,
+            "code_verifier": self.code_verifier,
+            "grant_type": OAUTH_GRANT_TYPE_AUTHORIZATION_CODE,
+            "redirect_uri": self.redirect_uri,
+        }
+        if self.client_secret:
+            data["client_secret"] = self.client_secret
+        return data
+
+
+@dataclass(frozen=True)
+class GoogleOAuthTokenRefreshRequest:
+    """Token endpoint form data for refreshing an access token."""
+
+    client_id: str
+    refresh_token: str
+    client_secret: str | None = None
+
+    def as_form_data(self) -> dict[str, str]:
+        """Return form data for Google's refresh-token grant."""
+        data = {
+            "client_id": self.client_id,
+            "grant_type": OAUTH_GRANT_TYPE_REFRESH_TOKEN,
+            "refresh_token": self.refresh_token,
+        }
+        if self.client_secret:
+            data["client_secret"] = self.client_secret
+        return data
 
 
 @dataclass(frozen=True)
@@ -175,7 +279,7 @@ class GoogleOAuthFlow:
         port = self._bound_redirect_port
         if port is None:
             port = self.redirect_port
-        return f"http://127.0.0.1:{port}"
+        return build_loopback_redirect_uri(port)
 
     @staticmethod
     def _build_code_challenge(code_verifier: str) -> str:
@@ -192,42 +296,33 @@ class GoogleOAuthFlow:
 
     def build_authorize_url(self, session: GoogleOAuthSession) -> str:
         """Build the Google OAuth authorization URL."""
-        query = urlencode(
-            {
-                "client_id": self.client_id,
-                "redirect_uri": self.redirect_uri,
-                "response_type": "code",
-                "scope": " ".join(self.scopes),
-                "state": session.state,
-                "code_challenge": self._build_code_challenge(session.code_verifier),
-                "code_challenge_method": "S256",
-                "access_type": "offline",
-                "prompt": "consent",
-                "include_granted_scopes": "true",
-            }
+        params = GoogleOAuthAuthorizeParams(
+            client_id=self.client_id,
+            redirect_uri=self.redirect_uri,
+            scopes=self.scopes,
+            state=session.state,
+            code_challenge=self._build_code_challenge(session.code_verifier),
         )
         logger.info(
-            "google_oauth_authorize_url_built",
+            LOG_GOOGLE_OAUTH_AUTHORIZE_URL_BUILT,
             redirect_uri=self.redirect_uri,
             scopes=self.scopes,
         )
-        return f"{AUTHORIZE_URL}?{query}"
+        return f"{AUTHORIZE_URL}?{params.to_query_string()}"
 
     def exchange_code(self, code: str, code_verifier: str) -> GoogleOAuthResult:
         """Exchange a Google authorization code for tokens."""
-        data = {
-            "client_id": self.client_id,
-            "code": code,
-            "code_verifier": code_verifier,
-            "grant_type": "authorization_code",
-            "redirect_uri": self.redirect_uri,
-        }
-        if self.client_secret:
-            data["client_secret"] = self.client_secret
+        request = GoogleOAuthTokenExchangeRequest(
+            client_id=self.client_id,
+            code=code,
+            code_verifier=code_verifier,
+            redirect_uri=self.redirect_uri,
+            client_secret=self.client_secret,
+        )
 
         response = self.requests.post(
             TOKEN_URL,
-            data=data,
+            data=request.as_form_data(),
             timeout=self.token_request_timeout,
         )
         payload = self._read_token_response(response, "exchange")
@@ -239,17 +334,15 @@ class GoogleOAuthFlow:
         if not normalized_refresh_token:
             raise GoogleOAuthError("Google OAuth refresh token is required.")
 
-        data = {
-            "client_id": self.client_id,
-            "grant_type": "refresh_token",
-            "refresh_token": normalized_refresh_token,
-        }
-        if self.client_secret:
-            data["client_secret"] = self.client_secret
+        request = GoogleOAuthTokenRefreshRequest(
+            client_id=self.client_id,
+            refresh_token=normalized_refresh_token,
+            client_secret=self.client_secret,
+        )
 
         response = self.requests.post(
             TOKEN_URL,
-            data=data,
+            data=request.as_form_data(),
             timeout=self.token_request_timeout,
         )
         payload = self._read_token_response(response, "refresh")
@@ -267,12 +360,12 @@ class GoogleOAuthFlow:
             browser_started = self.browser_opener(authorize_url)
         except Exception:
             server.server_close()
-            logger.error("google_oauth_browser_open_failed")
+            logger.error(LOG_GOOGLE_OAUTH_BROWSER_OPEN_FAILED)
             raise
 
         if browser_started is False:
             server.server_close()
-            logger.error("google_oauth_browser_open_failed")
+            logger.error(LOG_GOOGLE_OAUTH_BROWSER_OPEN_FAILED)
             raise GoogleOAuthError("Failed to open a browser for Google OAuth.")
 
         code = self._wait_for_callback(
@@ -295,7 +388,7 @@ class GoogleOAuthFlow:
         class CallbackHandler(BaseHTTPRequestHandler):
             def do_GET(self):  # type: ignore[override]
                 parsed = urlparse(self.path)
-                if parsed.path not in ("", "/", "/google/callback"):
+                if parsed.path not in CALLBACK_ACCEPTED_PATHS:
                     self.send_response(404)
                     self.end_headers()
                     self.wfile.write(b"Not found")
@@ -325,8 +418,8 @@ class GoogleOAuthFlow:
             def log_message(self, format, *args):  # noqa: A003
                 return
 
-        server = HTTPServer(("127.0.0.1", self.redirect_port), CallbackHandler)
-        server.timeout = 0.5
+        server = HTTPServer((LOOPBACK_HOST, self.redirect_port), CallbackHandler)
+        server.timeout = CALLBACK_SERVER_TIMEOUT_SECONDS
         self._bound_redirect_port = int(server.server_address[1])
 
         def serve_until_callback() -> None:
@@ -339,7 +432,7 @@ class GoogleOAuthFlow:
         thread = Thread(target=serve_until_callback, daemon=True)
         thread.start()
         logger.info(
-            "google_oauth_callback_listener_started",
+            LOG_GOOGLE_OAUTH_CALLBACK_LISTENER_STARTED,
             redirect_uri=self.redirect_uri,
         )
         return server, thread, callback_event, callback_data
@@ -355,7 +448,7 @@ class GoogleOAuthFlow:
         """Wait for the local callback and return the authorization code."""
         callback_event.wait(self.timeout)
         server.server_close()
-        thread.join(timeout=1)
+        thread.join(timeout=CALLBACK_THREAD_JOIN_TIMEOUT_SECONDS)
 
         if not callback_event.is_set():
             raise GoogleOAuthError("Google OAuth callback timed out.")

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
@@ -17,7 +17,12 @@ import webbrowser
 import requests
 
 from titan_cli.core.logging import get_logger
-from titan_cli.core.oauth import OAuthEventSink, OAuthRequest, OAuthTokenSet
+from titan_cli.core.oauth import (
+    OAuthEventSink,
+    OAuthRequest,
+    OAuthTokenInvalidError,
+    OAuthTokenSet,
+)
 
 
 AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
@@ -380,10 +385,14 @@ class GoogleOAuthFlow:
 
         if getattr(response, "status_code", 200) >= 400 or payload.get("error"):
             error = payload.get("error_description") or payload.get("error")
+            error_name = payload.get("error")
+            if operation == "refresh" and error_name == "invalid_grant":
+                raise OAuthTokenInvalidError(
+                    "Google OAuth refresh token is invalid or revoked."
+                )
             error_text = error.lower() if isinstance(error, str) else ""
-            if (
-                ("client_secret" in error_text or "client secret" in error_text)
-                and ("missing" in error_text or "invalid" in error_text)
+            if ("client_secret" in error_text or "client secret" in error_text) and (
+                "missing" in error_text or "invalid" in error_text
             ):
                 error = (
                     f"{error}. Enter the Client ID and Client Secret from the "

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
@@ -1,0 +1,486 @@
+"""Google OAuth helpers for Firebase Remote Config access."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from dataclasses import dataclass
+import hashlib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import secrets as secrets_module
+from threading import Event, Thread
+import time
+from typing import Callable
+from urllib.parse import parse_qs, urlencode, urlparse
+import webbrowser
+
+import requests
+
+from titan_cli.core.logging import get_logger
+from titan_cli.core.oauth import OAuthEventSink, OAuthRequest, OAuthTokenSet
+
+
+AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+logger = get_logger(__name__)
+
+CALLBACK_SUCCESS_HTML = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Titan Firebase Connection</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        background: #f6f7fb;
+        color: #182033;
+        font-family: system-ui, sans-serif;
+      }
+      main {
+        width: min(100%, 520px);
+        background: #ffffff;
+        border: 1px solid #d8deea;
+        border-radius: 16px;
+        padding: 28px;
+        box-shadow: 0 18px 50px rgba(24, 32, 51, 0.10);
+      }
+      h1 { margin: 0 0 10px; font-size: 28px; }
+      p { margin: 0; color: #5c667d; line-height: 1.55; }
+      .status { margin-top: 20px; color: #15803d; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Firebase connection received</h1>
+      <p>Titan has received the Google OAuth callback successfully.</p>
+      <p class="status">You can close this tab and return to Titan.</p>
+    </main>
+  </body>
+</html>
+""".encode("utf-8")
+
+CALLBACK_ERROR_HTML = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Titan Firebase Connection</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        background: #f6f7fb;
+        color: #182033;
+        font-family: system-ui, sans-serif;
+      }
+      main {
+        width: min(100%, 520px);
+        background: #ffffff;
+        border: 1px solid #d8deea;
+        border-radius: 16px;
+        padding: 28px;
+        box-shadow: 0 18px 50px rgba(24, 32, 51, 0.10);
+      }
+      h1 { margin: 0 0 10px; font-size: 28px; }
+      p { margin: 0; color: #5c667d; line-height: 1.55; }
+      .status { margin-top: 20px; color: #b91c1c; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Firebase connection failed</h1>
+      <p>Titan could not complete the Google OAuth callback.</p>
+      <p class="status">Return to Titan to see the error details.</p>
+    </main>
+  </body>
+</html>
+""".encode("utf-8")
+
+
+class GoogleOAuthError(Exception):
+    """Raised when Google OAuth cannot complete."""
+
+
+@dataclass(frozen=True)
+class GoogleOAuthSession:
+    """In-memory state for one Google OAuth PKCE flow."""
+
+    state: str
+    code_verifier: str
+
+
+@dataclass(frozen=True)
+class GoogleOAuthResult:
+    """Token data returned by Google's OAuth token endpoint."""
+
+    access_token: str
+    refresh_token: str | None
+    expires_in: int | None
+    token_type: str
+    granted_scopes: list[str]
+
+    @property
+    def expires_at(self) -> int | None:
+        """Return absolute expiry time in epoch seconds."""
+        if self.expires_in is None:
+            return None
+        return int(time.time()) + self.expires_in
+
+
+class GoogleOAuthFlow:
+    """Synchronous Google OAuth PKCE flow for installed applications."""
+
+    def __init__(
+        self,
+        client_id: str,
+        *,
+        client_secret: str | None = None,
+        redirect_port: int = 0,
+        scopes: list[str] | None = None,
+        timeout: int = 180,
+        token_request_timeout: int = 30,
+        browser_opener: Callable[[str], bool] | None = None,
+        requests_module=requests,
+    ) -> None:
+        self.client_id = client_id.strip()
+        self.client_secret = client_secret.strip() if client_secret else None
+        self.redirect_port = redirect_port
+        self.scopes = scopes or []
+        self.timeout = timeout
+        self.token_request_timeout = token_request_timeout
+        self.browser_opener = browser_opener or webbrowser.open
+        self.requests = requests_module
+        self._bound_redirect_port: int | None = None
+
+        if not self.client_id:
+            raise GoogleOAuthError("Google OAuth client ID is required.")
+
+    @property
+    def redirect_uri(self) -> str:
+        """Return the loopback redirect URI used for callback handling."""
+        port = self._bound_redirect_port
+        if port is None:
+            port = self.redirect_port
+        return f"http://127.0.0.1:{port}"
+
+    @staticmethod
+    def _build_code_challenge(code_verifier: str) -> str:
+        """Build a PKCE S256 code challenge from a verifier."""
+        digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+        return base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
+
+    def create_session(self) -> GoogleOAuthSession:
+        """Create a new OAuth session with state and PKCE verifier."""
+        return GoogleOAuthSession(
+            state=secrets_module.token_urlsafe(24),
+            code_verifier=secrets_module.token_urlsafe(48),
+        )
+
+    def build_authorize_url(self, session: GoogleOAuthSession) -> str:
+        """Build the Google OAuth authorization URL."""
+        query = urlencode(
+            {
+                "client_id": self.client_id,
+                "redirect_uri": self.redirect_uri,
+                "response_type": "code",
+                "scope": " ".join(self.scopes),
+                "state": session.state,
+                "code_challenge": self._build_code_challenge(session.code_verifier),
+                "code_challenge_method": "S256",
+                "access_type": "offline",
+                "prompt": "consent",
+                "include_granted_scopes": "true",
+            }
+        )
+        logger.info(
+            "google_oauth_authorize_url_built",
+            redirect_uri=self.redirect_uri,
+            scopes=self.scopes,
+        )
+        return f"{AUTHORIZE_URL}?{query}"
+
+    def exchange_code(self, code: str, code_verifier: str) -> GoogleOAuthResult:
+        """Exchange a Google authorization code for tokens."""
+        data = {
+            "client_id": self.client_id,
+            "code": code,
+            "code_verifier": code_verifier,
+            "grant_type": "authorization_code",
+            "redirect_uri": self.redirect_uri,
+        }
+        if self.client_secret:
+            data["client_secret"] = self.client_secret
+
+        response = self.requests.post(
+            TOKEN_URL,
+            data=data,
+            timeout=self.token_request_timeout,
+        )
+        payload = self._read_token_response(response, "exchange")
+        return self._build_oauth_result(payload, require_refresh_token=True)
+
+    def refresh_access_token(self, refresh_token: str) -> GoogleOAuthResult:
+        """Refresh a Google OAuth access token."""
+        normalized_refresh_token = refresh_token.strip() if refresh_token else ""
+        if not normalized_refresh_token:
+            raise GoogleOAuthError("Google OAuth refresh token is required.")
+
+        data = {
+            "client_id": self.client_id,
+            "grant_type": "refresh_token",
+            "refresh_token": normalized_refresh_token,
+        }
+        if self.client_secret:
+            data["client_secret"] = self.client_secret
+
+        response = self.requests.post(
+            TOKEN_URL,
+            data=data,
+            timeout=self.token_request_timeout,
+        )
+        payload = self._read_token_response(response, "refresh")
+        return self._build_oauth_result(payload, require_refresh_token=False)
+
+    def run(self) -> GoogleOAuthResult:
+        """Run the complete browser OAuth flow."""
+        session = self.create_session()
+        server, thread, callback_event, callback_data = self._start_callback_server(
+            session.state
+        )
+        authorize_url = self.build_authorize_url(session)
+
+        try:
+            browser_started = self.browser_opener(authorize_url)
+        except Exception:
+            server.server_close()
+            logger.error("google_oauth_browser_open_failed")
+            raise
+
+        if browser_started is False:
+            server.server_close()
+            logger.error("google_oauth_browser_open_failed")
+            raise GoogleOAuthError("Failed to open a browser for Google OAuth.")
+
+        code = self._wait_for_callback(
+            session.state,
+            server,
+            thread,
+            callback_event,
+            callback_data,
+        )
+        return self.exchange_code(code, session.code_verifier)
+
+    def _start_callback_server(
+        self,
+        expected_state: str,
+    ) -> tuple[HTTPServer, Thread, Event, dict[str, str]]:
+        """Bind and start the local OAuth callback listener."""
+        callback_event = Event()
+        callback_data: dict[str, str] = {}
+
+        class CallbackHandler(BaseHTTPRequestHandler):
+            def do_GET(self):  # type: ignore[override]
+                parsed = urlparse(self.path)
+                if parsed.path not in ("", "/", "/google/callback"):
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(b"Not found")
+                    return
+
+                query = parse_qs(parsed.query)
+                callback_data["code"] = query.get("code", [""])[0]
+                callback_data["state"] = query.get("state", [""])[0]
+                callback_data["error"] = query.get("error", [""])[0]
+                callback_succeeded = (
+                    not callback_data["error"]
+                    and callback_data["state"] == expected_state
+                    and bool(callback_data["code"])
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(
+                    CALLBACK_SUCCESS_HTML if callback_succeeded else CALLBACK_ERROR_HTML
+                )
+                callback_event.set()
+
+            def log_message(self, format, *args):  # noqa: A003
+                return
+
+        server = HTTPServer(("127.0.0.1", self.redirect_port), CallbackHandler)
+        server.timeout = 0.5
+        self._bound_redirect_port = int(server.server_address[1])
+
+        def serve_until_callback() -> None:
+            try:
+                while not callback_event.is_set():
+                    server.handle_request()
+            finally:
+                server.server_close()
+
+        thread = Thread(target=serve_until_callback, daemon=True)
+        thread.start()
+        logger.info(
+            "google_oauth_callback_listener_started",
+            redirect_uri=self.redirect_uri,
+        )
+        return server, thread, callback_event, callback_data
+
+    def _wait_for_callback(
+        self,
+        expected_state: str,
+        server: HTTPServer,
+        thread: Thread,
+        callback_event: Event,
+        callback_data: dict[str, str],
+    ) -> str:
+        """Wait for the local callback and return the authorization code."""
+        callback_event.wait(self.timeout)
+        server.server_close()
+        thread.join(timeout=1)
+
+        if not callback_event.is_set():
+            raise GoogleOAuthError("Google OAuth callback timed out.")
+
+        if callback_data.get("error"):
+            raise GoogleOAuthError(
+                f"Google OAuth authorization failed: {callback_data['error']}"
+            )
+
+        if callback_data.get("state") != expected_state:
+            raise GoogleOAuthError("Google OAuth state mismatch.")
+
+        code = callback_data.get("code")
+        if not code:
+            raise GoogleOAuthError(
+                "Google OAuth callback did not include an authorization code."
+            )
+        return code
+
+    def _read_token_response(self, response, operation: str) -> dict:
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise GoogleOAuthError(
+                f"Google OAuth {operation} response was not valid JSON."
+            ) from exc
+
+        if getattr(response, "status_code", 200) >= 400 or payload.get("error"):
+            error = payload.get("error_description") or payload.get("error")
+            error_text = error.lower() if isinstance(error, str) else ""
+            if (
+                ("client_secret" in error_text or "client secret" in error_text)
+                and ("missing" in error_text or "invalid" in error_text)
+            ):
+                error = (
+                    f"{error}. Enter the Client ID and Client Secret from the "
+                    "same Google OAuth Desktop app client."
+                )
+            raise GoogleOAuthError(
+                f"Google OAuth {operation} failed: {error or 'unknown_error'}"
+            )
+
+        return payload
+
+    def _build_oauth_result(
+        self,
+        payload: dict,
+        *,
+        require_refresh_token: bool,
+    ) -> GoogleOAuthResult:
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise GoogleOAuthError(
+                "Google OAuth response did not include an access token."
+            )
+
+        refresh_token = payload.get("refresh_token")
+        if require_refresh_token and not refresh_token:
+            raise GoogleOAuthError(
+                "Google OAuth response did not include a refresh token. "
+                "Verify the OAuth client is configured for installed apps and "
+                "that offline access consent was granted."
+            )
+
+        expires_in_raw = payload.get("expires_in")
+        expires_in = int(expires_in_raw) if expires_in_raw is not None else None
+        scope_string = payload.get("scope") or " ".join(self.scopes)
+        granted_scopes = [
+            scope.strip()
+            for scope in str(scope_string).split()
+            if scope.strip()
+        ]
+
+        return GoogleOAuthResult(
+            access_token=access_token.strip(),
+            refresh_token=(
+                refresh_token.strip() if isinstance(refresh_token, str) else None
+            ),
+            expires_in=expires_in,
+            token_type=str(payload.get("token_type") or "Bearer"),
+            granted_scopes=granted_scopes,
+        )
+
+
+class GoogleOAuthProvider:
+    """OAuthManager provider adapter for Google OAuth."""
+
+    def __init__(self, flow: GoogleOAuthFlow) -> None:
+        self.flow = flow
+
+    async def refresh(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        sink: OAuthEventSink,
+    ) -> OAuthTokenSet:
+        """Refresh a Google OAuth token set."""
+        if not token_set.refresh_token:
+            raise GoogleOAuthError("Google OAuth refresh token is required.")
+
+        result = await asyncio.to_thread(
+            self.flow.refresh_access_token,
+            token_set.refresh_token,
+        )
+        return self._to_token_set(
+            result,
+            request,
+            fallback_refresh_token=token_set.refresh_token,
+        )
+
+    async def authorize(
+        self,
+        request: OAuthRequest,
+        sink: OAuthEventSink,
+    ) -> OAuthTokenSet:
+        """Run an interactive Google OAuth login."""
+        result = await asyncio.to_thread(self.flow.run)
+        return self._to_token_set(result, request)
+
+    def _to_token_set(
+        self,
+        result: GoogleOAuthResult,
+        request: OAuthRequest,
+        *,
+        fallback_refresh_token: str | None = None,
+    ) -> OAuthTokenSet:
+        return OAuthTokenSet(
+            access_token=result.access_token,
+            refresh_token=result.refresh_token or fallback_refresh_token,
+            expires_at=result.expires_at,
+            token_type=result.token_type,
+            scopes=result.granted_scopes or request.scopes,
+            metadata={
+                "provider": "google",
+                "connection_id": request.connection_id,
+            },
+        )

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
@@ -10,7 +10,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import secrets as secrets_module
 from threading import Event, Thread
 import time
-from typing import Callable
+from typing import Callable, Sequence
 from urllib.parse import parse_qs, urlencode, urlparse
 import webbrowser
 
@@ -126,7 +126,7 @@ class GoogleOAuthResult:
     refresh_token: str | None
     expires_in: int | None
     token_type: str
-    granted_scopes: list[str]
+    granted_scopes: list[str] | None
 
     @property
     def expires_at(self) -> int | None:
@@ -417,12 +417,13 @@ class GoogleOAuthFlow:
 
         expires_in_raw = payload.get("expires_in")
         expires_in = int(expires_in_raw) if expires_in_raw is not None else None
-        scope_string = payload.get("scope") or " ".join(self.scopes)
-        granted_scopes = [
-            scope.strip()
-            for scope in str(scope_string).split()
-            if scope.strip()
-        ]
+        granted_scopes = None
+        if "scope" in payload:
+            granted_scopes = [
+                scope.strip()
+                for scope in str(payload.get("scope") or "").split()
+                if scope.strip()
+            ]
 
         return GoogleOAuthResult(
             access_token=access_token.strip(),
@@ -486,6 +487,7 @@ class GoogleOAuthProvider:
             result,
             request,
             fallback_refresh_token=token_set.refresh_token,
+            fallback_scopes=token_set.scopes,
         )
 
     async def authorize(
@@ -503,13 +505,18 @@ class GoogleOAuthProvider:
         request: OAuthRequest,
         *,
         fallback_refresh_token: str | None = None,
+        fallback_scopes: Sequence[str] | None = None,
     ) -> OAuthTokenSet:
         return OAuthTokenSet(
             access_token=result.access_token,
             refresh_token=result.refresh_token or fallback_refresh_token,
             expires_at=result.expires_at,
             token_type=result.token_type,
-            scopes=result.granted_scopes or request.scopes,
+            scopes=(
+                result.granted_scopes
+                if result.granted_scopes is not None
+                else (fallback_scopes or request.scopes)
+            ),
             metadata={
                 "provider": "google",
                 "connection_id": request.connection_id,

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/oauth.py
@@ -297,21 +297,25 @@ class GoogleOAuthFlow:
                     return
 
                 query = parse_qs(parsed.query)
-                callback_data["code"] = query.get("code", [""])[0]
-                callback_data["state"] = query.get("state", [""])[0]
-                callback_data["error"] = query.get("error", [""])[0]
-                callback_succeeded = (
-                    not callback_data["error"]
-                    and callback_data["state"] == expected_state
-                    and bool(callback_data["code"])
+                code = query.get("code", [""])[0]
+                state = query.get("state", [""])[0]
+                error = query.get("error", [""])[0]
+                status_code, body, completed = _resolve_callback_response(
+                    callback_data,
+                    code=code,
+                    state=state,
+                    error=error,
+                    expected_state=expected_state,
                 )
-                self.send_response(200)
+                self._send_callback_response(status_code, body)
+                if completed:
+                    callback_event.set()
+
+            def _send_callback_response(self, status_code: int, body: bytes) -> None:
+                self.send_response(status_code)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
                 self.end_headers()
-                self.wfile.write(
-                    CALLBACK_SUCCESS_HTML if callback_succeeded else CALLBACK_ERROR_HTML
-                )
-                callback_event.set()
+                self.wfile.write(body)
 
             def log_message(self, format, *args):  # noqa: A003
                 return
@@ -429,6 +433,33 @@ class GoogleOAuthFlow:
             token_type=str(payload.get("token_type") or "Bearer"),
             granted_scopes=granted_scopes,
         )
+
+
+def _resolve_callback_response(
+    callback_data: dict[str, str],
+    *,
+    code: str,
+    state: str,
+    error: str,
+    expected_state: str,
+) -> tuple[int, bytes, bool]:
+    """Return the loopback callback response without closing on invalid state."""
+    if state != expected_state:
+        return 400, CALLBACK_ERROR_HTML, False
+
+    if error:
+        callback_data["code"] = code
+        callback_data["state"] = state
+        callback_data["error"] = error
+        return 200, CALLBACK_ERROR_HTML, True
+
+    if not code:
+        return 400, CALLBACK_ERROR_HTML, False
+
+    callback_data["code"] = code
+    callback_data["state"] = state
+    callback_data["error"] = error
+    return 200, CALLBACK_SUCCESS_HTML, True
 
 
 class GoogleOAuthProvider:

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/__init__.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/__init__.py
@@ -1,0 +1,11 @@
+"""Firebase plugin operations."""
+
+from .remoteconfig_inventory import (
+    build_remote_config_inventory,
+    resolve_project_targets,
+)
+
+__all__ = [
+    "build_remote_config_inventory",
+    "resolve_project_targets",
+]

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/remoteconfig_inventory.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/remoteconfig_inventory.py
@@ -1,0 +1,397 @@
+"""Operations for building Firebase Remote Config inventories."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional
+
+from ..exceptions import FirebaseAuthRejectedError, FirebaseClientError
+from ..models import (
+    FirebaseProjectTarget,
+    RemoteConfigInventory,
+    RemoteConfigInventoryFailure,
+    RemoteConfigKeyInventory,
+    RemoteConfigKeyOccurrence,
+    RemoteConfigProjectInventory,
+    RemoteConfigValueType,
+    build_parameter_inventory,
+)
+
+if TYPE_CHECKING:
+    from ..client import FirebaseClient
+    from ..config import FirebasePluginConfig
+
+
+def resolve_project_targets(
+    config: FirebasePluginConfig,
+    *,
+    project_targets: Any = None,
+    projects: Any = None,
+    brand_projects: Optional[Mapping[str, Any]] = None,
+    brands: Any = None,
+    environments: Any = None,
+) -> list[FirebaseProjectTarget]:
+    """Resolve Firebase project targets from workflow inputs and plugin config."""
+    default_environment = config.default_environment
+    targets: list[FirebaseProjectTarget] = []
+
+    explicit_targets = project_targets if project_targets is not None else projects
+    if explicit_targets is None:
+        explicit_targets = config.projects
+    targets.extend(_targets_from_sequence(explicit_targets, default_environment))
+
+    raw_brand_projects = (
+        brand_projects if brand_projects is not None else config.brand_projects
+    )
+    targets.extend(
+        _targets_from_brand_mapping(
+            raw_brand_projects,
+            default_environment=default_environment,
+            layout=config.brand_projects_layout,
+        )
+    )
+
+    if not targets and config.default_project:
+        targets.append(
+            FirebaseProjectTarget(
+                project_id=config.default_project,
+                brand=config.default_project,
+                environment=default_environment,
+            )
+        )
+
+    return _filter_targets(
+        _dedupe_targets(targets),
+        brands=_as_filter_set(brands),
+        environments=_as_filter_set(environments),
+    )
+
+
+def build_remote_config_inventory(
+    client: FirebaseClient,
+    targets: Sequence[FirebaseProjectTarget],
+    *,
+    continue_on_error: bool = True,
+) -> RemoteConfigInventory:
+    """Read Remote Config templates and build an aggregated key inventory."""
+    if not targets:
+        raise FirebaseClientError("No Firebase project targets are configured.")
+
+    project_inventories: list[RemoteConfigProjectInventory] = []
+    failures: list[RemoteConfigInventoryFailure] = []
+
+    for target in targets:
+        try:
+            remote_config = client.get_remote_config(target.project_id)
+        except FirebaseAuthRejectedError:
+            raise
+        except FirebaseClientError as exc:
+            if not continue_on_error:
+                raise
+            failures.append(
+                RemoteConfigInventoryFailure(
+                    target=target,
+                    message=str(exc),
+                )
+            )
+            continue
+
+        project_inventories.append(
+            build_project_inventory(
+                target=target,
+                template=remote_config.template,
+                etag=remote_config.etag,
+            )
+        )
+
+    return RemoteConfigInventory(
+        targets=list(targets),
+        projects=project_inventories,
+        keys=build_key_inventory(project_inventories),
+        failures=failures,
+    )
+
+
+def build_project_inventory(
+    *,
+    target: FirebaseProjectTarget,
+    template: dict[str, Any],
+    etag: Optional[str],
+) -> RemoteConfigProjectInventory:
+    """Build normalized inventory for one Remote Config template."""
+    raw_parameters = template.get("parameters")
+    parameters_payload = raw_parameters if isinstance(raw_parameters, dict) else {}
+    parameters = {
+        key: build_parameter_inventory(key, payload if isinstance(payload, dict) else {})
+        for key, payload in sorted(parameters_payload.items())
+    }
+
+    version = template.get("version")
+    version_payload = version if isinstance(version, dict) else None
+    version_number = None
+    if version_payload and version_payload.get("versionNumber") is not None:
+        version_number = str(version_payload["versionNumber"])
+
+    return RemoteConfigProjectInventory(
+        target=target,
+        etag=etag,
+        version=version_payload,
+        version_number=version_number,
+        parameter_count=len(parameters),
+        parameters=parameters,
+    )
+
+
+def build_key_inventory(
+    projects: Sequence[RemoteConfigProjectInventory],
+) -> list[RemoteConfigKeyInventory]:
+    """Build unique key inventory across successful project reads."""
+    project_refs = [project.target.reference() for project in projects]
+    all_keys = sorted(
+        {
+            key
+            for project in projects
+            for key in project.parameters
+        }
+    )
+    inventories: list[RemoteConfigKeyInventory] = []
+
+    for key in all_keys:
+        occurrences: list[RemoteConfigKeyOccurrence] = []
+        present_refs: list[str] = []
+
+        for project in projects:
+            parameter = project.parameters.get(key)
+            if parameter is None:
+                continue
+
+            target = project.target
+            occurrences.append(
+                RemoteConfigKeyOccurrence(
+                    key=key,
+                    project_id=target.project_id,
+                    brand=target.brand,
+                    environment=target.environment,
+                    platform=target.platform,
+                    target_label=target.label,
+                    value_type=parameter.value_type,
+                    declared_value_type=parameter.declared_value_type,
+                    inferred_value_type=parameter.inferred_value_type,
+                    default_value=parameter.default_value,
+                    conditional_value_names=parameter.conditional_value_names,
+                    description=parameter.description,
+                )
+            )
+            present_refs.append(target.reference())
+
+        observed_types = _sort_value_types(
+            {occurrence.value_type for occurrence in occurrences}
+        )
+        inventories.append(
+            RemoteConfigKeyInventory(
+                key=key,
+                occurrences=occurrences,
+                projects_present=present_refs,
+                projects_missing=[
+                    project_ref
+                    for project_ref in project_refs
+                    if project_ref not in present_refs
+                ],
+                observed_types=observed_types,
+                has_type_mismatch=len(observed_types) > 1,
+            )
+        )
+
+    return inventories
+
+
+def _targets_from_sequence(
+    values: Any,
+    default_environment: Optional[str],
+) -> list[FirebaseProjectTarget]:
+    """Coerce a sequence of target declarations into project targets."""
+    if values is None:
+        return []
+    if isinstance(values, (str, Mapping, FirebaseProjectTarget)):
+        values = [values]
+    if not isinstance(values, Iterable):
+        return []
+
+    targets: list[FirebaseProjectTarget] = []
+    for item in values:
+        target = _target_from_value(item, default_environment=default_environment)
+        if target is not None:
+            targets.append(target)
+    return targets
+
+
+def _target_from_value(
+    value: Any,
+    *,
+    default_environment: Optional[str],
+    brand: Optional[str] = None,
+    environment: Optional[str] = None,
+) -> Optional[FirebaseProjectTarget]:
+    """Coerce one target declaration into a project target."""
+    if isinstance(value, FirebaseProjectTarget):
+        return _with_defaults(
+            value,
+            brand=brand,
+            environment=environment or default_environment,
+        )
+
+    if isinstance(value, str):
+        return FirebaseProjectTarget(
+            project_id=value,
+            brand=brand or value,
+            environment=environment or default_environment,
+        )
+
+    if not isinstance(value, Mapping):
+        return None
+
+    data = dict(value)
+    if "project" in data and "project_id" not in data:
+        data["project_id"] = data.pop("project")
+    if "env" in data and "environment" not in data:
+        data["environment"] = data.pop("env")
+    if "name" in data and "label" not in data:
+        data["label"] = data.pop("name")
+
+    if brand and "brand" not in data:
+        data["brand"] = brand
+    if environment and "environment" not in data:
+        data["environment"] = environment
+    if default_environment and "environment" not in data:
+        data["environment"] = default_environment
+
+    if "project_id" not in data:
+        return None
+
+    return FirebaseProjectTarget.model_validate(data)
+
+
+def _targets_from_brand_mapping(
+    values: Optional[Mapping[str, Any]],
+    *,
+    default_environment: Optional[str],
+    layout: str,
+) -> list[FirebaseProjectTarget]:
+    """Coerce a brand/environment mapping into project targets."""
+    if not values:
+        return []
+
+    targets: list[FirebaseProjectTarget] = []
+    for outer_key, outer_value in values.items():
+        target = _target_from_value(
+            outer_value,
+            default_environment=default_environment,
+            brand=outer_key,
+        )
+        if target is not None:
+            targets.append(target)
+            continue
+
+        if not isinstance(outer_value, Mapping):
+            continue
+
+        for inner_key, inner_value in outer_value.items():
+            if layout == "brand_environment":
+                brand = outer_key
+                environment = inner_key
+            else:
+                environment = outer_key
+                brand = inner_key
+
+            target = _target_from_value(
+                inner_value,
+                default_environment=default_environment,
+                brand=brand,
+                environment=environment,
+            )
+            if target is not None:
+                targets.append(target)
+
+    return targets
+
+
+def _with_defaults(
+    target: FirebaseProjectTarget,
+    *,
+    brand: Optional[str],
+    environment: Optional[str],
+) -> FirebaseProjectTarget:
+    """Return a target with optional defaults applied."""
+    data = target.model_dump()
+    if brand and not data.get("brand"):
+        data["brand"] = brand
+    if environment and not data.get("environment"):
+        data["environment"] = environment
+        data["label"] = None
+    return FirebaseProjectTarget.model_validate(data)
+
+
+def _dedupe_targets(
+    targets: Sequence[FirebaseProjectTarget],
+) -> list[FirebaseProjectTarget]:
+    """Remove duplicate project targets while preserving order."""
+    seen: set[tuple[Optional[str], Optional[str], Optional[str], str]] = set()
+    deduped: list[FirebaseProjectTarget] = []
+    for target in targets:
+        key = (
+            target.environment,
+            target.brand,
+            target.platform,
+            target.project_id,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(target)
+    return deduped
+
+
+def _filter_targets(
+    targets: Sequence[FirebaseProjectTarget],
+    *,
+    brands: Optional[set[str]],
+    environments: Optional[set[str]],
+) -> list[FirebaseProjectTarget]:
+    """Filter project targets by brand and environment names."""
+    filtered: list[FirebaseProjectTarget] = []
+    for target in targets:
+        if brands and (target.brand or "") not in brands:
+            continue
+        if environments and (target.environment or "") not in environments:
+            continue
+        filtered.append(target)
+    return filtered
+
+
+def _as_filter_set(value: Any) -> Optional[set[str]]:
+    """Normalize workflow filter values into a set."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        values = [part.strip() for part in value.split(",")]
+    elif isinstance(value, Iterable):
+        values = [str(part).strip() for part in value]
+    else:
+        values = [str(value).strip()]
+
+    normalized = {part for part in values if part}
+    return normalized or None
+
+
+def _sort_value_types(
+    value_types: set[RemoteConfigValueType],
+) -> list[RemoteConfigValueType]:
+    """Sort value types for deterministic inventories."""
+    order = {
+        RemoteConfigValueType.BOOLEAN: 0,
+        RemoteConfigValueType.JSON: 1,
+        RemoteConfigValueType.NUMBER: 2,
+        RemoteConfigValueType.STRING: 3,
+        RemoteConfigValueType.UNKNOWN: 4,
+    }
+    return sorted(value_types, key=lambda value_type: order[value_type])

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/remoteconfig_inventory.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/remoteconfig_inventory.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
+from pydantic import ValidationError
+
 from ..exceptions import FirebaseAuthRejectedError, FirebaseClientError
 from ..models import (
     FirebaseProjectTarget,
@@ -83,6 +85,11 @@ def build_remote_config_inventory(
     for target in targets:
         try:
             remote_config = client.get_remote_config(target.project_id)
+            project_inventory = build_project_inventory(
+                target=target,
+                template=remote_config.template,
+                etag=remote_config.etag,
+            )
         except FirebaseAuthRejectedError:
             raise
         except FirebaseClientError as exc:
@@ -96,13 +103,7 @@ def build_remote_config_inventory(
             )
             continue
 
-        project_inventories.append(
-            build_project_inventory(
-                target=target,
-                template=remote_config.template,
-                etag=remote_config.etag,
-            )
-        )
+        project_inventories.append(project_inventory)
 
     return RemoteConfigInventory(
         targets=list(targets),
@@ -119,18 +120,64 @@ def build_project_inventory(
     etag: Optional[str],
 ) -> RemoteConfigProjectInventory:
     """Build normalized inventory for one Remote Config template."""
+    if not isinstance(template, dict):
+        raise FirebaseClientError(
+            f"Remote Config template for {target.reference()} could not be "
+            "normalized: template must be a JSON object."
+        )
+
     raw_parameters = template.get("parameters")
-    parameters_payload = raw_parameters if isinstance(raw_parameters, dict) else {}
-    parameters = {
-        key: build_parameter_inventory(key, payload if isinstance(payload, dict) else {})
-        for key, payload in sorted(parameters_payload.items())
-    }
+    if raw_parameters is None:
+        parameters_payload = {}
+    elif isinstance(raw_parameters, dict):
+        parameters_payload = raw_parameters
+    else:
+        raise FirebaseClientError(
+            f"Remote Config template for {target.reference()} could not be "
+            "normalized: parameters must be a JSON object when present."
+        )
+
+    parameters = {}
+    for key, payload in sorted(parameters_payload.items()):
+        if not isinstance(payload, dict):
+            raise FirebaseClientError(
+                f"Remote Config parameter '{key}' for {target.reference()} "
+                "could not be normalized: parameter payload must be a JSON object."
+            )
+        try:
+            parameters[key] = build_parameter_inventory(
+                key,
+                payload,
+            )
+        except ValidationError as exc:
+            raise FirebaseClientError(
+                f"Remote Config parameter '{key}' for {target.reference()} "
+                f"could not be normalized: {_validation_error_summary(exc)}"
+            ) from exc
 
     version = template.get("version")
-    version_payload = version if isinstance(version, dict) else None
+    if version is None:
+        version_payload = None
+    elif isinstance(version, dict):
+        version_payload = version
+    else:
+        raise FirebaseClientError(
+            f"Remote Config template for {target.reference()} could not be "
+            "normalized: version must be a JSON object when present."
+        )
     version_number = None
     if version_payload and version_payload.get("versionNumber") is not None:
-        version_number = str(version_payload["versionNumber"])
+        raw_version_number = version_payload["versionNumber"]
+        if isinstance(raw_version_number, bool) or not isinstance(
+            raw_version_number,
+            (int, str),
+        ):
+            raise FirebaseClientError(
+                f"Remote Config template for {target.reference()} could not be "
+                "normalized: version.versionNumber must be a string or integer "
+                "when present."
+            )
+        version_number = str(raw_version_number)
 
     return RemoteConfigProjectInventory(
         target=target,
@@ -140,6 +187,17 @@ def build_project_inventory(
         parameter_count=len(parameters),
         parameters=parameters,
     )
+
+
+def _validation_error_summary(exc: ValidationError) -> str:
+    """Return a compact Pydantic validation error summary."""
+    errors = exc.errors()
+    if not errors:
+        return str(exc)
+    first_error = errors[0]
+    location = ".".join(str(part) for part in first_error.get("loc", ()))
+    message = str(first_error.get("msg") or exc)
+    return f"{location}: {message}" if location else message
 
 
 def build_key_inventory(

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/remoteconfig_inventory.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/operations/remoteconfig_inventory.py
@@ -62,10 +62,14 @@ def resolve_project_targets(
             )
         )
 
+    environment_aliases = _environment_alias_map(config.environments)
     return _filter_targets(
-        _dedupe_targets(targets),
+        _dedupe_targets(_normalize_target_environments(targets, environment_aliases)),
         brands=_as_filter_set(brands),
-        environments=_as_filter_set(environments),
+        environments=_as_filter_set(
+            environments,
+            aliases=environment_aliases,
+        ),
     )
 
 
@@ -426,7 +430,48 @@ def _filter_targets(
     return filtered
 
 
-def _as_filter_set(value: Any) -> Optional[set[str]]:
+def _environment_alias_map(environments: Sequence[Any]) -> dict[str, str]:
+    """Build a lookup from configured environment aliases to canonical names."""
+    aliases: dict[str, str] = {}
+    for environment in environments:
+        name = getattr(environment, "name", None)
+        if not isinstance(name, str) or not name.strip():
+            continue
+        canonical = name.strip()
+        for value in [canonical, *getattr(environment, "aliases", [])]:
+            if isinstance(value, str) and value.strip():
+                aliases[value.strip()] = canonical
+    return aliases
+
+
+def _normalize_target_environments(
+    targets: Sequence[FirebaseProjectTarget],
+    aliases: Mapping[str, str],
+) -> list[FirebaseProjectTarget]:
+    """Normalize target environments through configured aliases."""
+    if not aliases:
+        return list(targets)
+
+    normalized_targets: list[FirebaseProjectTarget] = []
+    for target in targets:
+        environment = target.environment
+        canonical = aliases.get(environment or "")
+        if not canonical or canonical == environment:
+            normalized_targets.append(target)
+            continue
+
+        data = target.model_dump()
+        data["environment"] = canonical
+        data["label"] = None
+        normalized_targets.append(FirebaseProjectTarget.model_validate(data))
+    return normalized_targets
+
+
+def _as_filter_set(
+    value: Any,
+    *,
+    aliases: Optional[Mapping[str, str]] = None,
+) -> Optional[set[str]]:
     """Normalize workflow filter values into a set."""
     if value is None:
         return None
@@ -437,7 +482,12 @@ def _as_filter_set(value: Any) -> Optional[set[str]]:
     else:
         values = [str(value).strip()]
 
-    normalized = {part for part in values if part}
+    alias_map = aliases or {}
+    normalized = {
+        alias_map.get(part, part)
+        for part in values
+        if part
+    }
     return normalized or None
 
 

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
@@ -73,9 +73,7 @@ class FirebasePlugin(TitanPlugin):
             oauth_client_secret = project_oauth_client_secret
         elif validated_config.oauth_client_id:
             oauth_client_id = validated_config.oauth_client_id
-            oauth_client_secret = (
-                validated_config.oauth_client_secret or project_oauth_client_secret
-            )
+            oauth_client_secret = validated_config.oauth_client_secret
             if (
                 oauth_client_secret is None
                 and generic_oauth_client_id == oauth_client_id

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
@@ -74,8 +74,7 @@ class FirebasePlugin(TitanPlugin):
         elif validated_config.oauth_client_id:
             oauth_client_id = validated_config.oauth_client_id
             oauth_client_secret = (
-                validated_config.oauth_client_secret
-                or project_oauth_client_secret
+                validated_config.oauth_client_secret or project_oauth_client_secret
             )
             if (
                 oauth_client_secret is None
@@ -200,12 +199,8 @@ class FirebasePlugin(TitanPlugin):
         return schema
 
     def is_available(self) -> bool:
-        """Return whether Firebase OAuth access is available."""
-        return (
-            hasattr(self, "_client")
-            and self._client is not None
-            and self._client.is_available()
-        )
+        """Return whether the Firebase client is initialized."""
+        return hasattr(self, "_client") and self._client is not None
 
     def get_client(self) -> FirebaseClient:
         """Return the initialized Firebase client."""

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
@@ -2,13 +2,22 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Optional
+
 from titan_cli.core.config import TitanConfig
+from titan_cli.core.oauth import OAuthManager
 from titan_cli.core.plugins.plugin_base import TitanPlugin
 from titan_cli.core.secrets import SecretManager
 
-from .client import FirebaseClient
+from .client import (
+    FirebaseClient,
+    OAUTH_CLIENT_ID_SECRET_KEY,
+    OAUTH_CLIENT_SECRET_KEY,
+)
 from .config import FirebasePluginConfig
 from .exceptions import FirebaseClientError, FirebaseConfigurationError
+from .oauth import GoogleOAuthFlow, GoogleOAuthProvider
 
 
 class FirebasePlugin(TitanPlugin):
@@ -24,7 +33,7 @@ class FirebasePlugin(TitanPlugin):
 
     @property
     def description(self) -> str:
-        return "Provides Firebase ADC auth and Remote Config access."
+        return "Provides Firebase OAuth auth and Remote Config access."
 
     @property
     def dependencies(self) -> list[str]:
@@ -38,7 +47,74 @@ class FirebasePlugin(TitanPlugin):
         except ValueError as exc:
             raise FirebaseConfigurationError(str(exc)) from exc
 
-        self._client = FirebaseClient(config=validated_config)
+        get_project_name = getattr(config, "get_project_name", None)
+        project_name = get_project_name() if callable(get_project_name) else None
+        if not isinstance(project_name, str) or not project_name.strip():
+            project_name = None
+
+        project_oauth_client_id = self._get_saved_oauth_client_id(
+            secrets,
+            project_name,
+            include_generic=False,
+        )
+        project_oauth_client_secret = self._get_saved_oauth_client_secret(
+            secrets,
+            project_name,
+            include_generic=False,
+        )
+        generic_oauth_client_id = self._get_saved_oauth_client_id(secrets, None)
+        generic_oauth_client_secret = self._get_saved_oauth_client_secret(
+            secrets,
+            None,
+        )
+
+        if project_oauth_client_id:
+            oauth_client_id = project_oauth_client_id
+            oauth_client_secret = project_oauth_client_secret
+        elif validated_config.oauth_client_id:
+            oauth_client_id = validated_config.oauth_client_id
+            oauth_client_secret = (
+                validated_config.oauth_client_secret
+                or project_oauth_client_secret
+            )
+            if (
+                oauth_client_secret is None
+                and generic_oauth_client_id == oauth_client_id
+            ):
+                oauth_client_secret = generic_oauth_client_secret
+        elif generic_oauth_client_id:
+            oauth_client_id = generic_oauth_client_id
+            oauth_client_secret = generic_oauth_client_secret
+        else:
+            oauth_client_id = None
+            oauth_client_secret = None
+        if oauth_client_id:
+            validated_config = validated_config.model_copy(
+                update={
+                    "oauth_client_id": oauth_client_id,
+                    "oauth_client_secret": oauth_client_secret,
+                }
+            )
+
+        oauth_providers = {}
+        if oauth_client_id:
+            oauth_providers["google"] = GoogleOAuthProvider(
+                GoogleOAuthFlow(
+                    client_id=oauth_client_id,
+                    client_secret=oauth_client_secret,
+                    redirect_port=validated_config.oauth_redirect_port,
+                    scopes=validated_config.oauth_scopes,
+                    timeout=validated_config.oauth_timeout,
+                    token_request_timeout=validated_config.request_timeout,
+                )
+            )
+
+        self._client = FirebaseClient(
+            config=validated_config,
+            secrets=secrets,
+            project_name=project_name,
+            oauth_manager=OAuthManager(secrets, providers=oauth_providers),
+        )
 
     def _get_plugin_config(self, config: TitanConfig) -> dict:
         """Extract Firebase plugin configuration from Titan config."""
@@ -48,13 +124,88 @@ class FirebasePlugin(TitanPlugin):
         plugin_entry = config.config.plugins["firebase"]
         return plugin_entry.config if hasattr(plugin_entry, "config") else {}
 
+    def _get_saved_oauth_client_id(
+        self,
+        secrets: SecretManager,
+        project_name: Optional[str],
+        *,
+        include_generic: bool = True,
+    ) -> Optional[str]:
+        """Return a Google OAuth client ID saved during interactive login."""
+        keys = []
+        if project_name:
+            keys.append(f"{project_name}_{OAUTH_CLIENT_ID_SECRET_KEY}")
+        if include_generic:
+            keys.append(OAUTH_CLIENT_ID_SECRET_KEY)
+
+        for key in keys:
+            value = secrets.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def _get_saved_oauth_client_secret(
+        self,
+        secrets: SecretManager,
+        project_name: Optional[str],
+        *,
+        include_generic: bool = True,
+    ) -> Optional[str]:
+        """Return a Google OAuth client secret saved during interactive login."""
+        keys = []
+        if project_name:
+            keys.append(f"{project_name}_{OAUTH_CLIENT_SECRET_KEY}")
+        if include_generic:
+            keys.append(OAUTH_CLIENT_SECRET_KEY)
+
+        for key in keys:
+            value = secrets.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
     def get_config_schema(self) -> dict:
         """Return the Firebase plugin JSON configuration schema."""
-        return FirebasePluginConfig.model_json_schema()
+        schema = FirebasePluginConfig.model_json_schema()
+        properties = schema.get("properties", {})
+        preferred_order = [
+            "oauth_client_id",
+            "oauth_client_secret",
+            "oauth_redirect_port",
+            "oauth_scopes",
+            "oauth_timeout",
+            "default_project",
+            "default_environment",
+            "projects",
+            "brand_projects",
+            "brand_projects_layout",
+            "api_base_url",
+            "request_timeout",
+            "access_token_env_var",
+            "access_token",
+        ]
+        ordered_properties = {
+            field_name: properties[field_name]
+            for field_name in preferred_order
+            if field_name in properties
+        }
+        ordered_properties.update(
+            {
+                field_name: field_info
+                for field_name, field_info in properties.items()
+                if field_name not in ordered_properties
+            }
+        )
+        schema["properties"] = ordered_properties
+        return schema
 
     def is_available(self) -> bool:
-        """Return whether Firebase ADC access is available."""
-        return hasattr(self, "_client") and self._client is not None and self._client.is_available()
+        """Return whether Firebase OAuth access is available."""
+        return (
+            hasattr(self, "_client")
+            and self._client is not None
+            and self._client.is_available()
+        )
 
     def get_client(self) -> FirebaseClient:
         """Return the initialized Firebase client."""
@@ -66,14 +217,25 @@ class FirebasePlugin(TitanPlugin):
 
     def get_steps(self) -> dict:
         """Return public workflow steps for the Firebase plugin."""
-        from .steps import (
+        from .steps.login_step import (
             execute_firebase_login_step,
-            execute_firebase_remoteconfig_get_step,
             execute_firebase_status_step,
+        )
+        from .steps.remoteconfig_get_step import execute_firebase_remoteconfig_get_step
+        from .steps.remoteconfig_inventory_step import (
+            execute_firebase_remoteconfig_inventory_step,
         )
 
         return {
             "firebase_login": execute_firebase_login_step,
             "firebase_status": execute_firebase_status_step,
             "firebase_remoteconfig_get": execute_firebase_remoteconfig_get_step,
+            "firebase_remoteconfig_inventory": (
+                execute_firebase_remoteconfig_inventory_step
+            ),
         }
+
+    @property
+    def workflows_path(self) -> Optional[Path]:
+        """Return the plugin workflows directory path."""
+        return Path(__file__).parent / "workflows"

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/plugin.py
@@ -1,0 +1,79 @@
+"""Titan CLI Firebase plugin."""
+
+from __future__ import annotations
+
+from titan_cli.core.config import TitanConfig
+from titan_cli.core.plugins.plugin_base import TitanPlugin
+from titan_cli.core.secrets import SecretManager
+
+from .client import FirebaseClient
+from .config import FirebasePluginConfig
+from .exceptions import FirebaseClientError, FirebaseConfigurationError
+
+
+class FirebasePlugin(TitanPlugin):
+    """Titan CLI plugin for Firebase operations."""
+
+    @property
+    def name(self) -> str:
+        return "firebase"
+
+    @property
+    def version(self) -> str:
+        return "0.1.0"
+
+    @property
+    def description(self) -> str:
+        return "Provides Firebase ADC auth and Remote Config access."
+
+    @property
+    def dependencies(self) -> list[str]:
+        return []
+
+    def initialize(self, config: TitanConfig, secrets: SecretManager) -> None:
+        """Initialize the Firebase client from merged Titan plugin config."""
+        plugin_config_data = self._get_plugin_config(config)
+        try:
+            validated_config = FirebasePluginConfig(**plugin_config_data)
+        except ValueError as exc:
+            raise FirebaseConfigurationError(str(exc)) from exc
+
+        self._client = FirebaseClient(config=validated_config)
+
+    def _get_plugin_config(self, config: TitanConfig) -> dict:
+        """Extract Firebase plugin configuration from Titan config."""
+        if "firebase" not in config.config.plugins:
+            return {}
+
+        plugin_entry = config.config.plugins["firebase"]
+        return plugin_entry.config if hasattr(plugin_entry, "config") else {}
+
+    def get_config_schema(self) -> dict:
+        """Return the Firebase plugin JSON configuration schema."""
+        return FirebasePluginConfig.model_json_schema()
+
+    def is_available(self) -> bool:
+        """Return whether Firebase ADC access is available."""
+        return hasattr(self, "_client") and self._client is not None and self._client.is_available()
+
+    def get_client(self) -> FirebaseClient:
+        """Return the initialized Firebase client."""
+        if not hasattr(self, "_client") or self._client is None:
+            raise FirebaseClientError(
+                "FirebasePlugin not initialized. Firebase client may not be available."
+            )
+        return self._client
+
+    def get_steps(self) -> dict:
+        """Return public workflow steps for the Firebase plugin."""
+        from .steps import (
+            execute_firebase_login_step,
+            execute_firebase_remoteconfig_get_step,
+            execute_firebase_status_step,
+        )
+
+        return {
+            "firebase_login": execute_firebase_login_step,
+            "firebase_status": execute_firebase_status_step,
+            "firebase_remoteconfig_get": execute_firebase_remoteconfig_get_step,
+        }

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/__init__.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/__init__.py
@@ -1,10 +1,26 @@
 """Public Firebase workflow steps."""
 
-from .login_step import execute_firebase_login_step, execute_firebase_status_step
-from .remoteconfig_get_step import execute_firebase_remoteconfig_get_step
+from __future__ import annotations
 
-__all__ = [
-    "execute_firebase_login_step",
-    "execute_firebase_remoteconfig_get_step",
-    "execute_firebase_status_step",
-]
+from importlib import import_module
+from typing import Any
+
+_STEP_EXPORTS = {
+    "execute_firebase_login_step": ".login_step",
+    "execute_firebase_status_step": ".login_step",
+    "execute_firebase_remoteconfig_get_step": ".remoteconfig_get_step",
+    "execute_firebase_remoteconfig_inventory_step": ".remoteconfig_inventory_step",
+}
+
+__all__ = list(_STEP_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose public step functions without eager cross-step imports."""
+    module_name = _STEP_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/__init__.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/__init__.py
@@ -1,0 +1,10 @@
+"""Public Firebase workflow steps."""
+
+from .login_step import execute_firebase_login_step, execute_firebase_status_step
+from .remoteconfig_get_step import execute_firebase_remoteconfig_get_step
+
+__all__ = [
+    "execute_firebase_login_step",
+    "execute_firebase_remoteconfig_get_step",
+    "execute_firebase_status_step",
+]

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/auth_retry.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/auth_retry.py
@@ -1,0 +1,36 @@
+"""Shared Firebase authentication retry helpers."""
+
+from __future__ import annotations
+
+from titan_cli.engine import Error, WorkflowContext
+
+from ..exceptions import FirebaseAuthRejectedError
+from .login_step import prompt_for_firebase_auth
+
+
+def reauthenticate_after_rejected_token(
+    ctx: WorkflowContext,
+    exc: FirebaseAuthRejectedError,
+) -> Error | None:
+    """Invalidate a rejected token source and prompt for fresh auth."""
+    invalidated = False
+    invalidator = getattr(ctx.firebase, "invalidate_access_token_source", None)
+    if callable(invalidator):
+        invalidated = bool(invalidator(exc.auth_source))
+
+    if ctx.textual:
+        if invalidated:
+            ctx.textual.warning_text("Saved Firebase auth was rejected.")
+        else:
+            ctx.textual.warning_text("Firebase auth was rejected.")
+
+    auth_available, auth_error, _oauth_attempted = prompt_for_firebase_auth(ctx)
+    if auth_error:
+        return auth_error
+    if not auth_available:
+        return Error(
+            "Firebase auth was rejected and no replacement credential was provided.",
+            exception=exc,
+            recoverable=True,
+        )
+    return None

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
@@ -236,8 +236,8 @@ def _prompt_and_save_access_token(ctx: WorkflowContext) -> Optional[Error]:
     """Prompt for a token and save it to Titan's OAuth token store."""
     _warning(
         ctx,
-        "Firebase browser OAuth is not configured. Paste an OAuth access token "
-        "to continue.",
+        "Firebase browser OAuth is not configured or did not complete. Paste an "
+        "OAuth access token to continue.",
     )
     token = _ask_for_access_token(ctx)
     if not token:
@@ -262,10 +262,7 @@ def _is_oauth_client_secret_error(exc: Exception) -> bool:
     """Return whether Google rejected the OAuth client secret at token exchange."""
     message = str(exc).lower()
     mentions_secret = "client_secret" in message or "client secret" in message
-    return mentions_secret and (
-        "missing" in message
-        or "invalid" in message
-    )
+    return mentions_secret and ("missing" in message or "invalid" in message)
 
 
 def _try_interactive_oauth(
@@ -294,13 +291,22 @@ def _try_interactive_oauth(
                 "app OAuth client.",
             )
             return True, None, True
-        return True, Error(str(exc), exception=exc, recoverable=True), False
+        _warning(
+            ctx,
+            f"Firebase browser OAuth did not complete: {exc}. "
+            "You can paste a temporary access token instead.",
+        )
+        return True, None, False
     except Exception as exc:
-        return True, Error(
-            f"Firebase Google OAuth login failed: {exc}",
-            exception=exc,
-            recoverable=True,
-        ), False
+        return (
+            True,
+            Error(
+                f"Firebase Google OAuth login failed: {exc}",
+                exception=exc,
+                recoverable=True,
+            ),
+            False,
+        )
 
     return True, None, False
 
@@ -310,22 +316,24 @@ def prompt_for_firebase_auth(
 ) -> tuple[bool, Optional[Error], bool]:
     """Prompt for browser OAuth or a manual token and return auth status."""
     oauth_sink = _WorkflowOAuthSink(ctx)
-    oauth_attempted_any = False
 
     for _attempt in range(3):
         oauth_attempted, oauth_error, client_id_rejected = _try_interactive_oauth(
             ctx,
             oauth_sink,
         )
-        oauth_attempted_any = oauth_attempted_any or oauth_attempted
         if oauth_error:
-            return False, oauth_error, oauth_attempted_any
+            return False, oauth_error, False
 
-        if oauth_attempted and not client_id_rejected and _is_available(
-            ctx,
-            oauth_sink,
+        if (
+            oauth_attempted
+            and not client_id_rejected
+            and _is_available(
+                ctx,
+                oauth_sink,
+            )
         ):
-            return True, None, oauth_attempted_any
+            return True, None, True
 
         oauth_client_id = getattr(ctx.firebase.config, "oauth_client_id", None)
         if oauth_client_id and not client_id_rejected:
@@ -333,15 +341,15 @@ def prompt_for_firebase_auth(
 
         oauth_config_error = _prompt_and_configure_oauth_client_id(ctx)
         if oauth_config_error:
-            return False, oauth_config_error, oauth_attempted_any
+            return False, oauth_config_error, False
         if not getattr(ctx.firebase.config, "oauth_client_id", None):
             break
 
     prompt_error = _prompt_and_save_access_token(ctx)
     if prompt_error:
-        return False, prompt_error, oauth_attempted_any
+        return False, prompt_error, False
 
-    return _is_available(ctx, oauth_sink), None, oauth_attempted_any
+    return _is_available(ctx, oauth_sink), None, False
 
 
 def _check_auth(
@@ -385,7 +393,9 @@ def _check_auth(
         )
 
     if prompt_for_missing_auth:
-        auth_available, auth_error, oauth_attempted = prompt_for_firebase_auth(ctx)
+        auth_available, auth_error, oauth_login_completed = prompt_for_firebase_auth(
+            ctx
+        )
         if auth_error:
             _error(ctx, auth_error.message)
             _end(ctx, "error")
@@ -396,7 +406,7 @@ def _check_auth(
                 ctx,
                 login_command=login_command,
                 token_saved=True,
-                oauth_login_completed=oauth_attempted,
+                oauth_login_completed=oauth_login_completed,
             )
 
     message = (

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
@@ -187,7 +187,9 @@ def _ask_for_oauth_client_secret(ctx: WorkflowContext) -> Optional[str]:
     return normalized or None
 
 
-def _prompt_and_configure_oauth_client_id(ctx: WorkflowContext) -> Optional[Error]:
+def _prompt_and_configure_oauth_client_id(
+    ctx: WorkflowContext,
+) -> tuple[bool, Optional[Error]]:
     """Prompt for and save the Google OAuth client ID when missing."""
     _warning(
         ctx,
@@ -197,7 +199,7 @@ def _prompt_and_configure_oauth_client_id(ctx: WorkflowContext) -> Optional[Erro
     )
     client_id = _ask_for_oauth_client_id(ctx)
     if not client_id:
-        return None
+        return False, None
 
     client_secret = _ask_for_oauth_client_secret(ctx)
     if not client_secret:
@@ -215,21 +217,27 @@ def _prompt_and_configure_oauth_client_id(ctx: WorkflowContext) -> Optional[Erro
         elif callable(configurer):
             configurer(client_id, client_secret=client_secret)
         else:
-            return Error(
-                "Firebase client cannot configure Google OAuth dynamically.",
-                recoverable=True,
+            return (
+                False,
+                Error(
+                    "Firebase client cannot configure Google OAuth dynamically.",
+                    recoverable=True,
+                ),
             )
     except FirebaseClientError as exc:
-        return Error(str(exc), exception=exc, recoverable=True)
+        return False, Error(str(exc), exception=exc, recoverable=True)
     except Exception as exc:
-        return Error(
-            f"Could not configure Firebase browser OAuth: {exc}",
-            exception=exc,
-            recoverable=True,
+        return (
+            False,
+            Error(
+                f"Could not configure Firebase browser OAuth: {exc}",
+                exception=exc,
+                recoverable=True,
+            ),
         )
 
     _success(ctx, "Firebase browser OAuth configured")
-    return None
+    return True, None
 
 
 def _prompt_and_save_access_token(ctx: WorkflowContext) -> Optional[Error]:
@@ -339,10 +347,12 @@ def prompt_for_firebase_auth(
         if oauth_client_id and not client_id_rejected:
             break
 
-        oauth_config_error = _prompt_and_configure_oauth_client_id(ctx)
+        oauth_configured, oauth_config_error = _prompt_and_configure_oauth_client_id(
+            ctx
+        )
         if oauth_config_error:
             return False, oauth_config_error, False
-        if not getattr(ctx.firebase.config, "oauth_client_id", None):
+        if not oauth_configured:
             break
 
     prompt_error = _prompt_and_save_access_token(ctx)

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
@@ -11,6 +11,9 @@ from titan_cli.engine import Error, Skip, Success, WorkflowContext, WorkflowResu
 
 from ..exceptions import FirebaseClientError
 
+_TRUE_BOOLEAN_STRINGS = {"1", "true", "yes", "y", "on"}
+_FALSE_BOOLEAN_STRINGS = {"0", "false", "no", "n", "off"}
+
 
 class _WorkflowOAuthSink:
     """Adapts provider-neutral OAuth events to the current workflow context."""
@@ -54,6 +57,33 @@ def _error(ctx: WorkflowContext, message: str) -> None:
         ctx.textual.error_text(message)
 
 
+def _get_workflow_bool(
+    ctx: WorkflowContext,
+    key: str,
+    *,
+    default: bool,
+) -> bool:
+    """Return a strict workflow boolean from ctx.data."""
+    if not ctx.has(key):
+        return default
+
+    value = ctx.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_BOOLEAN_STRINGS:
+            return True
+        if normalized in _FALSE_BOOLEAN_STRINGS:
+            return False
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+
+    raise ValueError(
+        f"{key} must be a boolean or one of: true/false, yes/no, on/off, 1/0."
+    )
+
+
 def _get_auth_source_label(ctx: WorkflowContext) -> Optional[str]:
     """Return a safe label for the current Firebase auth source."""
     source_getter = getattr(ctx.firebase, "get_access_token_source_label", None)
@@ -74,23 +104,19 @@ def _is_available(ctx: WorkflowContext, sink: _WorkflowOAuthSink) -> bool:
 def _auth_success(
     ctx: WorkflowContext,
     *,
-    account: Optional[str],
     login_command: str,
     token_saved: bool = False,
     oauth_login_completed: bool = False,
 ) -> Success:
     """Render and return a successful Firebase auth result."""
-    account_label = (
-        _get_auth_source_label(ctx)
-        or account
-        or ctx.firebase.config.access_token_env_var
-    )
-    _success(ctx, f"Firebase auth available via {account_label}")
+    auth_source_label = _get_auth_source_label(ctx) or "configured Firebase auth"
+    _success(ctx, f"Firebase auth available via {auth_source_label}")
     _end(ctx, "success")
     return Success(
         "Firebase auth available",
         metadata={
-            "firebase_account": account,
+            "firebase_account": None,
+            "firebase_auth_source": auth_source_label,
             "firebase_login_command": login_command,
             "firebase_access_token_saved": token_saved,
             "firebase_oauth_login_completed": oauth_login_completed,
@@ -333,21 +359,31 @@ def _check_auth(
         _end(ctx, "error")
         return Error(message)
 
-    account = ctx.firebase.get_active_account()
     login_command = ctx.firebase.get_login_command()
     oauth_sink = _WorkflowOAuthSink(ctx)
+    try:
+        prompt_for_missing_auth = _get_workflow_bool(
+            ctx,
+            "prompt_for_missing_auth",
+            default=prompt_for_missing_auth_default,
+        )
+        fail_on_missing_auth = _get_workflow_bool(
+            ctx,
+            "fail_on_missing_auth",
+            default=True,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        _error(ctx, message)
+        _end(ctx, "error")
+        return Error(message, recoverable=True)
 
     if _is_available(ctx, oauth_sink):
         return _auth_success(
             ctx,
-            account=account,
             login_command=login_command,
         )
 
-    prompt_for_missing_auth = ctx.get(
-        "prompt_for_missing_auth",
-        prompt_for_missing_auth_default,
-    )
     if prompt_for_missing_auth:
         auth_available, auth_error, oauth_attempted = prompt_for_firebase_auth(ctx)
         if auth_error:
@@ -358,7 +394,6 @@ def _check_auth(
         if auth_available:
             return _auth_success(
                 ctx,
-                account=account,
                 login_command=login_command,
                 token_saved=True,
                 oauth_login_completed=oauth_attempted,
@@ -368,7 +403,6 @@ def _check_auth(
         "Firebase auth not available. Configure Firebase oauth_client_id, set "
         f"{ctx.firebase.config.access_token_env_var}, or run: {login_command}"
     )
-    fail_on_missing_auth = ctx.get("fail_on_missing_auth", True)
     if fail_on_missing_auth:
         _error(ctx, message)
         _end(ctx, "error")
@@ -379,7 +413,8 @@ def _check_auth(
     return Skip(
         message,
         metadata={
-            "firebase_account": account,
+            "firebase_account": None,
+            "firebase_auth_source": None,
             "firebase_login_command": login_command,
             "firebase_access_token_saved": False,
             "firebase_oauth_login_completed": False,
@@ -399,7 +434,8 @@ def execute_firebase_login_step(ctx: WorkflowContext) -> WorkflowResult:
         prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to True.
 
     Outputs (saved to ctx.data):
-        firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.
+        firebase_account (Optional[str]): Reserved until Firebase token identity can be resolved; currently None.
+        firebase_auth_source (Optional[str]): Safe source label for the token Titan will use.
         firebase_login_command (str): Command the user can run to create an ADC session.
         firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.
         firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login.
@@ -428,7 +464,8 @@ def execute_firebase_status_step(ctx: WorkflowContext) -> WorkflowResult:
         prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to False.
 
     Outputs (saved to ctx.data):
-        firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.
+        firebase_account (Optional[str]): Reserved until Firebase token identity can be resolved; currently None.
+        firebase_auth_source (Optional[str]): Safe source label for the token Titan will use.
         firebase_login_command (str): Command the user can run to create an ADC session.
         firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.
         firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login.

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
@@ -1,0 +1,120 @@
+"""Firebase ADC authentication workflow steps."""
+
+from __future__ import annotations
+
+from titan_cli.engine import Error, Skip, Success, WorkflowContext, WorkflowResult
+
+
+def _begin(ctx: WorkflowContext, title: str) -> None:
+    if ctx.textual:
+        ctx.textual.begin_step(title)
+
+
+def _end(ctx: WorkflowContext, status: str) -> None:
+    if ctx.textual:
+        ctx.textual.end_step(status)
+
+
+def _success(ctx: WorkflowContext, message: str) -> None:
+    if ctx.textual:
+        ctx.textual.success_text(message)
+
+
+def _warning(ctx: WorkflowContext, message: str) -> None:
+    if ctx.textual:
+        ctx.textual.warning_text(message)
+
+
+def _error(ctx: WorkflowContext, message: str) -> None:
+    if ctx.textual:
+        ctx.textual.error_text(message)
+
+
+def _check_adc(ctx: WorkflowContext, title: str) -> WorkflowResult:
+    """Shared implementation for Firebase ADC login/status checks."""
+    _begin(ctx, title)
+
+    if not ctx.firebase:
+        message = "Firebase client not available"
+        _error(ctx, message)
+        _end(ctx, "error")
+        return Error(message)
+
+    account = ctx.firebase.get_active_account()
+    login_command = ctx.firebase.get_login_command()
+
+    if ctx.firebase.is_available():
+        account_label = account or "unknown gcloud account"
+        _success(ctx, f"Firebase ADC session available for {account_label}")
+        _end(ctx, "success")
+        return Success(
+            "Firebase ADC session available",
+            metadata={
+                "firebase_account": account,
+                "firebase_login_command": login_command,
+            },
+        )
+
+    message = (
+        "Firebase ADC session not available. Run: "
+        f"{login_command}"
+    )
+    fail_on_missing_auth = ctx.get("fail_on_missing_auth", True)
+    if fail_on_missing_auth:
+        _error(ctx, message)
+        _end(ctx, "error")
+        return Error(message, recoverable=True)
+
+    _warning(ctx, message)
+    _end(ctx, "skip")
+    return Skip(
+        message,
+        metadata={
+            "firebase_account": account,
+            "firebase_login_command": login_command,
+        },
+    )
+
+
+def execute_firebase_login_step(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    Validate that the current user has a Firebase ADC session.
+
+    Requires:
+        ctx.firebase: An initialized FirebaseClient.
+
+    Inputs (from ctx.data):
+        fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True.
+
+    Outputs (saved to ctx.data):
+        firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.
+        firebase_login_command (str): Command the user can run to create an ADC session.
+
+    Returns:
+        Success: If gcloud ADC is available.
+        Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.
+        Skip: If ADC auth is missing and fail_on_missing_auth is False.
+    """
+    return _check_adc(ctx, "Firebase ADC Login")
+
+
+def execute_firebase_status_step(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    Report the current Firebase ADC authentication status.
+
+    Requires:
+        ctx.firebase: An initialized FirebaseClient.
+
+    Inputs (from ctx.data):
+        fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True.
+
+    Outputs (saved to ctx.data):
+        firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.
+        firebase_login_command (str): Command the user can run to create an ADC session.
+
+    Returns:
+        Success: If gcloud ADC is available.
+        Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.
+        Skip: If ADC auth is missing and fail_on_missing_auth is False.
+    """
+    return _check_adc(ctx, "Firebase ADC Status")

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/login_step.py
@@ -1,8 +1,32 @@
-"""Firebase ADC authentication workflow steps."""
+"""Firebase authentication workflow steps."""
 
 from __future__ import annotations
 
+import getpass
+import sys
+from typing import Optional
+
+from titan_cli.core.oauth import OAuthEvent
 from titan_cli.engine import Error, Skip, Success, WorkflowContext, WorkflowResult
+
+from ..exceptions import FirebaseClientError
+
+
+class _WorkflowOAuthSink:
+    """Adapts provider-neutral OAuth events to the current workflow context."""
+
+    def __init__(self, ctx: WorkflowContext) -> None:
+        self.ctx = ctx
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Render only user-relevant OAuth events."""
+        if not self.ctx.textual:
+            return
+
+        if event.type in {"oauth.refresh.started", "oauth.authorize.started"}:
+            self.ctx.textual.dim_text(event.message)
+        elif event.type == "oauth.storage.saved":
+            self.ctx.textual.dim_text("OAuth credential saved in Titan OAuth store")
 
 
 def _begin(ctx: WorkflowContext, title: str) -> None:
@@ -30,8 +54,277 @@ def _error(ctx: WorkflowContext, message: str) -> None:
         ctx.textual.error_text(message)
 
 
-def _check_adc(ctx: WorkflowContext, title: str) -> WorkflowResult:
-    """Shared implementation for Firebase ADC login/status checks."""
+def _get_auth_source_label(ctx: WorkflowContext) -> Optional[str]:
+    """Return a safe label for the current Firebase auth source."""
+    source_getter = getattr(ctx.firebase, "get_access_token_source_label", None)
+    source_label = source_getter() if callable(source_getter) else None
+    if isinstance(source_label, str) and source_label.strip():
+        return source_label
+    return None
+
+
+def _is_available(ctx: WorkflowContext, sink: _WorkflowOAuthSink) -> bool:
+    """Return auth availability while supporting older Firebase client doubles."""
+    try:
+        return bool(ctx.firebase.is_available(sink=sink))
+    except TypeError:
+        return bool(ctx.firebase.is_available())
+
+
+def _auth_success(
+    ctx: WorkflowContext,
+    *,
+    account: Optional[str],
+    login_command: str,
+    token_saved: bool = False,
+    oauth_login_completed: bool = False,
+) -> Success:
+    """Render and return a successful Firebase auth result."""
+    account_label = (
+        _get_auth_source_label(ctx)
+        or account
+        or ctx.firebase.config.access_token_env_var
+    )
+    _success(ctx, f"Firebase auth available via {account_label}")
+    _end(ctx, "success")
+    return Success(
+        "Firebase auth available",
+        metadata={
+            "firebase_account": account,
+            "firebase_login_command": login_command,
+            "firebase_access_token_saved": token_saved,
+            "firebase_oauth_login_completed": oauth_login_completed,
+        },
+    )
+
+
+def _ask_for_access_token(ctx: WorkflowContext) -> Optional[str]:
+    """Ask the user for a Firebase OAuth access token in an interactive session."""
+    question = "Firebase access token (saved to Titan OAuth store)"
+    try:
+        if ctx.textual and hasattr(ctx.textual, "ask_password"):
+            token = ctx.textual.ask_password(question)
+        elif sys.stdin.isatty():
+            token = getpass.getpass(f"{question}: ")
+        else:
+            return None
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+    if not isinstance(token, str):
+        return None
+    normalized = token.strip()
+    return normalized or None
+
+
+def _ask_for_oauth_client_id(ctx: WorkflowContext) -> Optional[str]:
+    """Ask the user for a Google OAuth client ID in an interactive session."""
+    question = (
+        "Google OAuth Desktop app client ID for Titan Firebase login "
+        "(saved to Titan keyring)"
+    )
+    try:
+        if ctx.textual and hasattr(ctx.textual, "ask_text"):
+            client_id = ctx.textual.ask_text(question, default="")
+        elif sys.stdin.isatty():
+            client_id = input(f"{question}: ")
+        else:
+            return None
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+    if not isinstance(client_id, str):
+        return None
+    normalized = client_id.strip()
+    return normalized or None
+
+
+def _ask_for_oauth_client_secret(ctx: WorkflowContext) -> Optional[str]:
+    """Ask the user for a Google OAuth client secret in an interactive session."""
+    question = (
+        "Google OAuth Desktop app client secret for Titan Firebase login "
+        "(saved to Titan keyring)"
+    )
+    try:
+        if ctx.textual and hasattr(ctx.textual, "ask_password"):
+            client_secret = ctx.textual.ask_password(question)
+        elif sys.stdin.isatty():
+            client_secret = getpass.getpass(f"{question}: ")
+        else:
+            return None
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+    if not isinstance(client_secret, str):
+        return None
+    normalized = client_secret.strip()
+    return normalized or None
+
+
+def _prompt_and_configure_oauth_client_id(ctx: WorkflowContext) -> Optional[Error]:
+    """Prompt for and save the Google OAuth client ID when missing."""
+    _warning(
+        ctx,
+        "Firebase browser OAuth is not configured. Enter a Google OAuth "
+        "Desktop app client ID and client secret for Titan CLI to open Google "
+        "login, or leave the Client ID blank to paste a temporary access token.",
+    )
+    client_id = _ask_for_oauth_client_id(ctx)
+    if not client_id:
+        return None
+
+    client_secret = _ask_for_oauth_client_secret(ctx)
+    if not client_secret:
+        _warning(
+            ctx,
+            "Google may reject the token exchange without the Desktop app "
+            "client secret.",
+        )
+
+    saver = getattr(ctx.firebase, "save_oauth_client_id", None)
+    configurer = getattr(ctx.firebase, "configure_google_oauth", None)
+    try:
+        if callable(saver):
+            saver(client_id, client_secret=client_secret)
+        elif callable(configurer):
+            configurer(client_id, client_secret=client_secret)
+        else:
+            return Error(
+                "Firebase client cannot configure Google OAuth dynamically.",
+                recoverable=True,
+            )
+    except FirebaseClientError as exc:
+        return Error(str(exc), exception=exc, recoverable=True)
+    except Exception as exc:
+        return Error(
+            f"Could not configure Firebase browser OAuth: {exc}",
+            exception=exc,
+            recoverable=True,
+        )
+
+    _success(ctx, "Firebase browser OAuth configured")
+    return None
+
+
+def _prompt_and_save_access_token(ctx: WorkflowContext) -> Optional[Error]:
+    """Prompt for a token and save it to Titan's OAuth token store."""
+    _warning(
+        ctx,
+        "Firebase browser OAuth is not configured. Paste an OAuth access token "
+        "to continue.",
+    )
+    token = _ask_for_access_token(ctx)
+    if not token:
+        return None
+
+    try:
+        ctx.firebase.save_access_token(token)
+    except FirebaseClientError as exc:
+        return Error(str(exc), exception=exc, recoverable=True)
+    except Exception as exc:
+        return Error(
+            f"Could not save Firebase access token: {exc}",
+            exception=exc,
+            recoverable=True,
+        )
+
+    _success(ctx, "Firebase access token saved in Titan OAuth store")
+    return None
+
+
+def _is_oauth_client_secret_error(exc: Exception) -> bool:
+    """Return whether Google rejected the OAuth client secret at token exchange."""
+    message = str(exc).lower()
+    mentions_secret = "client_secret" in message or "client secret" in message
+    return mentions_secret and (
+        "missing" in message
+        or "invalid" in message
+    )
+
+
+def _try_interactive_oauth(
+    ctx: WorkflowContext,
+    sink: _WorkflowOAuthSink,
+) -> tuple[bool, Optional[Error], bool]:
+    """Run browser OAuth when the Firebase client is configured for it."""
+    oauth_client_id = getattr(ctx.firebase.config, "oauth_client_id", None)
+    if not oauth_client_id:
+        return False, None, False
+
+    _warning(ctx, "Firebase auth not available. Opening browser for Google login.")
+    token_getter = getattr(ctx.firebase, "get_access_token", None)
+    if not callable(token_getter):
+        return False, None, False
+
+    try:
+        token_getter(sink=sink, interactive=True)
+    except FirebaseClientError as exc:
+        if _is_oauth_client_secret_error(exc):
+            _warning(
+                ctx,
+                "Google accepted the browser login, but rejected the token "
+                "exchange because the OAuth client secret is missing or invalid. "
+                "Enter the Client ID and Client Secret from the same Desktop "
+                "app OAuth client.",
+            )
+            return True, None, True
+        return True, Error(str(exc), exception=exc, recoverable=True), False
+    except Exception as exc:
+        return True, Error(
+            f"Firebase Google OAuth login failed: {exc}",
+            exception=exc,
+            recoverable=True,
+        ), False
+
+    return True, None, False
+
+
+def prompt_for_firebase_auth(
+    ctx: WorkflowContext,
+) -> tuple[bool, Optional[Error], bool]:
+    """Prompt for browser OAuth or a manual token and return auth status."""
+    oauth_sink = _WorkflowOAuthSink(ctx)
+    oauth_attempted_any = False
+
+    for _attempt in range(3):
+        oauth_attempted, oauth_error, client_id_rejected = _try_interactive_oauth(
+            ctx,
+            oauth_sink,
+        )
+        oauth_attempted_any = oauth_attempted_any or oauth_attempted
+        if oauth_error:
+            return False, oauth_error, oauth_attempted_any
+
+        if oauth_attempted and not client_id_rejected and _is_available(
+            ctx,
+            oauth_sink,
+        ):
+            return True, None, oauth_attempted_any
+
+        oauth_client_id = getattr(ctx.firebase.config, "oauth_client_id", None)
+        if oauth_client_id and not client_id_rejected:
+            break
+
+        oauth_config_error = _prompt_and_configure_oauth_client_id(ctx)
+        if oauth_config_error:
+            return False, oauth_config_error, oauth_attempted_any
+        if not getattr(ctx.firebase.config, "oauth_client_id", None):
+            break
+
+    prompt_error = _prompt_and_save_access_token(ctx)
+    if prompt_error:
+        return False, prompt_error, oauth_attempted_any
+
+    return _is_available(ctx, oauth_sink), None, oauth_attempted_any
+
+
+def _check_auth(
+    ctx: WorkflowContext,
+    title: str,
+    *,
+    prompt_for_missing_auth_default: bool,
+) -> WorkflowResult:
+    """Shared implementation for Firebase login/status checks."""
     _begin(ctx, title)
 
     if not ctx.firebase:
@@ -42,22 +335,38 @@ def _check_adc(ctx: WorkflowContext, title: str) -> WorkflowResult:
 
     account = ctx.firebase.get_active_account()
     login_command = ctx.firebase.get_login_command()
+    oauth_sink = _WorkflowOAuthSink(ctx)
 
-    if ctx.firebase.is_available():
-        account_label = account or "unknown gcloud account"
-        _success(ctx, f"Firebase ADC session available for {account_label}")
-        _end(ctx, "success")
-        return Success(
-            "Firebase ADC session available",
-            metadata={
-                "firebase_account": account,
-                "firebase_login_command": login_command,
-            },
+    if _is_available(ctx, oauth_sink):
+        return _auth_success(
+            ctx,
+            account=account,
+            login_command=login_command,
         )
 
+    prompt_for_missing_auth = ctx.get(
+        "prompt_for_missing_auth",
+        prompt_for_missing_auth_default,
+    )
+    if prompt_for_missing_auth:
+        auth_available, auth_error, oauth_attempted = prompt_for_firebase_auth(ctx)
+        if auth_error:
+            _error(ctx, auth_error.message)
+            _end(ctx, "error")
+            return auth_error
+
+        if auth_available:
+            return _auth_success(
+                ctx,
+                account=account,
+                login_command=login_command,
+                token_saved=True,
+                oauth_login_completed=oauth_attempted,
+            )
+
     message = (
-        "Firebase ADC session not available. Run: "
-        f"{login_command}"
+        "Firebase auth not available. Configure Firebase oauth_client_id, set "
+        f"{ctx.firebase.config.access_token_env_var}, or run: {login_command}"
     )
     fail_on_missing_auth = ctx.get("fail_on_missing_auth", True)
     if fail_on_missing_auth:
@@ -72,49 +381,65 @@ def _check_adc(ctx: WorkflowContext, title: str) -> WorkflowResult:
         metadata={
             "firebase_account": account,
             "firebase_login_command": login_command,
+            "firebase_access_token_saved": False,
+            "firebase_oauth_login_completed": False,
         },
     )
 
 
 def execute_firebase_login_step(ctx: WorkflowContext) -> WorkflowResult:
     """
-    Validate that the current user has a Firebase ADC session.
+    Validate that the current user has Firebase OAuth authentication.
 
     Requires:
         ctx.firebase: An initialized FirebaseClient.
 
     Inputs (from ctx.data):
-        fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True.
+        fail_on_missing_auth (bool, optional): Return Error when auth is missing. Defaults to True.
+        prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to True.
 
     Outputs (saved to ctx.data):
         firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.
         firebase_login_command (str): Command the user can run to create an ADC session.
+        firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.
+        firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login.
 
     Returns:
-        Success: If gcloud ADC is available.
-        Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.
-        Skip: If ADC auth is missing and fail_on_missing_auth is False.
+        Success: If Firebase OAuth auth is available.
+        Error: If Firebase client or auth is missing and fail_on_missing_auth is True.
+        Skip: If auth is missing and fail_on_missing_auth is False.
     """
-    return _check_adc(ctx, "Firebase ADC Login")
+    return _check_auth(
+        ctx,
+        "Firebase Login",
+        prompt_for_missing_auth_default=True,
+    )
 
 
 def execute_firebase_status_step(ctx: WorkflowContext) -> WorkflowResult:
     """
-    Report the current Firebase ADC authentication status.
+    Report the current Firebase OAuth authentication status.
 
     Requires:
         ctx.firebase: An initialized FirebaseClient.
 
     Inputs (from ctx.data):
-        fail_on_missing_auth (bool, optional): Return Error when ADC is missing. Defaults to True.
+        fail_on_missing_auth (bool, optional): Return Error when auth is missing. Defaults to True.
+        prompt_for_missing_auth (bool, optional): Prompt for Google OAuth setup/login when auth is missing. Defaults to False.
 
     Outputs (saved to ctx.data):
         firebase_account (Optional[str]): Active gcloud account reported by `gcloud auth list`.
         firebase_login_command (str): Command the user can run to create an ADC session.
+        firebase_access_token_saved (bool): Whether this step saved a token to Titan's OAuth token store.
+        firebase_oauth_login_completed (bool): Whether this step completed browser OAuth login.
 
     Returns:
-        Success: If gcloud ADC is available.
-        Error: If Firebase client or ADC auth is missing and fail_on_missing_auth is True.
-        Skip: If ADC auth is missing and fail_on_missing_auth is False.
+        Success: If Firebase OAuth auth is available.
+        Error: If Firebase client or auth is missing and fail_on_missing_auth is True.
+        Skip: If auth is missing and fail_on_missing_auth is False.
     """
-    return _check_adc(ctx, "Firebase ADC Status")
+    return _check_auth(
+        ctx,
+        "Firebase Auth Status",
+        prompt_for_missing_auth_default=False,
+    )

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_get_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_get_step.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 
 from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
 
-from ..exceptions import FirebaseClientError
+from ..exceptions import FirebaseAuthRejectedError, FirebaseClientError
+from .auth_retry import reauthenticate_after_rejected_token
 
 
 def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResult:
@@ -55,14 +56,27 @@ def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResu
             ctx.textual.end_step("error")
         return Error(message)
 
-    loading = (
-        ctx.textual.loading(f"Reading Remote Config for {project_id}...")
-        if ctx.textual
-        else nullcontext()
-    )
+    loading_message = f"Reading Remote Config for {project_id}..."
     try:
-        with loading:
+        with _loading(ctx, loading_message):
             remote_config = ctx.firebase.get_remote_config(str(project_id))
+    except FirebaseAuthRejectedError as exc:
+        retry_error = reauthenticate_after_rejected_token(ctx, exc)
+        if retry_error:
+            if ctx.textual:
+                ctx.textual.error_text(retry_error.message)
+                ctx.textual.end_step("error")
+            return retry_error
+
+        try:
+            with _loading(ctx, loading_message):
+                remote_config = ctx.firebase.get_remote_config(str(project_id))
+        except FirebaseClientError as retry_exc:
+            message = str(retry_exc)
+            if ctx.textual:
+                ctx.textual.error_text(message)
+                ctx.textual.end_step("error")
+            return Error(message, exception=retry_exc)
     except FirebaseClientError as exc:
         message = str(exc)
         if ctx.textual:
@@ -72,7 +86,9 @@ def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResu
 
     if ctx.textual:
         version = remote_config.version or {}
-        version_number = version.get("versionNumber") if isinstance(version, dict) else None
+        version_number = (
+            version.get("versionNumber") if isinstance(version, dict) else None
+        )
         suffix = f" version {version_number}" if version_number else ""
         ctx.textual.success_text(
             f"Remote Config template loaded for {remote_config.project_id}{suffix}"
@@ -88,3 +104,10 @@ def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResu
             "firebase_remoteconfig_version": remote_config.version,
         },
     )
+
+
+def _loading(ctx: WorkflowContext, message: str) -> AbstractContextManager[object]:
+    """Return a fresh loading context for each request attempt."""
+    if ctx.textual:
+        return ctx.textual.loading(message)
+    return nullcontext()

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_get_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_get_step.py
@@ -1,0 +1,90 @@
+"""Firebase Remote Config read workflow step."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
+
+from ..exceptions import FirebaseClientError
+
+
+def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    Read a Firebase Remote Config template for one project.
+
+    Requires:
+        ctx.firebase: An initialized FirebaseClient.
+
+    Inputs (from ctx.data):
+        project_id (str, optional): Firebase project ID to read.
+        firebase_project_id (str, optional): Alternate project ID key from a previous step.
+
+    Outputs (saved to ctx.data):
+        firebase_project_id (str): Firebase project ID used for the request.
+        firebase_remoteconfig_template (dict): Remote Config template JSON payload.
+        firebase_remoteconfig_etag (Optional[str]): ETag returned by Firebase for later publishing.
+        firebase_remoteconfig_version (Optional[dict]): Remote Config template version payload.
+
+    Returns:
+        Success: If the Remote Config template is read successfully.
+        Error: If Firebase is unavailable, no project ID is provided, or the API request fails.
+    """
+    if ctx.textual:
+        ctx.textual.begin_step("Get Firebase Remote Config")
+
+    if not ctx.firebase:
+        message = "Firebase client not available"
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message)
+
+    project_id = (
+        ctx.get("project_id")
+        or ctx.get("firebase_project_id")
+        or ctx.firebase.config.default_project
+    )
+    if not project_id:
+        message = (
+            "Firebase project_id is required. Pass project_id or configure "
+            "plugins.firebase.config.default_project."
+        )
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message)
+
+    loading = (
+        ctx.textual.loading(f"Reading Remote Config for {project_id}...")
+        if ctx.textual
+        else nullcontext()
+    )
+    try:
+        with loading:
+            remote_config = ctx.firebase.get_remote_config(str(project_id))
+    except FirebaseClientError as exc:
+        message = str(exc)
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message, exception=exc)
+
+    if ctx.textual:
+        version = remote_config.version or {}
+        version_number = version.get("versionNumber") if isinstance(version, dict) else None
+        suffix = f" version {version_number}" if version_number else ""
+        ctx.textual.success_text(
+            f"Remote Config template loaded for {remote_config.project_id}{suffix}"
+        )
+        ctx.textual.end_step("success")
+
+    return Success(
+        "Firebase Remote Config template loaded",
+        metadata={
+            "firebase_project_id": remote_config.project_id,
+            "firebase_remoteconfig_template": remote_config.template,
+            "firebase_remoteconfig_etag": remote_config.etag,
+            "firebase_remoteconfig_version": remote_config.version,
+        },
+    )

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_get_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_get_step.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager, nullcontext
+from typing import Any
 
 from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
 
@@ -29,7 +30,7 @@ def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResu
 
     Returns:
         Success: If the Remote Config template is read successfully.
-        Error: If Firebase is unavailable, no project ID is provided, or the API request fails.
+        Error: If Firebase is unavailable, no project ID is provided, the API request fails, or the template payload is malformed.
     """
     if ctx.textual:
         ctx.textual.begin_step("Get Firebase Remote Config")
@@ -84,11 +85,18 @@ def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResu
             ctx.textual.end_step("error")
         return Error(message, exception=exc)
 
-    if ctx.textual:
-        version = remote_config.version or {}
-        version_number = (
-            version.get("versionNumber") if isinstance(version, dict) else None
+    try:
+        template, version, version_number = _validate_remote_config_template(
+            remote_config.template
         )
+    except FirebaseClientError as exc:
+        message = str(exc)
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message, exception=exc)
+
+    if ctx.textual:
         suffix = f" version {version_number}" if version_number else ""
         ctx.textual.success_text(
             f"Remote Config template loaded for {remote_config.project_id}{suffix}"
@@ -99,9 +107,9 @@ def execute_firebase_remoteconfig_get_step(ctx: WorkflowContext) -> WorkflowResu
         "Firebase Remote Config template loaded",
         metadata={
             "firebase_project_id": remote_config.project_id,
-            "firebase_remoteconfig_template": remote_config.template,
+            "firebase_remoteconfig_template": template,
             "firebase_remoteconfig_etag": remote_config.etag,
-            "firebase_remoteconfig_version": remote_config.version,
+            "firebase_remoteconfig_version": version,
         },
     )
 
@@ -111,3 +119,37 @@ def _loading(ctx: WorkflowContext, message: str) -> AbstractContextManager[objec
     if ctx.textual:
         return ctx.textual.loading(message)
     return nullcontext()
+
+
+def _validate_remote_config_template(
+    template: Any,
+) -> tuple[dict[str, Any], dict[str, Any] | None, str | None]:
+    """Validate the Remote Config template shape before rendering metadata."""
+    if not isinstance(template, dict):
+        raise FirebaseClientError(
+            "Firebase Remote Config template payload was malformed: "
+            "template must be a JSON object."
+        )
+
+    version = template.get("version")
+    if version is not None and not isinstance(version, dict):
+        raise FirebaseClientError(
+            "Firebase Remote Config template payload was malformed: "
+            "version must be a JSON object when present."
+        )
+
+    version_number = None
+    if version:
+        raw_version_number = version.get("versionNumber")
+        if raw_version_number is not None:
+            if isinstance(raw_version_number, bool) or not isinstance(
+                raw_version_number,
+                (int, str),
+            ):
+                raise FirebaseClientError(
+                    "Firebase Remote Config template payload was malformed: "
+                    "version.versionNumber must be a string or integer when present."
+                )
+            version_number = str(raw_version_number)
+
+    return template, version, version_number

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_inventory_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_inventory_step.py
@@ -1,0 +1,203 @@
+"""Firebase Remote Config inventory workflow step."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager, nullcontext
+from typing import Any
+
+from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
+
+from ..exceptions import FirebaseAuthRejectedError, FirebaseClientError
+from ..operations.remoteconfig_inventory import resolve_project_targets
+from .auth_retry import reauthenticate_after_rejected_token
+
+
+def execute_firebase_remoteconfig_inventory_step(
+    ctx: WorkflowContext,
+) -> WorkflowResult:
+    """
+    Build a key inventory across configured Firebase Remote Config projects.
+
+    Requires:
+        ctx.firebase: An initialized FirebaseClient.
+
+    Inputs (from ctx.data):
+        project_targets (list[dict], optional): Explicit Firebase project targets.
+        firebase_project_targets (list[dict], optional): Alternate explicit target key.
+        projects (list[dict|str], optional): Firebase project targets or project IDs.
+        brand_projects (dict, optional): Brand/environment project mapping override.
+        brand (str, optional): Single brand filter.
+        brands (list[str]|str, optional): Brand filter list or comma-separated string.
+        environment (str, optional): Single environment filter.
+        environments (list[str]|str, optional): Environment filter list or comma-separated string.
+        continue_on_error (bool, optional): Continue when one project read fails. Defaults to True.
+
+    Outputs (saved to ctx.data):
+        firebase_remoteconfig_inventory (dict): Aggregated inventory payload.
+        firebase_remoteconfig_keys (list[dict]): Unique key inventory rows.
+        firebase_remoteconfig_targets (list[dict]): Project targets that were requested.
+        firebase_remoteconfig_project_count (int): Number of projects read successfully.
+        firebase_remoteconfig_key_count (int): Number of unique keys found.
+        firebase_remoteconfig_failures (list[dict]): Project read failures, when any.
+
+    Returns:
+        Success: If at least one project is read and key inventory is built.
+        Error: If Firebase is unavailable, no targets are configured, or all project reads fail.
+    """
+    if ctx.textual:
+        ctx.textual.begin_step("Inventory Firebase Remote Config Keys")
+
+    if not ctx.firebase:
+        message = "Firebase client not available"
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message)
+
+    targets = resolve_project_targets(
+        ctx.firebase.config,
+        project_targets=(
+            ctx.get("project_targets") or ctx.get("firebase_project_targets")
+        ),
+        projects=ctx.get("projects"),
+        brand_projects=ctx.get("brand_projects"),
+        brands=ctx.get("brands") or ctx.get("brand"),
+        environments=ctx.get("environments") or ctx.get("environment"),
+    )
+    if not targets:
+        message = (
+            "No Firebase project targets configured. Configure "
+            "plugins.firebase.config.projects or brand_projects."
+        )
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message)
+
+    continue_on_error = _as_bool(ctx.get("continue_on_error"), default=True)
+    loading_message = f"Reading Remote Config keys from {len(targets)} project(s)..."
+
+    try:
+        with _loading(ctx, loading_message):
+            inventory = ctx.firebase.get_remote_config_inventory(
+                targets,
+                continue_on_error=continue_on_error,
+            )
+    except FirebaseAuthRejectedError as exc:
+        retry_error = reauthenticate_after_rejected_token(ctx, exc)
+        if retry_error:
+            if ctx.textual:
+                ctx.textual.error_text(retry_error.message)
+                ctx.textual.end_step("error")
+            return retry_error
+
+        try:
+            with _loading(ctx, loading_message):
+                inventory = ctx.firebase.get_remote_config_inventory(
+                    targets,
+                    continue_on_error=continue_on_error,
+                )
+        except FirebaseClientError as retry_exc:
+            message = str(retry_exc)
+            if ctx.textual:
+                ctx.textual.error_text(message)
+                ctx.textual.end_step("error")
+            return Error(message, exception=retry_exc)
+    except FirebaseClientError as exc:
+        message = str(exc)
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message, exception=exc)
+
+    if inventory.project_count == 0:
+        message = "No Firebase Remote Config project could be read."
+        if inventory.failures:
+            message = f"{message} First failure: {inventory.failures[0].message}"
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message)
+
+    payload = inventory.model_dump(mode="json")
+    if ctx.textual:
+        ctx.textual.success_text(
+            "Remote Config inventory loaded: "
+            f"{inventory.key_count} key(s) across {inventory.project_count} project(s)"
+        )
+        _render_inventory_table(ctx, inventory)
+        if inventory.failures:
+            ctx.textual.warning_text(
+                f"{len(inventory.failures)} project(s) could not be read"
+            )
+        ctx.textual.end_step("success")
+
+    return Success(
+        "Firebase Remote Config inventory loaded",
+        metadata={
+            "firebase_remoteconfig_inventory": payload,
+            "firebase_remoteconfig_keys": payload["keys"],
+            "firebase_remoteconfig_targets": payload["targets"],
+            "firebase_remoteconfig_project_count": inventory.project_count,
+            "firebase_remoteconfig_key_count": inventory.key_count,
+            "firebase_remoteconfig_failures": payload["failures"],
+        },
+    )
+
+
+def _loading(ctx: WorkflowContext, message: str) -> AbstractContextManager[object]:
+    """Return a fresh loading context for each request attempt."""
+    if ctx.textual:
+        return ctx.textual.loading(message)
+    return nullcontext()
+
+
+def _as_bool(value: Any, *, default: bool) -> bool:
+    """Coerce workflow values into a boolean."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+def _render_inventory_table(ctx: WorkflowContext, inventory: Any) -> None:
+    """Render a compact Remote Config keys table in the TUI."""
+    if not ctx.textual or not inventory.keys:
+        return
+
+    project_count = inventory.project_count
+    rows = []
+    for key_inventory in inventory.keys:
+        observed_types = ", ".join(
+            value_type.value for value_type in key_inventory.observed_types
+        )
+        missing = (
+            ", ".join(key_inventory.projects_missing)
+            if key_inventory.projects_missing
+            else "-"
+        )
+        rows.append(
+            [
+                key_inventory.key,
+                observed_types or "UNKNOWN",
+                f"{len(key_inventory.projects_present)}/{project_count}",
+                missing,
+            ]
+        )
+
+    ctx.textual.table(
+        headers=["Key", "Type(s)", "Projects", "Missing in"],
+        rows=rows,
+        title="Remote Config Keys",
+        full_width=True,
+        zebra_stripes=True,
+        show_cursor=False,
+        cursor_type="none",
+    )

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_inventory_step.py
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/steps/remoteconfig_inventory_step.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any
 
+from pydantic import ValidationError
+
 from titan_cli.engine import Error, Success, WorkflowContext, WorkflowResult
 
 from ..exceptions import FirebaseAuthRejectedError, FirebaseClientError
@@ -54,16 +56,23 @@ def execute_firebase_remoteconfig_inventory_step(
             ctx.textual.end_step("error")
         return Error(message)
 
-    targets = resolve_project_targets(
-        ctx.firebase.config,
-        project_targets=(
-            ctx.get("project_targets") or ctx.get("firebase_project_targets")
-        ),
-        projects=ctx.get("projects"),
-        brand_projects=ctx.get("brand_projects"),
-        brands=ctx.get("brands") or ctx.get("brand"),
-        environments=ctx.get("environments") or ctx.get("environment"),
-    )
+    try:
+        targets = resolve_project_targets(
+            ctx.firebase.config,
+            project_targets=(
+                ctx.get("project_targets") or ctx.get("firebase_project_targets")
+            ),
+            projects=ctx.get("projects"),
+            brand_projects=ctx.get("brand_projects"),
+            brands=ctx.get("brands") or ctx.get("brand"),
+            environments=ctx.get("environments") or ctx.get("environment"),
+        )
+    except (FirebaseClientError, TypeError, ValueError, ValidationError) as exc:
+        message = f"Invalid Firebase project targets: {exc}"
+        if ctx.textual:
+            ctx.textual.error_text(message)
+            ctx.textual.end_step("error")
+        return Error(message, exception=exc, recoverable=True)
     if not targets:
         message = (
             "No Firebase project targets configured. Configure "

--- a/plugins/titan-plugin-firebase/titan_plugin_firebase/workflows/list-remoteconfig-keys.yaml
+++ b/plugins/titan-plugin-firebase/titan_plugin_firebase/workflows/list-remoteconfig-keys.yaml
@@ -1,0 +1,14 @@
+name: "List Firebase Remote Config Keys"
+description: "List Remote Config keys across configured Firebase brand projects"
+params:
+  continue_on_error: true
+steps:
+  - id: firebase_login
+    name: "Validate Firebase Auth"
+    plugin: firebase
+    step: firebase_login
+
+  - id: firebase_remoteconfig_inventory
+    name: "Build Remote Config Key Inventory"
+    plugin: firebase
+    step: firebase_remoteconfig_inventory

--- a/poetry.lock
+++ b/poetry.lock
@@ -2915,6 +2915,24 @@ rich = "*"
 textual = ">=0.66.0"
 
 [[package]]
+name = "titan-plugin-firebase"
+version = "0.1.0"
+description = "Firebase plugin for Titan CLI"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = []
+develop = true
+
+[package.dependencies]
+requests = ">=2.31.0,<3.0.0"
+titan-cli = ">=0.6.0"
+
+[package.source]
+type = "directory"
+url = "plugins/titan-plugin-firebase"
+
+[[package]]
 name = "titan-plugin-git"
 version = "1.0.0"
 description = "Git plugin for Titan CLI"
@@ -2979,6 +2997,7 @@ files = []
 develop = true
 
 [package.dependencies]
+requests = ">=2.31.0"
 slack-sdk = ">=3.27.0"
 titan-cli = ">=0.6.0"
 
@@ -3446,4 +3465,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0.0"
-content-hash = "ec6c0e438f3c94618c439b4d442fe2a030eb3d233a9ae9498596f6781737a0fb"
+content-hash = "b735b923e81c3366bae34d1e015124ddf64c9d65525a27ab2d8eef157d67c73f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ packages = [
     {include = "titan_plugin_git", from = "plugins/titan-plugin-git"},
     {include = "titan_plugin_github", from = "plugins/titan-plugin-github"},
     {include = "titan_plugin_jira", from = "plugins/titan-plugin-jira"},
+    {include = "titan_plugin_firebase", from = "plugins/titan-plugin-firebase"},
     {include = "titan_plugin_slack", from = "plugins/titan-plugin-slack"}
 ]
 
@@ -66,6 +67,7 @@ textual-dev = "^1.0.0"
 titan-plugin-git = {path = "plugins/titan-plugin-git", develop = true}
 titan-plugin-github = {path = "plugins/titan-plugin-github", develop = true}
 titan-plugin-jira = {path = "plugins/titan-plugin-jira", develop = true}
+titan-plugin-firebase = {path = "plugins/titan-plugin-firebase", develop = true}
 titan-plugin-slack = {path = "plugins/titan-plugin-slack", develop = true}
 
 [build-system]
@@ -79,6 +81,7 @@ titan = "titan_cli.cli:app"
 git = "titan_plugin_git.plugin:GitPlugin"
 github = "titan_plugin_github.plugin:GitHubPlugin"
 jira = "titan_plugin_jira.plugin:JiraPlugin"
+firebase = "titan_plugin_firebase.plugin:FirebasePlugin"
 slack = "titan_plugin_slack.plugin:SlackPlugin"
 
 [tool.pytest.ini_options]
@@ -87,6 +90,7 @@ testpaths = [
     "plugins/titan-plugin-git/tests",
     "plugins/titan-plugin-github/tests",
     "plugins/titan-plugin-jira/tests",
+    "plugins/titan-plugin-firebase/tests",
     "plugins/titan-plugin-slack/tests"
 ]
 python_files = ["test_*.py"]

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1001,7 +1001,9 @@ def test_global_plugin_source_is_scoped_to_active_project(tmp_path: Path, monkey
 
         config_b.load(skip_plugin_init=True)
         assert config_b.get_plugin_source_channel("sample") == "dev_local"
-        assert config_b.get_plugin_source_path("sample") == Path("/tmp/sample-dev")
+        assert config_b.get_plugin_source_path("sample") == Path(
+            "/tmp/sample-dev"
+        ).resolve()
 
         os.chdir(project_a)
         config_a = TitanConfig(skip_plugin_init=True)

--- a/tests/core/test_known_plugins.py
+++ b/tests/core/test_known_plugins.py
@@ -7,3 +7,14 @@ def test_known_plugins_includes_slack() -> None:
     assert slack_plugin is not None
     assert slack_plugin["package_name"] == "titan-plugin-slack"
     assert slack_plugin["dependencies"] == []
+
+
+def test_known_plugins_includes_firebase() -> None:
+    firebase_plugin = next(
+        (plugin for plugin in KNOWN_PLUGINS if plugin["name"] == "firebase"),
+        None,
+    )
+
+    assert firebase_plugin is not None
+    assert firebase_plugin["package_name"] == "titan-plugin-firebase"
+    assert firebase_plugin["dependencies"] == []

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -275,6 +275,83 @@ def test_oauth_manager_reads_legacy_secret_key(monkeypatch, tmp_path) -> None:
     assert credential.source == "keyring:demo_firebase_access_token"
 
 
+def test_oauth_manager_interactive_uses_legacy_before_authorization(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+
+    class AuthorizingProvider:
+        def __init__(self) -> None:
+            self.authorize_calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run")
+
+        async def authorize(self, request, sink):
+            self.authorize_calls += 1
+            return OAuthTokenSet(access_token="browser-token")
+
+    provider = AuthorizingProvider()
+    manager = _manager(
+        FakeSecretManager({"demo_firebase_access_token": " legacy-token "}),
+        tmp_path,
+        providers={"google": provider},
+    )
+
+    credential = asyncio.run(manager.get_credential(_request(interactive=True)))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_firebase_access_token"
+    assert provider.authorize_calls == 0
+
+
+def test_oauth_manager_refresh_failure_checks_legacy_before_authorization(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager({"demo_firebase_access_token": " legacy-token "})
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshThenAuthorizeProvider:
+        def __init__(self) -> None:
+            self.refresh_calls = 0
+            self.authorize_calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.refresh_calls += 1
+            raise RuntimeError("temporary refresh failure")
+
+        async def authorize(self, request, sink):
+            self.authorize_calls += 1
+            return OAuthTokenSet(access_token="browser-token")
+
+    provider = RefreshThenAuthorizeProvider()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_firebase_access_token"
+    assert provider.refresh_calls == 1
+    assert provider.authorize_calls == 0
+
+
 def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
     manager = _manager(FakeSecretManager(), tmp_path)

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -16,15 +16,32 @@ from titan_cli.core.oauth import (
     OAuthTokenStore,
     QueuedOAuthEventSink,
 )
+from titan_cli.core.secrets import ResolvedSecret
 
 
 class FakeSecretManager:
     def __init__(self, initial: dict[str, str] | None = None) -> None:
         self.values = dict(initial or {})
+        self.scoped_values: dict[tuple[str, str, str], str] = {
+            ("user", "titan", key): value for key, value in self.values.items()
+        }
         self.set_calls: list[tuple[str, str, str]] = []
+        self.delete_calls: list[tuple[str, str]] = []
 
     def get(self, key: str, namespace: str = "titan") -> str | None:
-        return self.values.get(key)
+        resolved = self.get_with_scope(key, namespace=namespace)
+        return resolved.value if resolved else None
+
+    def get_with_scope(
+        self,
+        key: str,
+        namespace: str = "titan",
+    ) -> ResolvedSecret | None:
+        for scope in ("env", "project", "user"):
+            scoped_key = (scope, namespace, key)
+            if scoped_key in self.scoped_values:
+                return ResolvedSecret(self.scoped_values[scoped_key], scope)
+        return None
 
     def set(
         self,
@@ -34,10 +51,14 @@ class FakeSecretManager:
         scope: str = "user",
     ) -> None:
         self.values[key] = value
+        self.scoped_values[(scope, namespace, key)] = value
         self.set_calls.append((key, value, scope))
 
     def delete(self, key: str, namespace: str = "titan", scope: str = "user") -> None:
-        self.values.pop(key, None)
+        self.scoped_values.pop((scope, namespace, key), None)
+        if scope == "user":
+            self.values.pop(key, None)
+        self.delete_calls.append((key, scope))
 
 
 def _manager(
@@ -149,6 +170,57 @@ def test_oauth_manager_refreshes_token_inside_expiry_margin(
 
     assert credential.access_token == "fresh-token"
     assert credential.source == "oauth-refresh"
+
+
+@pytest.mark.parametrize("storage_scope", ["env", "project"])
+def test_oauth_manager_refresh_preserves_original_storage_scope(
+    monkeypatch,
+    tmp_path,
+    storage_scope,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="refresh-token",
+            expires_at=int(time.time()) + 120,
+        ),
+        scope=storage_scope,
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+    assert secrets.set_calls[-1][0] == secret_key
+    assert secrets.set_calls[-1][2] == storage_scope
+    stored_payload = json.loads(
+        secrets.scoped_values[(storage_scope, "titan", secret_key)]
+    )
+    assert stored_payload["access_token"] == "fresh-token"
 
 
 def test_oauth_manager_refreshes_before_legacy_secret(monkeypatch, tmp_path) -> None:
@@ -280,9 +352,7 @@ def test_oauth_manager_refreshes_only_once_under_concurrency(
     credentials = asyncio.run(resolve_many())
 
     assert provider.calls == 1
-    assert {credential.access_token for credential in credentials} == {
-        "fresh-token-1"
-    }
+    assert {credential.access_token for credential in credentials} == {"fresh-token-1"}
 
 
 def test_oauth_manager_interactive_authorizes_after_refresh_failure(
@@ -337,6 +407,57 @@ def test_oauth_manager_interactive_authorizes_after_refresh_failure(
     stored_payload = json.loads(secrets.values[old_secret_key])
     assert stored_payload["refresh_token"] == "new-refresh-token"
     assert "oauth.refresh.stale_deleted" in [event.type for event in sink.events]
+
+
+@pytest.mark.parametrize("storage_scope", ["env", "project"])
+def test_oauth_manager_relogin_preserves_stale_token_storage_scope(
+    monkeypatch,
+    tmp_path,
+    storage_scope,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="old-refresh-token",
+            expires_at=1,
+        ),
+        scope=storage_scope,
+    )
+
+    class ReauthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise RuntimeError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            return OAuthTokenSet(
+                access_token="new-login-token",
+                refresh_token="new-refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": ReauthorizingProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "new-login-token"
+    assert secrets.delete_calls[-1] == (old_secret_key, storage_scope)
+    assert secrets.set_calls[-1][0] == old_secret_key
+    assert secrets.set_calls[-1][2] == storage_scope
+    assert ("user", "titan", old_secret_key) not in secrets.scoped_values
+    stored_payload = json.loads(
+        secrets.scoped_values[(storage_scope, "titan", old_secret_key)]
+    )
+    assert stored_payload["refresh_token"] == "new-refresh-token"
 
 
 def test_oauth_manager_saves_one_json_blob(tmp_path) -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -94,6 +94,24 @@ def _request(**overrides) -> OAuthRequest:
     return OAuthRequest(**defaults)
 
 
+def test_oauth_request_normalizes_scalar_scope_and_legacy_secret_key() -> None:
+    request = OAuthRequest(
+        provider="google",
+        connection_id="firebase:demo",
+        scopes="openid",
+        legacy_secret_keys="firebase_access_token",
+    )
+
+    assert request.scopes == ("openid",)
+    assert request.legacy_secret_keys == ("firebase_access_token",)
+
+
+def test_oauth_token_set_normalizes_scalar_scope() -> None:
+    token_set = OAuthTokenSet(access_token="access-token", scopes="openid")
+
+    assert token_set.scopes == ("openid",)
+
+
 def test_oauth_manager_prefers_environment_token(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("FIREBASE_ACCESS_TOKEN", "env-token")
     manager = _manager(

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -605,3 +605,27 @@ def test_queued_oauth_event_sink_drains_events() -> None:
         "oauth.resolve.succeeded",
     ]
     assert sink.get(block=False) is None
+
+
+def test_queued_oauth_event_sink_drops_new_events_when_full() -> None:
+    sink = QueuedOAuthEventSink(maxsize=1)
+
+    sink.emit(OAuthEvent(type="oauth.resolve.started", operation_id="op-1"))
+    sink.emit(OAuthEvent(type="oauth.resolve.succeeded", operation_id="op-1"))
+
+    assert [event.type for event in sink.drain()] == ["oauth.resolve.started"]
+    assert sink.dropped_count == 1
+
+
+def test_oauth_manager_queue_overflow_does_not_abort_resolution(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("FIREBASE_ACCESS_TOKEN", "env-token")
+    manager = _manager(FakeSecretManager(), tmp_path)
+    sink = QueuedOAuthEventSink(maxsize=1)
+
+    credential = asyncio.run(manager.get_credential(_request(), sink=sink))
+
+    assert credential.access_token == "env-token"
+    assert sink.dropped_count >= 1

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1,9 +1,11 @@
 import asyncio
 import json
+import threading
 import time
 
 import pytest
 
+import titan_cli.core.oauth.locks as oauth_locks
 from titan_cli.core.oauth import (
     CollectingOAuthEventSink,
     OAuthAuthenticationRequired,
@@ -617,6 +619,51 @@ def test_oauth_lock_async_acquire_cancellation_does_not_leak_lock(tmp_path) -> N
         next_lock.release()
 
     asyncio.run(exercise_cancelled_acquire())
+
+
+def test_oauth_lock_file_lock_uses_remaining_timeout(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    captured_timeouts = []
+
+    class FakeFileLock:
+        def __init__(
+            self,
+            path,
+            *,
+            timeout_seconds,
+            poll_interval_seconds,
+        ) -> None:
+            captured_timeouts.append(timeout_seconds)
+
+        def acquire(self, cancel_event=None) -> None:
+            return None
+
+        def release(self) -> None:
+            return None
+
+    monkeypatch.setattr(oauth_locks, "_FileLock", FakeFileLock)
+    manager = OAuthLockManager(
+        lock_dir=tmp_path,
+        enable_file_locks=True,
+        poll_interval_seconds=0.01,
+    )
+    thread_lock = manager._get_thread_lock("firebase:demo")
+    thread_lock.acquire()
+
+    def release_thread_lock() -> None:
+        time.sleep(0.05)
+        thread_lock.release()
+
+    releaser = threading.Thread(target=release_thread_lock)
+    releaser.start()
+    held_lock = manager.acquire_blocking("firebase:demo", timeout_seconds=0.5)
+    held_lock.release()
+    releaser.join()
+
+    assert captured_timeouts
+    assert 0 < captured_timeouts[0] < 0.5
 
 
 def test_queued_oauth_event_sink_drains_events() -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -594,6 +594,31 @@ def test_oauth_manager_saves_one_json_blob(tmp_path) -> None:
     assert [call[0] for call in secrets.set_calls] == [secret_key]
 
 
+def test_oauth_lock_async_acquire_cancellation_does_not_leak_lock(tmp_path) -> None:
+    async def exercise_cancelled_acquire() -> None:
+        manager = OAuthLockManager(
+            lock_dir=tmp_path,
+            enable_file_locks=False,
+            poll_interval_seconds=0.01,
+        )
+        held_lock = manager.acquire_blocking("firebase:demo", timeout_seconds=1)
+        pending_acquire = asyncio.create_task(
+            manager.acquire("firebase:demo", timeout_seconds=1)
+        )
+
+        await asyncio.sleep(0.05)
+        pending_acquire.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending_acquire
+
+        held_lock.release()
+        await asyncio.sleep(0.05)
+        next_lock = await manager.acquire("firebase:demo", timeout_seconds=0.2)
+        next_lock.release()
+
+    asyncio.run(exercise_cancelled_acquire())
+
+
 def test_queued_oauth_event_sink_drains_events() -> None:
     sink = QueuedOAuthEventSink()
 

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1,0 +1,368 @@
+import asyncio
+import json
+import time
+
+import pytest
+
+from titan_cli.core.oauth import (
+    CollectingOAuthEventSink,
+    OAuthAuthenticationRequired,
+    OAuthAuthorizationError,
+    OAuthEvent,
+    OAuthLockManager,
+    OAuthManager,
+    OAuthRequest,
+    OAuthTokenSet,
+    OAuthTokenStore,
+    QueuedOAuthEventSink,
+)
+
+
+class FakeSecretManager:
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
+        self.values = dict(initial or {})
+        self.set_calls: list[tuple[str, str, str]] = []
+
+    def get(self, key: str, namespace: str = "titan") -> str | None:
+        return self.values.get(key)
+
+    def set(
+        self,
+        key: str,
+        value: str,
+        namespace: str = "titan",
+        scope: str = "user",
+    ) -> None:
+        self.values[key] = value
+        self.set_calls.append((key, value, scope))
+
+    def delete(self, key: str, namespace: str = "titan", scope: str = "user") -> None:
+        self.values.pop(key, None)
+
+
+def _manager(
+    secrets: FakeSecretManager,
+    tmp_path,
+    *,
+    providers=None,
+) -> OAuthManager:
+    return OAuthManager(
+        secrets,
+        providers=providers,
+        lock_manager=OAuthLockManager(
+            lock_dir=tmp_path,
+            enable_file_locks=False,
+        ),
+    )
+
+
+def _request(**overrides) -> OAuthRequest:
+    defaults = {
+        "provider": "google",
+        "connection_id": "firebase:demo",
+        "scopes": ["https://www.googleapis.com/auth/firebase.remoteconfig"],
+        "legacy_secret_keys": ["demo_firebase_access_token"],
+        "access_token_env_var": "FIREBASE_ACCESS_TOKEN",
+        "subject": "demo",
+    }
+    defaults.update(overrides)
+    return OAuthRequest(**defaults)
+
+
+def test_oauth_manager_prefers_environment_token(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("FIREBASE_ACCESS_TOKEN", "env-token")
+    manager = _manager(
+        FakeSecretManager({"demo_firebase_access_token": "legacy-token"}),
+        tmp_path,
+    )
+    sink = CollectingOAuthEventSink()
+
+    credential = asyncio.run(manager.get_credential(_request(), sink=sink))
+
+    assert credential.access_token == "env-token"
+    assert credential.source == "FIREBASE_ACCESS_TOKEN"
+    assert sink.events[-1].type == "oauth.resolve.succeeded"
+    assert sink.events[-1].metadata == {"source": "FIREBASE_ACCESS_TOKEN"}
+
+
+def test_oauth_manager_uses_stored_oauth_blob(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="stored-token",
+            expires_at=int(time.time()) + 3600,
+        ),
+    )
+    manager = OAuthManager(
+        secrets,
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "stored-token"
+    assert credential.source == "oauth-cache"
+
+
+def test_oauth_manager_refreshes_token_inside_expiry_margin(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="refresh-token",
+            expires_at=int(time.time()) + 120,
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+
+
+def test_oauth_manager_refreshes_before_legacy_secret(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager({"demo_firebase_access_token": "legacy-token"})
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+
+
+def test_oauth_manager_reads_legacy_secret_key(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    manager = _manager(
+        FakeSecretManager({"demo_firebase_access_token": " legacy-token "}),
+        tmp_path,
+    )
+
+    credential = asyncio.run(manager.get_credential(_request()))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_firebase_access_token"
+
+
+def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    manager = _manager(FakeSecretManager(), tmp_path)
+
+    with pytest.raises(OAuthAuthenticationRequired):
+        asyncio.run(manager.get_credential(_request()))
+
+
+def test_oauth_manager_wraps_authorization_errors(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+
+    class BrokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run")
+
+        async def authorize(self, request, sink):
+            raise RuntimeError("browser failed")
+
+    manager = _manager(
+        FakeSecretManager(),
+        tmp_path,
+        providers={"google": BrokenProvider()},
+    )
+    request = _request(interactive=True)
+
+    with pytest.raises(OAuthAuthorizationError, match="browser failed"):
+        asyncio.run(manager.get_credential(request))
+
+
+def test_oauth_manager_refreshes_only_once_under_concurrency(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.calls += 1
+            await asyncio.sleep(0.02)
+            return OAuthTokenSet(
+                access_token=f"fresh-token-{self.calls}",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    provider = RefreshProvider()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    async def resolve_many():
+        return await asyncio.gather(
+            *(manager.get_credential(request) for _ in range(8))
+        )
+
+    credentials = asyncio.run(resolve_many())
+
+    assert provider.calls == 1
+    assert {credential.access_token for credential in credentials} == {
+        "fresh-token-1"
+    }
+
+
+def test_oauth_manager_interactive_authorizes_after_refresh_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="old-refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class ReauthorizingProvider:
+        def __init__(self) -> None:
+            self.refresh_calls = 0
+            self.authorize_calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.refresh_calls += 1
+            raise RuntimeError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            self.authorize_calls += 1
+            return OAuthTokenSet(
+                access_token="new-login-token",
+                refresh_token="new-refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    provider = ReauthorizingProvider()
+    sink = CollectingOAuthEventSink()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request, sink=sink))
+
+    assert credential.access_token == "new-login-token"
+    assert credential.source == "oauth-login"
+    assert provider.refresh_calls == 1
+    assert provider.authorize_calls == 1
+    stored_payload = json.loads(secrets.values[old_secret_key])
+    assert stored_payload["refresh_token"] == "new-refresh-token"
+    assert "oauth.refresh.stale_deleted" in [event.type for event in sink.events]
+
+
+def test_oauth_manager_saves_one_json_blob(tmp_path) -> None:
+    secrets = FakeSecretManager()
+    manager = _manager(secrets, tmp_path)
+    request = _request()
+
+    secret_key = manager.save_token_set_blocking(
+        request,
+        OAuthTokenSet(access_token="manual-token"),
+    )
+
+    assert secret_key.startswith("oauth_google_")
+    stored_payload = json.loads(secrets.values[secret_key])
+    assert stored_payload["access_token"] == "manual-token"
+    assert [call[0] for call in secrets.set_calls] == [secret_key]
+
+
+def test_queued_oauth_event_sink_drains_events() -> None:
+    sink = QueuedOAuthEventSink()
+
+    sink.emit(OAuthEvent(type="oauth.resolve.started", operation_id="op-1"))
+    sink.emit(OAuthEvent(type="oauth.resolve.succeeded", operation_id="op-1"))
+
+    assert [event.type for event in sink.drain()] == [
+        "oauth.resolve.started",
+        "oauth.resolve.succeeded",
+    ]
+    assert sink.get(block=False) is None

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -112,6 +112,26 @@ def test_oauth_token_set_normalizes_scalar_scope() -> None:
     assert token_set.scopes == ("openid",)
 
 
+def test_oauth_token_set_from_dict_rejects_non_string_refresh_token() -> None:
+    with pytest.raises(ValueError, match="refresh_token"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "refresh_token": 123,
+            }
+        )
+
+
+def test_oauth_token_set_from_dict_rejects_non_string_scope_element() -> None:
+    with pytest.raises(ValueError, match=r"scopes\[1\]"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "scopes": ["openid", 123],
+            }
+        )
+
+
 def test_oauth_manager_prefers_environment_token(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("FIREBASE_ACCESS_TOKEN", "env-token")
     manager = _manager(
@@ -705,6 +725,28 @@ def test_file_lock_retries_lock_contention_error(tmp_path) -> None:
 
     assert attempts == 2
     lock.release()
+
+
+def test_file_lock_windows_byte_initialization_does_not_grow_file(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    lock_path = tmp_path / "oauth.lock"
+    lock = oauth_locks._FileLock(
+        lock_path,
+        timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+    monkeypatch.setattr(oauth_locks.os, "name", "nt")
+
+    lock._handle = open(lock_path, "a+")
+    try:
+        lock._ensure_windows_lock_byte()
+        lock._ensure_windows_lock_byte()
+    finally:
+        lock._close_handle()
+
+    assert lock_path.read_text() == "0"
 
 
 def test_file_lock_propagates_non_contention_oserror(tmp_path) -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import errno
 import json
 import threading
 import time
@@ -664,6 +665,47 @@ def test_oauth_lock_file_lock_uses_remaining_timeout(
 
     assert captured_timeouts
     assert 0 < captured_timeouts[0] < 0.5
+
+
+def test_file_lock_retries_lock_contention_error(tmp_path) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+    attempts = 0
+
+    def try_acquire_once() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+
+    lock._try_acquire_once = try_acquire_once
+
+    lock.acquire()
+
+    assert attempts == 2
+    lock.release()
+
+
+def test_file_lock_propagates_non_contention_oserror(tmp_path) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+
+    def try_acquire_once() -> None:
+        raise OSError(errno.ENOSPC, "no space left on device")
+
+    lock._try_acquire_once = try_acquire_once
+
+    with pytest.raises(OSError) as exc_info:
+        lock.acquire()
+
+    assert exc_info.value.errno == errno.ENOSPC
+    assert lock._handle is None
 
 
 def test_queued_oauth_event_sink_drains_events() -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -12,6 +12,7 @@ from titan_cli.core.oauth import (
     OAuthLockManager,
     OAuthManager,
     OAuthRequest,
+    OAuthTokenInvalidError,
     OAuthTokenSet,
     OAuthTokenStore,
     QueuedOAuthEventSink,
@@ -406,11 +407,51 @@ def test_oauth_manager_interactive_authorizes_after_refresh_failure(
     assert provider.authorize_calls == 1
     stored_payload = json.loads(secrets.values[old_secret_key])
     assert stored_payload["refresh_token"] == "new-refresh-token"
-    assert "oauth.refresh.stale_deleted" in [event.type for event in sink.events]
+    assert "oauth.refresh.stale_deleted" not in [event.type for event in sink.events]
+    assert secrets.delete_calls == []
+
+
+def test_oauth_manager_keeps_stored_token_when_refresh_and_relogin_fail(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("FIREBASE_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="old-refresh-token",
+            expires_at=1,
+        ),
+    )
+    old_payload = secrets.scoped_values[("user", "titan", old_secret_key)]
+
+    class BrokenReauthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise RuntimeError("temporary network failure")
+
+        async def authorize(self, request, sink):
+            raise OAuthAuthorizationError("user cancelled")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": BrokenReauthorizingProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    with pytest.raises(OAuthAuthorizationError, match="user cancelled"):
+        asyncio.run(manager.get_credential(request))
+
+    assert secrets.delete_calls == []
+    assert secrets.scoped_values[("user", "titan", old_secret_key)] == old_payload
 
 
 @pytest.mark.parametrize("storage_scope", ["env", "project"])
-def test_oauth_manager_relogin_preserves_stale_token_storage_scope(
+def test_oauth_manager_deletes_explicitly_invalid_token_before_relogin(
     monkeypatch,
     tmp_path,
     storage_scope,
@@ -431,7 +472,7 @@ def test_oauth_manager_relogin_preserves_stale_token_storage_scope(
 
     class ReauthorizingProvider:
         async def refresh(self, request, token_set, sink):
-            raise RuntimeError("refresh token revoked")
+            raise OAuthTokenInvalidError("refresh token revoked")
 
         async def authorize(self, request, sink):
             return OAuthTokenSet(

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -4,11 +4,13 @@ import os
 
 from titan_cli.core.secrets import SecretManager
 
+
 # Fixture for a temporary project path
 @pytest.fixture
 def tmp_project_path(tmp_path):
     (tmp_path / ".titan").mkdir()
     return tmp_path
+
 
 # Fixture for mocking os.environ
 @pytest.fixture
@@ -16,19 +18,24 @@ def mock_env():
     with patch.dict(os.environ, clear=True):
         yield
 
+
 # Fixture for mocking keyring
 @pytest.fixture
 def mock_keyring():
-    with patch('keyring.get_password') as mock_get, \
-         patch('keyring.set_password') as mock_set, \
-         patch('keyring.delete_password') as mock_delete:
+    with (
+        patch("keyring.get_password") as mock_get,
+        patch("keyring.set_password") as mock_set,
+        patch("keyring.delete_password") as mock_delete,
+    ):
         yield mock_get, mock_set, mock_delete
+
 
 # Fixture for mocking dotenv
 @pytest.fixture
 def mock_dotenv():
-    with patch('titan_cli.core.secrets.load_dotenv') as mock_load:
+    with patch("titan_cli.core.secrets.load_dotenv") as mock_load:
         yield mock_load
+
 
 # --- Test SecretManager initialization and project secret loading ---
 def test_secret_manager_init_loads_project_secrets(tmp_project_path, mock_dotenv):
@@ -37,16 +44,19 @@ def test_secret_manager_init_loads_project_secrets(tmp_project_path, mock_dotenv
     SecretManager(project_path=tmp_project_path)
     mock_dotenv.assert_called_once_with(secrets_file)
 
+
 def test_secret_manager_init_no_project_secrets_file(tmp_project_path, mock_dotenv):
     SecretManager(project_path=tmp_project_path)
     mock_dotenv.assert_not_called()
+
 
 # --- Test get method ---
 def test_get_from_env(mock_env, mock_keyring):
     os.environ["MY_ENV_SECRET"] = "env_value"
     sm = SecretManager()
     assert sm.get("my_env_secret") == "env_value"
-    mock_keyring[0].assert_not_called() # keyring.get_password
+    mock_keyring[0].assert_not_called()  # keyring.get_password
+
 
 def test_get_from_keyring(mock_env, mock_keyring):
     mock_keyring[0].return_value = "keyring_value"
@@ -54,10 +64,12 @@ def test_get_from_keyring(mock_env, mock_keyring):
     assert sm.get("my_keyring_secret") == "keyring_value"
     mock_keyring[0].assert_called_once_with("titan", "my_keyring_secret")
 
+
 def test_get_none_if_not_found(mock_env, mock_keyring):
     mock_keyring[0].return_value = None
     sm = SecretManager()
     assert sm.get("non_existent_secret") is None
+
 
 def test_get_priority_env_over_keyring(mock_env, mock_keyring):
     os.environ["SHARED_SECRET"] = "env_value"
@@ -66,11 +78,74 @@ def test_get_priority_env_over_keyring(mock_env, mock_keyring):
     assert sm.get("shared_secret") == "env_value"
     mock_keyring[0].assert_not_called()
 
+
+def test_get_with_scope_identifies_project_secret(
+    tmp_project_path,
+    mock_env,
+    mock_keyring,
+):
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    resolved = sm.get_with_scope("project_token")
+
+    assert resolved is not None
+    assert resolved.value == "project_value"
+    assert resolved.scope == "project"
+    mock_keyring[0].assert_not_called()
+
+
+def test_get_with_scope_keeps_real_env_over_project_secret(
+    tmp_project_path,
+    mock_env,
+):
+    os.environ["PROJECT_TOKEN"] = "env_value"
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    resolved = sm.get_with_scope("project_token")
+
+    assert resolved is not None
+    assert resolved.value == "env_value"
+    assert resolved.scope == "env"
+
+
+def test_project_scope_updates_process_env_when_it_mirrors_project(
+    tmp_project_path,
+    mock_env,
+):
+    sm = SecretManager(project_path=tmp_project_path)
+
+    sm.set("project_token", "old_value", scope="project")
+    sm.set("project_token", "new_value", scope="project")
+
+    assert os.environ["PROJECT_TOKEN"] == "new_value"
+    resolved = sm.get_with_scope("project_token")
+    assert resolved is not None
+    assert resolved.value == "new_value"
+    assert resolved.scope == "project"
+
+
+def test_project_scope_delete_clears_process_env_when_it_mirrors_project(
+    tmp_project_path,
+    mock_env,
+):
+    sm = SecretManager(project_path=tmp_project_path)
+
+    sm.set("project_token", "project_value", scope="project")
+    sm.delete("project_token", scope="project")
+
+    assert "PROJECT_TOKEN" not in os.environ
+
+
 # --- Test set method ---
 def test_set_env_scope(mock_env):
     sm = SecretManager()
     sm.set("my_temp_secret", "temp_value", scope="env")
     assert os.environ["MY_TEMP_SECRET"] == "temp_value"
+
 
 def test_set_user_scope(mock_keyring):
     sm = SecretManager()
@@ -87,34 +162,38 @@ def test_set_user_scope_raises_when_keyring_write_fails(mock_keyring, tmp_projec
 
     assert not (tmp_project_path / ".titan" / "secrets.env").exists()
 
+
 def test_set_project_scope_new_secret(tmp_project_path):
     sm = SecretManager(project_path=tmp_project_path)
     sm.set("my_project_secret", "project_value", scope="project")
-    
+
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     assert secrets_file.exists()
     with open(secrets_file, "r") as f:
         content = f.read()
     assert "MY_PROJECT_SECRET='project_value'" in content
 
+
 def test_set_project_scope_update_secret(tmp_project_path):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("EXISTING_SECRET='old_value'\nOTHER_KEY='other_value'\n")
-    
+
     sm = SecretManager(project_path=tmp_project_path)
     sm.set("existing_secret", "new_value", scope="project")
-    
+
     with open(secrets_file, "r") as f:
         content = f.read()
     assert "EXISTING_SECRET='new_value'" in content
     assert "OTHER_KEY='other_value'" in content
     assert "EXISTING_SECRET='old_value'" not in content
 
+
 def test_set_project_scope_creates_dir_if_not_exists(tmp_path):
     project_path = tmp_path / "new_project"
     sm = SecretManager(project_path=project_path)
     sm.set("new_secret", "value", scope="project")
     assert (project_path / ".titan" / "secrets.env").exists()
+
 
 # --- Test delete method ---
 def test_delete_env_scope(mock_env):
@@ -123,30 +202,33 @@ def test_delete_env_scope(mock_env):
     sm.delete("to_delete", scope="env")
     assert "TO_DELETE" not in os.environ
 
+
 def test_delete_user_scope(mock_keyring):
     sm = SecretManager()
     sm.delete("to_delete", scope="user")
     mock_keyring[2].assert_called_once_with("titan", "to_delete")
 
+
 def test_delete_project_scope(tmp_project_path):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("TO_DELETE='value'\nOTHER_KEY='other_value'\n")
-    
+
     sm = SecretManager(project_path=tmp_project_path)
     sm.delete("to_delete", scope="project")
-    
+
     with open(secrets_file, "r") as f:
         content = f.read()
     assert "TO_DELETE" not in content
     assert "OTHER_KEY='other_value'" in content
 
+
 def test_delete_project_scope_secret_not_found(tmp_project_path):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("OTHER_KEY='other_value'\n")
-    
+
     sm = SecretManager(project_path=tmp_project_path)
     sm.delete("non_existent", scope="project")
-    
+
     with open(secrets_file, "r") as f:
         content = f.read()
-    assert "OTHER_KEY='other_value'" in content # Content should be unchanged
+    assert "OTHER_KEY='other_value'" in content  # Content should be unchanged

--- a/tests/engine/test_workflow_context_builder_firebase.py
+++ b/tests/engine/test_workflow_context_builder_firebase.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from titan_cli.engine.builder import WorkflowContextBuilder
+from titan_plugin_firebase.plugin import FirebasePlugin
 
 
 def test_with_firebase_loads_client_from_plugin_registry() -> None:
@@ -12,11 +13,15 @@ def test_with_firebase_loads_client_from_plugin_registry() -> None:
     firebase_plugin.is_available.return_value = True
     firebase_plugin.get_client.return_value = firebase_client
 
-    ctx = WorkflowContextBuilder(
-        plugin_registry=plugin_registry,
-        secrets=MagicMock(),
-        ai_config=None,
-    ).with_firebase().build()
+    ctx = (
+        WorkflowContextBuilder(
+            plugin_registry=plugin_registry,
+            secrets=MagicMock(),
+            ai_config=None,
+        )
+        .with_firebase()
+        .build()
+    )
 
     assert ctx.firebase is firebase_client
 
@@ -25,10 +30,42 @@ def test_with_firebase_uses_explicit_client() -> None:
     plugin_registry = MagicMock()
     firebase_client = MagicMock()
 
-    ctx = WorkflowContextBuilder(
-        plugin_registry=plugin_registry,
-        secrets=MagicMock(),
-        ai_config=None,
-    ).with_firebase(firebase_client).build()
+    ctx = (
+        WorkflowContextBuilder(
+            plugin_registry=plugin_registry,
+            secrets=MagicMock(),
+            ai_config=None,
+        )
+        .with_firebase(firebase_client)
+        .build()
+    )
 
     assert ctx.firebase is firebase_client
+
+
+def test_with_firebase_injects_initialized_plugin_client_without_auth(
+    monkeypatch,
+) -> None:
+    plugin_registry = MagicMock()
+    firebase_plugin = FirebasePlugin()
+    config = MagicMock()
+    config.config.plugins = {"firebase": MagicMock(config={})}
+    firebase_plugin.initialize(config, MagicMock())
+    monkeypatch.setattr(
+        firebase_plugin.get_client(),
+        "is_available",
+        MagicMock(return_value=False),
+    )
+    plugin_registry.get_plugin.return_value = firebase_plugin
+
+    ctx = (
+        WorkflowContextBuilder(
+            plugin_registry=plugin_registry,
+            secrets=MagicMock(),
+            ai_config=None,
+        )
+        .with_firebase()
+        .build()
+    )
+
+    assert ctx.firebase is firebase_plugin.get_client()

--- a/tests/engine/test_workflow_context_builder_firebase.py
+++ b/tests/engine/test_workflow_context_builder_firebase.py
@@ -1,0 +1,34 @@
+from unittest.mock import MagicMock
+
+from titan_cli.engine.builder import WorkflowContextBuilder
+
+
+def test_with_firebase_loads_client_from_plugin_registry() -> None:
+    plugin_registry = MagicMock()
+    firebase_plugin = MagicMock()
+    firebase_client = MagicMock()
+
+    plugin_registry.get_plugin.return_value = firebase_plugin
+    firebase_plugin.is_available.return_value = True
+    firebase_plugin.get_client.return_value = firebase_client
+
+    ctx = WorkflowContextBuilder(
+        plugin_registry=plugin_registry,
+        secrets=MagicMock(),
+        ai_config=None,
+    ).with_firebase().build()
+
+    assert ctx.firebase is firebase_client
+
+
+def test_with_firebase_uses_explicit_client() -> None:
+    plugin_registry = MagicMock()
+    firebase_client = MagicMock()
+
+    ctx = WorkflowContextBuilder(
+        plugin_registry=plugin_registry,
+        secrets=MagicMock(),
+        ai_config=None,
+    ).with_firebase(firebase_client).build()
+
+    assert ctx.firebase is firebase_client

--- a/tests/ui/test_plugin_config_resolver.py
+++ b/tests/ui/test_plugin_config_resolver.py
@@ -52,3 +52,16 @@ def test_resolve_plugin_config_screen_falls_back_to_generic_wizard() -> None:
 
     assert isinstance(screen, PluginConfigWizardScreen)
     assert screen.plugin_name == "sample"
+
+
+def test_generic_plugin_config_wizard_skips_hidden_schema_fields() -> None:
+    config = MagicMock()
+    screen = PluginConfigWizardScreen(config, "sample")
+    screen.properties = {
+        "oauth_client_id": {"type": "string"},
+        "access_token": {"type": "string", "ui_hidden": True},
+    }
+
+    screen._build_steps()
+
+    assert [step["id"] for step in screen.steps] == ["oauth_client_id", "review"]

--- a/titan_cli/core/oauth/__init__.py
+++ b/titan_cli/core/oauth/__init__.py
@@ -14,6 +14,7 @@ from .exceptions import (
     OAuthLockTimeout,
     OAuthProviderNotFound,
     OAuthStorageError,
+    OAuthTokenInvalidError,
     OAuthTokenRefreshError,
 )
 from .locks import OAuthHeldLock, OAuthLockManager
@@ -42,6 +43,7 @@ __all__ = [
     "OAuthProviderNotFound",
     "OAuthRequest",
     "OAuthStorageError",
+    "OAuthTokenInvalidError",
     "OAuthTokenRefreshError",
     "OAuthTokenSet",
     "OAuthTokenStore",

--- a/titan_cli/core/oauth/__init__.py
+++ b/titan_cli/core/oauth/__init__.py
@@ -1,0 +1,51 @@
+"""OAuth coordination primitives for Titan plugins."""
+
+from .events import (
+    CollectingOAuthEventSink,
+    NullOAuthEventSink,
+    OAuthEvent,
+    OAuthEventSink,
+    QueuedOAuthEventSink,
+)
+from .exceptions import (
+    OAuthAuthenticationRequired,
+    OAuthAuthorizationError,
+    OAuthError,
+    OAuthLockTimeout,
+    OAuthProviderNotFound,
+    OAuthStorageError,
+    OAuthTokenRefreshError,
+)
+from .locks import OAuthHeldLock, OAuthLockManager
+from .manager import OAuthManager, OAuthProvider
+from .models import (
+    OAuthCredential,
+    OAuthRequest,
+    OAuthTokenSet,
+    build_oauth_credential_key,
+)
+from .storage import OAuthTokenStore
+
+__all__ = [
+    "CollectingOAuthEventSink",
+    "NullOAuthEventSink",
+    "OAuthAuthenticationRequired",
+    "OAuthAuthorizationError",
+    "OAuthCredential",
+    "OAuthError",
+    "OAuthEvent",
+    "OAuthEventSink",
+    "OAuthHeldLock",
+    "OAuthLockManager",
+    "OAuthManager",
+    "OAuthProvider",
+    "OAuthProviderNotFound",
+    "OAuthRequest",
+    "OAuthStorageError",
+    "OAuthTokenRefreshError",
+    "OAuthTokenSet",
+    "OAuthTokenStore",
+    "OAuthLockTimeout",
+    "QueuedOAuthEventSink",
+    "build_oauth_credential_key",
+]

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from queue import Empty, Queue
+from queue import Empty, Full, Queue
+from threading import Lock
 from typing import Any, Protocol
 
 
@@ -53,10 +54,21 @@ class QueuedOAuthEventSink:
 
     def __init__(self, maxsize: int = 0) -> None:
         self.queue: Queue[OAuthEvent] = Queue(maxsize=maxsize)
+        self._dropped_count = 0
+        self._dropped_count_lock = Lock()
 
     def emit(self, event: OAuthEvent) -> None:
-        """Queue an OAuth event without exposing token material."""
-        self.queue.put_nowait(event)
+        """Queue an OAuth event without allowing overflow to abort OAuth."""
+        try:
+            self.queue.put_nowait(event)
+        except Full:
+            self._record_dropped_event()
+
+    @property
+    def dropped_count(self) -> int:
+        """Return how many events were dropped because the queue was full."""
+        with self._dropped_count_lock:
+            return self._dropped_count
 
     def get(
         self,
@@ -78,3 +90,8 @@ class QueuedOAuthEventSink:
             if event is None:
                 return events
             events.append(event)
+
+    def _record_dropped_event(self) -> None:
+        """Record a dropped event without blocking the OAuth flow."""
+        with self._dropped_count_lock:
+            self._dropped_count += 1

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -1,0 +1,80 @@
+"""Provider-neutral OAuth events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from queue import Empty, Queue
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class OAuthEvent:
+    """A safe OAuth lifecycle event.
+
+    Events must never include raw access tokens or refresh tokens.
+    """
+
+    type: str
+    operation_id: str
+    credential_key: str | None = None
+    provider: str | None = None
+    connection_id: str | None = None
+    message: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class OAuthEventSink(Protocol):
+    """Receives OAuth lifecycle events."""
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Handle an OAuth event."""
+
+
+class NullOAuthEventSink:
+    """Event sink that intentionally discards every OAuth event."""
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Discard an OAuth event."""
+
+
+class CollectingOAuthEventSink:
+    """Event sink useful for tests and headless callers."""
+
+    def __init__(self) -> None:
+        self.events: list[OAuthEvent] = []
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Record an OAuth event."""
+        self.events.append(event)
+
+
+class QueuedOAuthEventSink:
+    """Thread-safe queue-backed sink for runtime event dispatchers."""
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self.queue: Queue[OAuthEvent] = Queue(maxsize=maxsize)
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Queue an OAuth event without exposing token material."""
+        self.queue.put_nowait(event)
+
+    def get(
+        self,
+        *,
+        block: bool = True,
+        timeout: float | None = None,
+    ) -> OAuthEvent | None:
+        """Return the next queued event, or None when no event is available."""
+        try:
+            return self.queue.get(block=block, timeout=timeout)
+        except Empty:
+            return None
+
+    def drain(self) -> list[OAuthEvent]:
+        """Return all currently queued events."""
+        events = []
+        while True:
+            event = self.get(block=False)
+            if event is None:
+                return events
+            events.append(event)

--- a/titan_cli/core/oauth/exceptions.py
+++ b/titan_cli/core/oauth/exceptions.py
@@ -25,5 +25,9 @@ class OAuthTokenRefreshError(OAuthError):
     """Raised when an OAuth provider cannot refresh an expired credential."""
 
 
+class OAuthTokenInvalidError(OAuthTokenRefreshError):
+    """Raised when a stored OAuth refresh token is explicitly invalid."""
+
+
 class OAuthLockTimeout(OAuthError):
     """Raised when a credential lock cannot be acquired in time."""

--- a/titan_cli/core/oauth/exceptions.py
+++ b/titan_cli/core/oauth/exceptions.py
@@ -1,0 +1,29 @@
+"""Exceptions raised by Titan's OAuth coordination layer."""
+
+
+class OAuthError(Exception):
+    """Base exception for OAuth coordination failures."""
+
+
+class OAuthAuthenticationRequired(OAuthError):
+    """Raised when no usable credential is available."""
+
+
+class OAuthAuthorizationError(OAuthError):
+    """Raised when an OAuth provider cannot authorize a new credential."""
+
+
+class OAuthProviderNotFound(OAuthError):
+    """Raised when a request needs an OAuth provider that is not registered."""
+
+
+class OAuthStorageError(OAuthError):
+    """Raised when OAuth credential storage cannot be read or written."""
+
+
+class OAuthTokenRefreshError(OAuthError):
+    """Raised when an OAuth provider cannot refresh an expired credential."""
+
+
+class OAuthLockTimeout(OAuthError):
+    """Raised when a credential lock cannot be acquired in time."""

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+import errno
 import hashlib
 import os
 from pathlib import Path
@@ -48,7 +49,10 @@ class _FileLock:
                 self._try_acquire_once()
                 self._acquired = True
                 return
-            except (BlockingIOError, OSError):
+            except OSError as exc:
+                if not self._is_lock_contention(exc):
+                    self._close_handle()
+                    raise
                 if self._timed_out(start):
                     self._close_handle()
                     raise OAuthLockTimeout(
@@ -98,6 +102,17 @@ class _FileLock:
         if self.timeout_seconds is None:
             return False
         return time.monotonic() - start >= self.timeout_seconds
+
+    def _is_lock_contention(self, exc: OSError) -> bool:
+        """Return whether an OS error represents a busy lock."""
+        if getattr(exc, "winerror", None) in {32, 33}:
+            return True
+        lock_contention_errnos = {
+            errno.EACCES,
+            errno.EAGAIN,
+            errno.EWOULDBLOCK,
+        }
+        return exc.errno in lock_contention_errnos
 
     def _close_handle(self) -> None:
         if self._handle:

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -14,6 +14,10 @@ import time
 from .exceptions import OAuthLockTimeout
 
 
+class _OAuthLockAcquisitionCancelled(Exception):
+    """Raised inside the worker thread when async lock acquisition is cancelled."""
+
+
 class _FileLock:
     """Small cross-process file lock with no third-party dependency."""
 
@@ -30,13 +34,16 @@ class _FileLock:
         self._handle = None
         self._acquired = False
 
-    def acquire(self) -> None:
+    def acquire(self, cancel_event: threading.Event | None = None) -> None:
         """Acquire the file lock, waiting up to timeout_seconds."""
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._handle = open(self.path, "a+")
         start = time.monotonic()
 
         while True:
+            if cancel_event and cancel_event.is_set():
+                self._close_handle()
+                raise _OAuthLockAcquisitionCancelled
             try:
                 self._try_acquire_once()
                 self._acquired = True
@@ -138,27 +145,44 @@ class OAuthLockManager:
         timeout_seconds: float | None = 60,
     ) -> OAuthHeldLock:
         """Acquire a credential lock without blocking the event loop."""
-        return await asyncio.to_thread(
-            self.acquire_blocking,
-            key,
-            timeout_seconds=timeout_seconds,
+        cancel_event = threading.Event()
+        worker = asyncio.create_task(
+            asyncio.to_thread(
+                self.acquire_blocking,
+                key,
+                timeout_seconds=timeout_seconds,
+                _cancel_event=cancel_event,
+            )
         )
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            try:
+                held_lock = await asyncio.shield(worker)
+            except _OAuthLockAcquisitionCancelled:
+                pass
+            except OAuthLockTimeout:
+                pass
+            else:
+                held_lock.release()
+            raise
 
     def acquire_blocking(
         self,
         key: str,
         *,
         timeout_seconds: float | None = 60,
+        _cancel_event: threading.Event | None = None,
     ) -> OAuthHeldLock:
         """Acquire a credential lock from synchronous code."""
         thread_lock = self._get_thread_lock(key)
-        if timeout_seconds is None:
-            acquired = thread_lock.acquire()
-        else:
-            acquired = thread_lock.acquire(timeout=timeout_seconds)
-
-        if not acquired:
-            raise OAuthLockTimeout(f"Timed out waiting for OAuth lock '{key}'.")
+        self._acquire_thread_lock(
+            thread_lock,
+            key,
+            timeout_seconds=timeout_seconds,
+            cancel_event=_cancel_event,
+        )
 
         file_lock = None
         try:
@@ -168,7 +192,7 @@ class OAuthLockManager:
                     timeout_seconds=timeout_seconds,
                     poll_interval_seconds=self.poll_interval_seconds,
                 )
-                file_lock.acquire()
+                file_lock.acquire(cancel_event=_cancel_event)
             return OAuthHeldLock(key=key, thread_lock=thread_lock, file_lock=file_lock)
         except Exception:
             thread_lock.release()
@@ -187,6 +211,47 @@ class OAuthLockManager:
             yield held_lock
         finally:
             await asyncio.to_thread(held_lock.release)
+
+    def _acquire_thread_lock(
+        self,
+        thread_lock: threading.Lock,
+        key: str,
+        *,
+        timeout_seconds: float | None,
+        cancel_event: threading.Event | None,
+    ) -> None:
+        """Acquire an in-process lock while observing async cancellation."""
+        start = time.monotonic()
+        while True:
+            if cancel_event and cancel_event.is_set():
+                raise _OAuthLockAcquisitionCancelled
+
+            acquired = thread_lock.acquire(
+                timeout=self._next_poll_timeout(start, timeout_seconds)
+            )
+            if acquired:
+                return
+
+            if self._timed_out(start, timeout_seconds):
+                raise OAuthLockTimeout(f"Timed out waiting for OAuth lock '{key}'.")
+
+    def _next_poll_timeout(
+        self,
+        start: float,
+        timeout_seconds: float | None,
+    ) -> float:
+        """Return the next bounded wait interval for cancellable acquisition."""
+        if timeout_seconds is None:
+            return self.poll_interval_seconds
+        remaining = timeout_seconds - (time.monotonic() - start)
+        return max(0.0, min(self.poll_interval_seconds, remaining))
+
+    def _timed_out(self, start: float, timeout_seconds: float | None) -> bool:
+        """Return whether a lock wait exceeded its timeout."""
+        return (
+            timeout_seconds is not None
+            and time.monotonic() - start >= timeout_seconds
+        )
 
     def _get_thread_lock(self, key: str) -> threading.Lock:
         with self._guard:

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -1,0 +1,199 @@
+"""Credential-scoped locks for OAuth operations."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import threading
+import time
+
+from .exceptions import OAuthLockTimeout
+
+
+class _FileLock:
+    """Small cross-process file lock with no third-party dependency."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        timeout_seconds: float | None,
+        poll_interval_seconds: float,
+    ) -> None:
+        self.path = path
+        self.timeout_seconds = timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self._handle = None
+        self._acquired = False
+
+    def acquire(self) -> None:
+        """Acquire the file lock, waiting up to timeout_seconds."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = open(self.path, "a+")
+        start = time.monotonic()
+
+        while True:
+            try:
+                self._try_acquire_once()
+                self._acquired = True
+                return
+            except (BlockingIOError, OSError):
+                if self._timed_out(start):
+                    self._close_handle()
+                    raise OAuthLockTimeout(
+                        f"Timed out waiting for OAuth lock '{self.path.name}'."
+                    )
+                time.sleep(self.poll_interval_seconds)
+
+    def release(self) -> None:
+        """Release the file lock."""
+        if not self._handle:
+            return
+
+        try:
+            if self._acquired:
+                if os.name == "nt":
+                    import msvcrt
+
+                    self._handle.seek(0)
+                    msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._acquired = False
+            self._close_handle()
+
+    def _try_acquire_once(self) -> None:
+        if not self._handle:
+            raise RuntimeError("File lock handle is not open.")
+
+        if os.name == "nt":
+            import msvcrt
+
+            self._handle.seek(0)
+            self._handle.write("0")
+            self._handle.flush()
+            self._handle.seek(0)
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _timed_out(self, start: float) -> bool:
+        if self.timeout_seconds is None:
+            return False
+        return time.monotonic() - start >= self.timeout_seconds
+
+    def _close_handle(self) -> None:
+        if self._handle:
+            self._handle.close()
+            self._handle = None
+
+
+@dataclass
+class OAuthHeldLock:
+    """A held OAuth credential lock."""
+
+    key: str
+    thread_lock: threading.Lock
+    file_lock: _FileLock | None = None
+
+    def release(self) -> None:
+        """Release file and in-process locks."""
+        try:
+            if self.file_lock:
+                self.file_lock.release()
+        finally:
+            self.thread_lock.release()
+
+
+class OAuthLockManager:
+    """Coordinates refresh/login for the same OAuth credential."""
+
+    def __init__(
+        self,
+        *,
+        lock_dir: Path | None = None,
+        poll_interval_seconds: float = 0.05,
+        enable_file_locks: bool = True,
+    ) -> None:
+        self.lock_dir = lock_dir or Path.home() / ".titan" / "oauth" / "locks"
+        self.poll_interval_seconds = poll_interval_seconds
+        self.enable_file_locks = enable_file_locks
+        self._guard = threading.Lock()
+        self._locks: dict[str, threading.Lock] = {}
+
+    async def acquire(
+        self,
+        key: str,
+        *,
+        timeout_seconds: float | None = 60,
+    ) -> OAuthHeldLock:
+        """Acquire a credential lock without blocking the event loop."""
+        return await asyncio.to_thread(
+            self.acquire_blocking,
+            key,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def acquire_blocking(
+        self,
+        key: str,
+        *,
+        timeout_seconds: float | None = 60,
+    ) -> OAuthHeldLock:
+        """Acquire a credential lock from synchronous code."""
+        thread_lock = self._get_thread_lock(key)
+        if timeout_seconds is None:
+            acquired = thread_lock.acquire()
+        else:
+            acquired = thread_lock.acquire(timeout=timeout_seconds)
+
+        if not acquired:
+            raise OAuthLockTimeout(f"Timed out waiting for OAuth lock '{key}'.")
+
+        file_lock = None
+        try:
+            if self.enable_file_locks:
+                file_lock = _FileLock(
+                    self._lock_path(key),
+                    timeout_seconds=timeout_seconds,
+                    poll_interval_seconds=self.poll_interval_seconds,
+                )
+                file_lock.acquire()
+            return OAuthHeldLock(key=key, thread_lock=thread_lock, file_lock=file_lock)
+        except Exception:
+            thread_lock.release()
+            raise
+
+    @asynccontextmanager
+    async def lock(
+        self,
+        key: str,
+        *,
+        timeout_seconds: float | None = 60,
+    ):
+        """Async context manager for a credential lock."""
+        held_lock = await self.acquire(key, timeout_seconds=timeout_seconds)
+        try:
+            yield held_lock
+        finally:
+            await asyncio.to_thread(held_lock.release)
+
+    def _get_thread_lock(self, key: str) -> threading.Lock:
+        with self._guard:
+            if key not in self._locks:
+                self._locks[key] = threading.Lock()
+            return self._locks[key]
+
+    def _lock_path(self, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self.lock_dir / f"{digest}.lock"

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -39,6 +39,11 @@ class _FileLock:
         """Acquire the file lock, waiting up to timeout_seconds."""
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._handle = open(self.path, "a+")
+        try:
+            self._ensure_windows_lock_byte()
+        except Exception:
+            self._close_handle()
+            raise
         start = time.monotonic()
 
         while True:
@@ -88,9 +93,6 @@ class _FileLock:
             import msvcrt
 
             self._handle.seek(0)
-            self._handle.write("0")
-            self._handle.flush()
-            self._handle.seek(0)
             msvcrt.locking(self._handle.fileno(), msvcrt.LK_NBLCK, 1)
             return
 
@@ -113,6 +115,18 @@ class _FileLock:
             errno.EWOULDBLOCK,
         }
         return exc.errno in lock_contention_errnos
+
+    def _ensure_windows_lock_byte(self) -> None:
+        """Initialize the byte Windows locks without growing the file on retries."""
+        if os.name != "nt" or not self._handle:
+            return
+        self._handle.seek(0, os.SEEK_END)
+        if self._handle.tell() > 0:
+            self._handle.seek(0)
+            return
+        self._handle.write("0")
+        self._handle.flush()
+        self._handle.seek(0)
 
     def _close_handle(self) -> None:
         if self._handle:

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -176,11 +176,13 @@ class OAuthLockManager:
         _cancel_event: threading.Event | None = None,
     ) -> OAuthHeldLock:
         """Acquire a credential lock from synchronous code."""
+        started_at = time.monotonic()
         thread_lock = self._get_thread_lock(key)
         self._acquire_thread_lock(
             thread_lock,
             key,
             timeout_seconds=timeout_seconds,
+            started_at=started_at,
             cancel_event=_cancel_event,
         )
 
@@ -189,7 +191,10 @@ class OAuthLockManager:
             if self.enable_file_locks:
                 file_lock = _FileLock(
                     self._lock_path(key),
-                    timeout_seconds=timeout_seconds,
+                    timeout_seconds=self._remaining_timeout(
+                        started_at,
+                        timeout_seconds,
+                    ),
                     poll_interval_seconds=self.poll_interval_seconds,
                 )
                 file_lock.acquire(cancel_event=_cancel_event)
@@ -218,21 +223,21 @@ class OAuthLockManager:
         key: str,
         *,
         timeout_seconds: float | None,
+        started_at: float,
         cancel_event: threading.Event | None,
     ) -> None:
         """Acquire an in-process lock while observing async cancellation."""
-        start = time.monotonic()
         while True:
             if cancel_event and cancel_event.is_set():
                 raise _OAuthLockAcquisitionCancelled
 
             acquired = thread_lock.acquire(
-                timeout=self._next_poll_timeout(start, timeout_seconds)
+                timeout=self._next_poll_timeout(started_at, timeout_seconds)
             )
             if acquired:
                 return
 
-            if self._timed_out(start, timeout_seconds):
+            if self._timed_out(started_at, timeout_seconds):
                 raise OAuthLockTimeout(f"Timed out waiting for OAuth lock '{key}'.")
 
     def _next_poll_timeout(
@@ -245,6 +250,16 @@ class OAuthLockManager:
             return self.poll_interval_seconds
         remaining = timeout_seconds - (time.monotonic() - start)
         return max(0.0, min(self.poll_interval_seconds, remaining))
+
+    def _remaining_timeout(
+        self,
+        start: float,
+        timeout_seconds: float | None,
+    ) -> float | None:
+        """Return remaining timeout budget from a shared acquisition start."""
+        if timeout_seconds is None:
+            return None
+        return max(0.0, timeout_seconds - (time.monotonic() - start))
 
     def _timed_out(self, start: float, timeout_seconds: float | None) -> bool:
         """Return whether a lock wait exceeded its timeout."""

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -93,7 +93,7 @@ class OAuthManager:
             self._emit_resolved(event_sink, operation_id, request, credential)
             return credential
 
-        stored_token_set = self.token_store.read(request)
+        stored_token_set = self.token_store.read_with_scope(request)
         provider = self.providers.get(request.provider)
         if not provider:
             legacy_credential = self._credential_from_legacy_secret(
@@ -109,7 +109,7 @@ class OAuthManager:
                 )
                 return legacy_credential
 
-            if stored_token_set and stored_token_set.refresh_token:
+            if stored_token_set and stored_token_set.token_set.refresh_token:
                 self._emit(
                     event_sink,
                     "oauth.provider.missing",
@@ -165,8 +165,10 @@ class OAuthManager:
                 self._emit_resolved(event_sink, operation_id, request, credential)
                 return credential
 
-            stored_token_set = self.token_store.read(request)
-            if stored_token_set and stored_token_set.refresh_token:
+            stored_token_set = self.token_store.read_with_scope(request)
+            reauthorize_storage_scope: ScopeType = "user"
+            if stored_token_set and stored_token_set.token_set.refresh_token:
+                storage_scope = stored_token_set.scope
                 self._emit(
                     event_sink,
                     "oauth.refresh.started",
@@ -178,7 +180,7 @@ class OAuthManager:
                 try:
                     refreshed = await provider.refresh(
                         request,
-                        stored_token_set,
+                        stored_token_set.token_set,
                         event_sink,
                     )
                 except OAuthError:
@@ -192,7 +194,8 @@ class OAuthManager:
                     )
                     if not request.interactive:
                         raise
-                    self.token_store.delete(request)
+                    self.token_store.delete(request, scope=storage_scope)
+                    reauthorize_storage_scope = storage_scope
                     self._emit(
                         event_sink,
                         "oauth.refresh.stale_deleted",
@@ -212,7 +215,8 @@ class OAuthManager:
                     )
                     if not request.interactive:
                         raise OAuthTokenRefreshError(str(exc)) from exc
-                    self.token_store.delete(request)
+                    self.token_store.delete(request, scope=storage_scope)
+                    reauthorize_storage_scope = storage_scope
                     self._emit(
                         event_sink,
                         "oauth.refresh.stale_deleted",
@@ -222,7 +226,7 @@ class OAuthManager:
                         "Deleted stale OAuth credential after refresh failure.",
                     )
                 else:
-                    self.token_store.write(request, refreshed)
+                    self.token_store.write(request, refreshed, scope=storage_scope)
                     credential = self._credential_from_token_set(
                         request,
                         credential_key,
@@ -263,7 +267,11 @@ class OAuthManager:
                         "OAuth authorization failed.",
                     )
                     raise OAuthAuthorizationError(str(exc)) from exc
-                self.token_store.write(request, token_set)
+                self.token_store.write(
+                    request,
+                    token_set,
+                    scope=reauthorize_storage_scope,
+                )
                 credential = self._credential_from_token_set(
                     request,
                     credential_key,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -15,6 +15,7 @@ from .exceptions import (
     OAuthAuthorizationError,
     OAuthError,
     OAuthProviderNotFound,
+    OAuthTokenInvalidError,
     OAuthTokenRefreshError,
 )
 from .locks import OAuthLockManager
@@ -183,7 +184,7 @@ class OAuthManager:
                         stored_token_set.token_set,
                         event_sink,
                     )
-                except OAuthError:
+                except OAuthTokenInvalidError:
                     self._emit(
                         event_sink,
                         "oauth.refresh.failed",
@@ -204,6 +205,18 @@ class OAuthManager:
                         credential_key,
                         "Deleted stale OAuth credential after refresh failure.",
                     )
+                except OAuthError:
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth refresh failed.",
+                    )
+                    if not request.interactive:
+                        raise
+                    reauthorize_storage_scope = storage_scope
                 except Exception as exc:
                     self._emit(
                         event_sink,
@@ -215,16 +228,7 @@ class OAuthManager:
                     )
                     if not request.interactive:
                         raise OAuthTokenRefreshError(str(exc)) from exc
-                    self.token_store.delete(request, scope=storage_scope)
                     reauthorize_storage_scope = storage_scope
-                    self._emit(
-                        event_sink,
-                        "oauth.refresh.stale_deleted",
-                        operation_id,
-                        request,
-                        credential_key,
-                        "Deleted stale OAuth credential after refresh failure.",
-                    )
                 else:
                     self.token_store.write(request, refreshed, scope=storage_scope)
                     credential = self._credential_from_token_set(

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -240,6 +240,19 @@ class OAuthManager:
                     self._emit_resolved(event_sink, operation_id, request, credential)
                     return credential
 
+            legacy_credential = self._credential_from_legacy_secret(
+                request,
+                credential_key,
+            )
+            if legacy_credential:
+                self._emit_resolved(
+                    event_sink,
+                    operation_id,
+                    request,
+                    legacy_credential,
+                )
+                return legacy_credential
+
             if request.interactive:
                 self._emit(
                     event_sink,
@@ -284,19 +297,6 @@ class OAuthManager:
                 )
                 self._emit_resolved(event_sink, operation_id, request, credential)
                 return credential
-
-            legacy_credential = self._credential_from_legacy_secret(
-                request,
-                credential_key,
-            )
-            if legacy_credential:
-                self._emit_resolved(
-                    event_sink,
-                    operation_id,
-                    request,
-                    legacy_credential,
-                )
-                return legacy_credential
 
             self._emit(
                 event_sink,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -1,0 +1,502 @@
+"""Async-ready OAuth credential manager."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import Protocol
+
+from titan_cli.core.secrets import ScopeType, SecretManager
+
+from .events import NullOAuthEventSink, OAuthEvent, OAuthEventSink
+from .exceptions import (
+    OAuthAuthenticationRequired,
+    OAuthAuthorizationError,
+    OAuthError,
+    OAuthProviderNotFound,
+    OAuthTokenRefreshError,
+)
+from .locks import OAuthLockManager
+from .models import (
+    OAuthCredential,
+    OAuthRequest,
+    OAuthTokenSet,
+    build_oauth_credential_key,
+)
+from .storage import OAuthTokenStore
+
+
+class OAuthProvider(Protocol):
+    """Provider adapter used by OAuthManager for refresh/login flows."""
+
+    async def refresh(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        sink: OAuthEventSink,
+    ) -> OAuthTokenSet:
+        """Refresh a stored token set."""
+
+    async def authorize(
+        self,
+        request: OAuthRequest,
+        sink: OAuthEventSink,
+    ) -> OAuthTokenSet:
+        """Run an interactive authorization flow."""
+
+
+class OAuthManager:
+    """Resolves OAuth credentials through env, storage, legacy keys, and providers."""
+
+    def __init__(
+        self,
+        secrets: SecretManager,
+        *,
+        providers: dict[str, OAuthProvider] | None = None,
+        token_store: OAuthTokenStore | None = None,
+        lock_manager: OAuthLockManager | None = None,
+        refresh_margin_seconds: int = 300,
+    ) -> None:
+        self.secrets = secrets
+        self.providers = providers or {}
+        self.token_store = token_store or OAuthTokenStore(secrets)
+        self.lock_manager = lock_manager or OAuthLockManager()
+        self.refresh_margin_seconds = refresh_margin_seconds
+
+    async def get_credential(
+        self,
+        request: OAuthRequest,
+        *,
+        sink: OAuthEventSink | None = None,
+    ) -> OAuthCredential:
+        """Resolve a credential without blocking the event loop while waiting."""
+        event_sink = sink or NullOAuthEventSink()
+        operation_id = uuid.uuid4().hex
+        credential_key = build_oauth_credential_key(request)
+
+        self._emit(
+            event_sink,
+            "oauth.resolve.started",
+            operation_id,
+            request,
+            credential_key,
+            "Resolving OAuth credential.",
+        )
+
+        credential = self._resolve_without_provider(
+            request,
+            credential_key,
+            include_legacy=False,
+        )
+        if credential:
+            self._emit_resolved(event_sink, operation_id, request, credential)
+            return credential
+
+        stored_token_set = self.token_store.read(request)
+        provider = self.providers.get(request.provider)
+        if not provider:
+            legacy_credential = self._credential_from_legacy_secret(
+                request,
+                credential_key,
+            )
+            if legacy_credential:
+                self._emit_resolved(
+                    event_sink,
+                    operation_id,
+                    request,
+                    legacy_credential,
+                )
+                return legacy_credential
+
+            if stored_token_set and stored_token_set.refresh_token:
+                self._emit(
+                    event_sink,
+                    "oauth.provider.missing",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "OAuth refresh provider is not registered.",
+                )
+                raise OAuthProviderNotFound(
+                    f"OAuth provider '{request.provider}' is not registered."
+                )
+            if request.interactive:
+                self._emit(
+                    event_sink,
+                    "oauth.provider.missing",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "OAuth authorization provider is not registered.",
+                )
+                raise OAuthProviderNotFound(
+                    f"OAuth provider '{request.provider}' is not registered."
+                )
+
+            self._emit(
+                event_sink,
+                "oauth.resolve.auth_required",
+                operation_id,
+                request,
+                credential_key,
+                "OAuth authentication is required.",
+            )
+            raise OAuthAuthenticationRequired(
+                f"OAuth credential for '{request.connection_id}' is not available."
+            )
+
+        async with self.lock_manager.lock(credential_key):
+            self._emit(
+                event_sink,
+                "oauth.lock.acquired",
+                operation_id,
+                request,
+                credential_key,
+                "OAuth credential lock acquired.",
+            )
+
+            credential = self._resolve_without_provider(
+                request,
+                credential_key,
+                include_legacy=False,
+            )
+            if credential:
+                self._emit_resolved(event_sink, operation_id, request, credential)
+                return credential
+
+            stored_token_set = self.token_store.read(request)
+            if stored_token_set and stored_token_set.refresh_token:
+                self._emit(
+                    event_sink,
+                    "oauth.refresh.started",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "Refreshing OAuth credential.",
+                )
+                try:
+                    refreshed = await provider.refresh(
+                        request,
+                        stored_token_set,
+                        event_sink,
+                    )
+                except OAuthError:
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth refresh failed.",
+                    )
+                    if not request.interactive:
+                        raise
+                    self.token_store.delete(request)
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.stale_deleted",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "Deleted stale OAuth credential after refresh failure.",
+                    )
+                except Exception as exc:
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth refresh failed.",
+                    )
+                    if not request.interactive:
+                        raise OAuthTokenRefreshError(str(exc)) from exc
+                    self.token_store.delete(request)
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.stale_deleted",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "Deleted stale OAuth credential after refresh failure.",
+                    )
+                else:
+                    self.token_store.write(request, refreshed)
+                    credential = self._credential_from_token_set(
+                        request,
+                        credential_key,
+                        refreshed,
+                        source="oauth-refresh",
+                    )
+                    self._emit_resolved(event_sink, operation_id, request, credential)
+                    return credential
+
+            if request.interactive:
+                self._emit(
+                    event_sink,
+                    "oauth.authorize.started",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "Starting OAuth authorization.",
+                )
+                try:
+                    token_set = await provider.authorize(request, event_sink)
+                except OAuthError:
+                    self._emit(
+                        event_sink,
+                        "oauth.authorize.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth authorization failed.",
+                    )
+                    raise
+                except Exception as exc:
+                    self._emit(
+                        event_sink,
+                        "oauth.authorize.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth authorization failed.",
+                    )
+                    raise OAuthAuthorizationError(str(exc)) from exc
+                self.token_store.write(request, token_set)
+                credential = self._credential_from_token_set(
+                    request,
+                    credential_key,
+                    token_set,
+                    source="oauth-login",
+                )
+                self._emit_resolved(event_sink, operation_id, request, credential)
+                return credential
+
+            legacy_credential = self._credential_from_legacy_secret(
+                request,
+                credential_key,
+            )
+            if legacy_credential:
+                self._emit_resolved(
+                    event_sink,
+                    operation_id,
+                    request,
+                    legacy_credential,
+                )
+                return legacy_credential
+
+            self._emit(
+                event_sink,
+                "oauth.resolve.auth_required",
+                operation_id,
+                request,
+                credential_key,
+                "OAuth authentication is required.",
+            )
+            raise OAuthAuthenticationRequired(
+                f"OAuth credential for '{request.connection_id}' is not available."
+            )
+
+    def get_credential_blocking(
+        self,
+        request: OAuthRequest,
+        *,
+        sink: OAuthEventSink | None = None,
+    ) -> OAuthCredential:
+        """Resolve a credential from synchronous code."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.get_credential(request, sink=sink))
+
+        raise OAuthError(
+            "get_credential_blocking cannot run inside an active event loop. "
+            "Use await get_credential(...) instead."
+        )
+
+    async def save_token_set(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType = "user",
+        sink: OAuthEventSink | None = None,
+    ) -> str:
+        """Persist a token set under the request's credential lock."""
+        event_sink = sink or NullOAuthEventSink()
+        operation_id = uuid.uuid4().hex
+        credential_key = build_oauth_credential_key(request)
+
+        async with self.lock_manager.lock(credential_key):
+            secret_key = self.token_store.write(request, token_set, scope=scope)
+
+        self._emit(
+            event_sink,
+            "oauth.storage.saved",
+            operation_id,
+            request,
+            credential_key,
+            "OAuth credential saved.",
+            metadata={"secret_key": secret_key},
+        )
+        return secret_key
+
+    def save_token_set_blocking(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType = "user",
+        sink: OAuthEventSink | None = None,
+    ) -> str:
+        """Persist a token set from synchronous code."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(
+                self.save_token_set(
+                    request,
+                    token_set,
+                    scope=scope,
+                    sink=sink,
+                )
+            )
+
+        raise OAuthError(
+            "save_token_set_blocking cannot run inside an active event loop. "
+            "Use await save_token_set(...) instead."
+        )
+
+    def _resolve_without_provider(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+        *,
+        include_legacy: bool = True,
+    ) -> OAuthCredential | None:
+        env_credential = self._credential_from_env(request, credential_key)
+        if env_credential:
+            return env_credential
+
+        stored_token_set = self.token_store.read(request)
+        if stored_token_set and stored_token_set.is_valid(
+            refresh_margin_seconds=self.refresh_margin_seconds,
+        ):
+            return self._credential_from_token_set(
+                request,
+                credential_key,
+                stored_token_set,
+                source="oauth-cache",
+            )
+
+        if include_legacy:
+            return self._credential_from_legacy_secret(request, credential_key)
+        return None
+
+    def _credential_from_env(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+    ) -> OAuthCredential | None:
+        if not request.access_token_env_var:
+            return None
+        token = os.environ.get(request.access_token_env_var, "").strip()
+        if not token:
+            return None
+        return OAuthCredential(
+            access_token=token,
+            token_type="Bearer",
+            scopes=request.scopes,
+            provider=request.provider,
+            connection_id=request.connection_id,
+            credential_key=credential_key,
+            source=request.access_token_env_var,
+        )
+
+    def _credential_from_legacy_secret(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+    ) -> OAuthCredential | None:
+        for secret_key in request.legacy_secret_keys:
+            token = self.secrets.get(secret_key)
+            if token and token.strip():
+                return OAuthCredential(
+                    access_token=token.strip(),
+                    token_type="Bearer",
+                    scopes=request.scopes,
+                    provider=request.provider,
+                    connection_id=request.connection_id,
+                    credential_key=credential_key,
+                    source=f"keyring:{secret_key}",
+                )
+        return None
+
+    def _credential_from_token_set(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+        token_set: OAuthTokenSet,
+        *,
+        source: str,
+    ) -> OAuthCredential:
+        return OAuthCredential(
+            access_token=token_set.access_token,
+            token_type=token_set.token_type,
+            expires_at=token_set.expires_at,
+            scopes=token_set.scopes or request.scopes,
+            provider=request.provider,
+            connection_id=request.connection_id,
+            credential_key=credential_key,
+            source=source,
+        )
+
+    def _emit_resolved(
+        self,
+        sink: OAuthEventSink,
+        operation_id: str,
+        request: OAuthRequest,
+        credential: OAuthCredential,
+    ) -> None:
+        self._emit(
+            sink,
+            "oauth.resolve.succeeded",
+            operation_id,
+            request,
+            credential.credential_key,
+            "OAuth credential resolved.",
+            metadata={"source": credential.source},
+        )
+
+    def _emit(
+        self,
+        sink: OAuthEventSink,
+        event_type: str,
+        operation_id: str,
+        request: OAuthRequest,
+        credential_key: str,
+        message: str,
+        *,
+        metadata: dict | None = None,
+    ) -> None:
+        sink.emit(
+            OAuthEvent(
+                type=event_type,
+                operation_id=operation_id,
+                credential_key=credential_key,
+                provider=request.provider,
+                connection_id=request.connection_id,
+                message=message,
+                metadata=self._safe_metadata(metadata or {}),
+            )
+        )
+
+    def _safe_metadata(self, metadata: dict) -> dict:
+        safe_metadata = {}
+        for key, value in metadata.items():
+            if "token" in str(key).lower():
+                safe_metadata[key] = "<redacted>"
+            else:
+                safe_metadata[key] = value
+        return safe_metadata

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -1,0 +1,166 @@
+"""Provider-neutral OAuth data models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+import time
+from typing import Any, Mapping, Sequence
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_values(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    return tuple(sorted({value.strip() for value in values if value and value.strip()}))
+
+
+@dataclass(frozen=True)
+class OAuthRequest:
+    """A provider-neutral request for an OAuth credential."""
+
+    provider: str
+    connection_id: str
+    scopes: Sequence[str] = field(default_factory=tuple)
+    interactive: bool = False
+    access_token_env_var: str | None = None
+    legacy_secret_keys: Sequence[str] = field(default_factory=tuple)
+    subject: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provider", self.provider.strip().lower())
+        object.__setattr__(self, "connection_id", self.connection_id.strip())
+        object.__setattr__(self, "scopes", _normalize_values(self.scopes))
+        object.__setattr__(
+            self,
+            "legacy_secret_keys",
+            tuple(
+                value.strip()
+                for value in self.legacy_secret_keys
+                if value and value.strip()
+            ),
+        )
+        object.__setattr__(
+            self,
+            "access_token_env_var",
+            _normalize_optional(self.access_token_env_var),
+        )
+        object.__setattr__(self, "subject", _normalize_optional(self.subject))
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+        if not self.provider:
+            raise ValueError("OAuth provider is required.")
+        if not self.connection_id:
+            raise ValueError("OAuth connection_id is required.")
+
+
+@dataclass(frozen=True)
+class OAuthTokenSet:
+    """Stored OAuth token data."""
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: int | None = None
+    token_type: str = "Bearer"
+    scopes: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "access_token", self.access_token.strip())
+        object.__setattr__(self, "refresh_token", _normalize_optional(self.refresh_token))
+        object.__setattr__(self, "token_type", self.token_type.strip() or "Bearer")
+        object.__setattr__(self, "scopes", _normalize_values(self.scopes))
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+    def is_valid(
+        self,
+        *,
+        now: int | None = None,
+        refresh_margin_seconds: int = 300,
+    ) -> bool:
+        """Return whether the access token can be used without refresh."""
+        if not self.access_token:
+            return False
+        if self.expires_at is None:
+            return True
+        current_time = int(time.time()) if now is None else now
+        return self.expires_at > current_time + refresh_margin_seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize token data for SecretManager storage."""
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at,
+            "token_type": self.token_type,
+            "scopes": list(self.scopes),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "OAuthTokenSet":
+        """Build a token set from SecretManager storage."""
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise ValueError("Stored OAuth token set is missing access_token.")
+
+        expires_at_raw = payload.get("expires_at")
+        expires_at = int(expires_at_raw) if expires_at_raw is not None else None
+
+        scopes_raw = payload.get("scopes")
+        scopes = scopes_raw if isinstance(scopes_raw, list) else ()
+
+        metadata_raw = payload.get("metadata")
+        metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
+
+        return cls(
+            access_token=access_token,
+            refresh_token=payload.get("refresh_token"),
+            expires_at=expires_at,
+            token_type=str(payload.get("token_type") or "Bearer"),
+            scopes=scopes,
+            metadata=metadata,
+        )
+
+
+@dataclass(frozen=True)
+class OAuthCredential:
+    """Resolved credential returned to callers."""
+
+    access_token: str
+    provider: str
+    connection_id: str
+    credential_key: str
+    source: str
+    token_type: str = "Bearer"
+    expires_at: int | None = None
+    scopes: Sequence[str] = field(default_factory=tuple)
+
+
+def build_oauth_credential_key(request: OAuthRequest) -> str:
+    """Build a stable, non-secret credential key for an OAuth request."""
+    provider_label = "".join(
+        char if char.isalnum() else "_"
+        for char in request.provider.lower()
+    ).strip("_") or "oauth"
+    material = {
+        "provider": request.provider,
+        "connection_id": request.connection_id,
+        "scopes": list(request.scopes),
+        "subject": request.subject,
+    }
+    encoded = json.dumps(
+        material,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()[:32]
+    return f"{provider_label}_{digest}"

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -2,26 +2,43 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 import hashlib
 import json
 import time
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 
-def _normalize_optional(value: str | None) -> str | None:
+def _normalize_optional(value: Any, *, field_name: str = "value") -> str | None:
     if value is None:
         return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string when present.")
     stripped = value.strip()
     return stripped or None
 
 
-def _normalize_values(values: Sequence[str] | str | None) -> tuple[str, ...]:
-    if not values:
+def _normalize_values(
+    values: Sequence[str] | str | None,
+    *,
+    field_name: str = "values",
+) -> tuple[str, ...]:
+    if values is None:
         return ()
     if isinstance(values, str):
         values = (values,)
-    return tuple(sorted({value.strip() for value in values if value and value.strip()}))
+    elif not isinstance(values, Sequence):
+        raise ValueError(f"{field_name} must be a string or sequence of strings.")
+
+    normalized_values = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            raise ValueError(f"{field_name}[{index}] must be a string.")
+        stripped = value.strip()
+        if stripped:
+            normalized_values.append(stripped)
+    return tuple(sorted(set(normalized_values)))
 
 
 @dataclass(frozen=True)
@@ -40,18 +57,32 @@ class OAuthRequest:
     def __post_init__(self) -> None:
         object.__setattr__(self, "provider", self.provider.strip().lower())
         object.__setattr__(self, "connection_id", self.connection_id.strip())
-        object.__setattr__(self, "scopes", _normalize_values(self.scopes))
+        object.__setattr__(
+            self,
+            "scopes",
+            _normalize_values(self.scopes, field_name="scopes"),
+        )
         object.__setattr__(
             self,
             "legacy_secret_keys",
-            _normalize_values(self.legacy_secret_keys),
+            _normalize_values(
+                self.legacy_secret_keys,
+                field_name="legacy_secret_keys",
+            ),
         )
         object.__setattr__(
             self,
             "access_token_env_var",
-            _normalize_optional(self.access_token_env_var),
+            _normalize_optional(
+                self.access_token_env_var,
+                field_name="access_token_env_var",
+            ),
         )
-        object.__setattr__(self, "subject", _normalize_optional(self.subject))
+        object.__setattr__(
+            self,
+            "subject",
+            _normalize_optional(self.subject, field_name="subject"),
+        )
         object.__setattr__(self, "metadata", dict(self.metadata or {}))
 
         if not self.provider:
@@ -73,9 +104,17 @@ class OAuthTokenSet:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "access_token", self.access_token.strip())
-        object.__setattr__(self, "refresh_token", _normalize_optional(self.refresh_token))
+        object.__setattr__(
+            self,
+            "refresh_token",
+            _normalize_optional(self.refresh_token, field_name="refresh_token"),
+        )
         object.__setattr__(self, "token_type", self.token_type.strip() or "Bearer")
-        object.__setattr__(self, "scopes", _normalize_values(self.scopes))
+        object.__setattr__(
+            self,
+            "scopes",
+            _normalize_values(self.scopes, field_name="scopes"),
+        )
         object.__setattr__(self, "metadata", dict(self.metadata or {}))
 
     def is_valid(
@@ -113,15 +152,25 @@ class OAuthTokenSet:
         expires_at_raw = payload.get("expires_at")
         expires_at = int(expires_at_raw) if expires_at_raw is not None else None
 
-        scopes_raw = payload.get("scopes")
-        scopes = scopes_raw if isinstance(scopes_raw, list) else ()
+        refresh_token = _normalize_optional(
+            payload.get("refresh_token"),
+            field_name="Stored OAuth token set refresh_token",
+        )
+
+        try:
+            scopes = _normalize_values(
+                payload.get("scopes"),
+                field_name="Stored OAuth token set scopes",
+            )
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
 
         metadata_raw = payload.get("metadata")
         metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
 
         return cls(
             access_token=access_token,
-            refresh_token=payload.get("refresh_token"),
+            refresh_token=refresh_token,
             expires_at=expires_at,
             token_type=str(payload.get("token_type") or "Bearer"),
             scopes=scopes,

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -16,9 +16,11 @@ def _normalize_optional(value: str | None) -> str | None:
     return stripped or None
 
 
-def _normalize_values(values: Sequence[str] | None) -> tuple[str, ...]:
+def _normalize_values(values: Sequence[str] | str | None) -> tuple[str, ...]:
     if not values:
         return ()
+    if isinstance(values, str):
+        values = (values,)
     return tuple(sorted({value.strip() for value in values if value and value.strip()}))
 
 
@@ -42,11 +44,7 @@ class OAuthRequest:
         object.__setattr__(
             self,
             "legacy_secret_keys",
-            tuple(
-                value.strip()
-                for value in self.legacy_secret_keys
-                if value and value.strip()
-            ),
+            _normalize_values(self.legacy_secret_keys),
         )
         object.__setattr__(
             self,

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -1,0 +1,84 @@
+"""SecretManager-backed OAuth token storage."""
+
+from __future__ import annotations
+
+import json
+
+from titan_cli.core.secrets import ScopeType, SecretManager
+
+from .exceptions import OAuthStorageError
+from .models import OAuthRequest, OAuthTokenSet, build_oauth_credential_key
+
+
+class OAuthTokenStore:
+    """Stores one JSON token-set blob per OAuth credential."""
+
+    def __init__(
+        self,
+        secrets: SecretManager,
+        *,
+        namespace: str = "titan",
+        secret_prefix: str = "oauth",
+    ) -> None:
+        self.secrets = secrets
+        self.namespace = namespace
+        self.secret_prefix = secret_prefix
+
+    def build_secret_key(self, request: OAuthRequest) -> str:
+        """Return the SecretManager key for an OAuth request."""
+        return f"{self.secret_prefix}_{build_oauth_credential_key(request)}"
+
+    def read(self, request: OAuthRequest) -> OAuthTokenSet | None:
+        """Read a stored token set, if present."""
+        secret_key = self.build_secret_key(request)
+        raw_value = self._get_secret(secret_key)
+        if not raw_value:
+            return None
+
+        try:
+            payload = json.loads(raw_value)
+            if not isinstance(payload, dict):
+                raise ValueError("OAuth token payload is not an object.")
+            return OAuthTokenSet.from_dict(payload)
+        except Exception as exc:
+            raise OAuthStorageError(
+                f"Stored OAuth credential '{secret_key}' is not valid."
+            ) from exc
+
+    def write(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType = "user",
+    ) -> str:
+        """Write a token set and return the SecretManager key used."""
+        secret_key = self.build_secret_key(request)
+        payload = json.dumps(
+            token_set.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        self._set_secret(secret_key, payload, scope=scope)
+        return secret_key
+
+    def delete(self, request: OAuthRequest, *, scope: ScopeType = "user") -> None:
+        """Delete a stored token set."""
+        self._delete_secret(self.build_secret_key(request), scope=scope)
+
+    def _get_secret(self, key: str) -> str | None:
+        if self.namespace == "titan":
+            return self.secrets.get(key)
+        return self.secrets.get(key, namespace=self.namespace)
+
+    def _set_secret(self, key: str, value: str, *, scope: ScopeType) -> None:
+        if self.namespace == "titan":
+            self.secrets.set(key, value, scope=scope)
+            return
+        self.secrets.set(key, value, namespace=self.namespace, scope=scope)
+
+    def _delete_secret(self, key: str, *, scope: ScopeType) -> None:
+        if self.namespace == "titan":
+            self.secrets.delete(key, scope=scope)
+            return
+        self.secrets.delete(key, namespace=self.namespace, scope=scope)

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 
-from titan_cli.core.secrets import ScopeType, SecretManager
+from titan_cli.core.secrets import ResolvedSecret, ScopeType, SecretManager
 
 from .exceptions import OAuthStorageError
 from .models import OAuthRequest, OAuthTokenSet, build_oauth_credential_key
+
+
+@dataclass(frozen=True)
+class StoredOAuthTokenSet:
+    """Stored OAuth token set with its SecretManager scope."""
+
+    token_set: OAuthTokenSet
+    scope: ScopeType
 
 
 class OAuthTokenStore:
@@ -30,16 +39,24 @@ class OAuthTokenStore:
 
     def read(self, request: OAuthRequest) -> OAuthTokenSet | None:
         """Read a stored token set, if present."""
+        stored_token_set = self.read_with_scope(request)
+        return stored_token_set.token_set if stored_token_set else None
+
+    def read_with_scope(self, request: OAuthRequest) -> StoredOAuthTokenSet | None:
+        """Read a stored token set with the scope that supplied it."""
         secret_key = self.build_secret_key(request)
-        raw_value = self._get_secret(secret_key)
-        if not raw_value:
+        resolved_secret = self._get_secret_with_scope(secret_key)
+        if not resolved_secret or not resolved_secret.value:
             return None
 
         try:
-            payload = json.loads(raw_value)
+            payload = json.loads(resolved_secret.value)
             if not isinstance(payload, dict):
                 raise ValueError("OAuth token payload is not an object.")
-            return OAuthTokenSet.from_dict(payload)
+            return StoredOAuthTokenSet(
+                token_set=OAuthTokenSet.from_dict(payload),
+                scope=resolved_secret.scope,
+            )
         except Exception as exc:
             raise OAuthStorageError(
                 f"Stored OAuth credential '{secret_key}' is not valid."
@@ -66,7 +83,21 @@ class OAuthTokenStore:
         """Delete a stored token set."""
         self._delete_secret(self.build_secret_key(request), scope=scope)
 
-    def _get_secret(self, key: str) -> str | None:
+    def _get_secret_with_scope(self, key: str) -> ResolvedSecret | None:
+        get_with_scope = getattr(self.secrets, "get_with_scope", None)
+        if get_with_scope:
+            if self.namespace == "titan":
+                resolved_secret = get_with_scope(key)
+            else:
+                resolved_secret = get_with_scope(key, namespace=self.namespace)
+            normalized_secret = _normalize_resolved_secret(resolved_secret)
+            if normalized_secret:
+                return normalized_secret
+
+        raw_value = self._get_secret_legacy(key)
+        return ResolvedSecret(raw_value, "user") if raw_value else None
+
+    def _get_secret_legacy(self, key: str) -> str | None:
         if self.namespace == "titan":
             return self.secrets.get(key)
         return self.secrets.get(key, namespace=self.namespace)
@@ -82,3 +113,14 @@ class OAuthTokenStore:
             self.secrets.delete(key, scope=scope)
             return
         self.secrets.delete(key, namespace=self.namespace, scope=scope)
+
+
+def _normalize_resolved_secret(value: object) -> ResolvedSecret | None:
+    """Normalize SecretManager-compatible scoped secret results."""
+    if value is None:
+        return None
+    secret_value = getattr(value, "value", None)
+    secret_scope = getattr(value, "scope", None)
+    if isinstance(secret_value, str) and secret_scope in {"env", "project", "user"}:
+        return ResolvedSecret(secret_value, secret_scope)
+    return None

--- a/titan_cli/core/plugins/available.py
+++ b/titan_cli/core/plugins/available.py
@@ -29,6 +29,12 @@ KNOWN_PLUGINS: List[KnownPlugin] = [
         "dependencies": []
     },
     {
+        "name": "firebase",
+        "description": "Firebase ADC auth and Remote Config integration.",
+        "package_name": "titan-plugin-firebase",
+        "dependencies": []
+    },
+    {
         "name": "slack",
         "description": "Slack integration for personal messaging and workspace access.",
         "package_name": "titan-plugin-slack",

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -1,11 +1,22 @@
 # titan_cli/core/secrets.py
 import os
+from dataclasses import dataclass
 import keyring
 from pathlib import Path
-from typing import Optional, Literal
-from dotenv import load_dotenv
+from typing import Literal, Optional
+
+from dotenv import dotenv_values, load_dotenv
 
 ScopeType = Literal["env", "project", "user"]
+
+
+@dataclass(frozen=True)
+class ResolvedSecret:
+    """Secret value plus the scope that supplied it."""
+
+    value: str
+    scope: ScopeType
+
 
 class SecretManager:
     """
@@ -18,12 +29,14 @@ class SecretManager:
 
     def __init__(self, project_path: Optional[Path] = None):
         self.project_path = project_path or Path.cwd()
+        self._project_secret_values: dict[str, str] = {}
         self._load_project_secrets()
 
     def _load_project_secrets(self):
         """Load secrets from .titan/secrets.env"""
         secrets_file = self.project_path / ".titan" / "secrets.env"
         if secrets_file.exists():
+            self._project_secret_values = self._read_project_secrets_file()
             load_dotenv(secrets_file)
 
     def get(self, key: str, namespace: str = "titan") -> Optional[str]:
@@ -38,27 +51,38 @@ class SecretManager:
         Note: Project secrets (.titan/secrets.env) are loaded
         into environment on init, so they are checked in step 1.
         """
-        # 1. Environment variable (includes project secrets)
-        env_key = key.upper()
-        if env_key in os.environ:
-            return os.environ[env_key]
+        resolved = self.get_with_scope(key, namespace=namespace)
+        return resolved.value if resolved else None
 
-        # 2. System keyring
+    def get_with_scope(
+        self,
+        key: str,
+        namespace: str = "titan",
+    ) -> Optional[ResolvedSecret]:
+        """Get a secret with the scope that supplied the winning value."""
+        env_key = key.upper()
+        env_value = os.environ.get(env_key)
+        project_value = self._project_secret_values.get(env_key)
+
+        if env_value is not None:
+            if project_value is not None and env_value == project_value:
+                return ResolvedSecret(env_value, "project")
+            return ResolvedSecret(env_value, "env")
+
+        if project_value is not None:
+            return ResolvedSecret(project_value, "project")
+
         try:
             value = keyring.get_password(namespace, key)
             if value:
-                return value
+                return ResolvedSecret(value, "user")
         except Exception:
             pass  # Keyring might not be available
 
         return None
 
     def set(
-        self,
-        key: str,
-        value: str,
-        namespace: str = "titan",
-        scope: ScopeType = "user"
+        self, key: str, value: str, namespace: str = "titan", scope: ScopeType = "user"
     ):
         """
         Set secret
@@ -84,6 +108,8 @@ class SecretManager:
             # Store in .titan/secrets.env
             secrets_file = self.project_path / ".titan" / "secrets.env"
             secrets_file.parent.mkdir(parents=True, exist_ok=True)
+            key_upper = key.upper()
+            old_project_value = self._project_secret_values.get(key_upper)
 
             # Read existing content
             existing_lines = []
@@ -92,7 +118,6 @@ class SecretManager:
                     existing_lines = f.readlines()
 
             # Update or append
-            key_upper = key.upper()
             updated = False
             for i, line in enumerate(existing_lines):
                 if line.startswith(f"{key_upper}="):
@@ -106,6 +131,9 @@ class SecretManager:
             # Write back
             with open(secrets_file, "w") as f:
                 f.writelines(existing_lines)
+            self._project_secret_values[key_upper] = value
+            if _env_key_should_follow_project(key_upper, old_project_value):
+                os.environ[key_upper] = value
 
     def delete(self, key: str, namespace: str = "titan", scope: ScopeType = "user"):
         """Delete secret from specified scope"""
@@ -117,20 +145,48 @@ class SecretManager:
             try:
                 keyring.delete_password(namespace, key)
             except Exception:
-                pass # Keyring might not be available
+                pass  # Keyring might not be available
 
         elif scope == "project":
             secrets_file = self.project_path / ".titan" / "secrets.env"
             if not secrets_file.exists():
                 return
+            key_upper = key.upper()
+            old_project_value = self._project_secret_values.pop(key_upper, None)
 
             # Read and filter
             with open(secrets_file, "r") as f:
                 lines = f.readlines()
 
-            key_upper = key.upper()
             filtered = [line for line in lines if not line.startswith(f"{key_upper}=")]
 
             # Write back
             with open(secrets_file, "w") as f:
                 f.writelines(filtered)
+            if (
+                old_project_value is not None
+                and os.environ.get(key_upper) == old_project_value
+            ):
+                os.environ.pop(key_upper, None)
+
+    def _read_project_secrets_file(self) -> dict[str, str]:
+        """Read project secrets without consulting process environment."""
+        secrets_file = self.project_path / ".titan" / "secrets.env"
+        if not secrets_file.exists():
+            return {}
+        values = dotenv_values(secrets_file)
+        return {
+            key.upper(): value for key, value in values.items() if value is not None
+        }
+
+
+def _env_key_should_follow_project(
+    key_upper: str,
+    old_project_value: Optional[str],
+) -> bool:
+    """Return whether process env mirrors project storage for a secret key."""
+    if key_upper not in os.environ:
+        return True
+    return (
+        old_project_value is not None and os.environ.get(key_upper) == old_project_value
+    )

--- a/titan_cli/engine/builder.py
+++ b/titan_cli/engine/builder.py
@@ -59,6 +59,7 @@ class WorkflowContextBuilder:
         self._git = None
         self._github = None
         self._jira = None
+        self._firebase = None
         self._slack = None
 
         # Plugin managers (keyed by plugin name)
@@ -198,6 +199,33 @@ class WorkflowContextBuilder:
                 self._slack = None
         return self
 
+    def with_firebase(
+        self,
+        firebase_client: Optional[Any] = None,
+    ) -> WorkflowContextBuilder:
+        """
+        Add Firebase client to workflow context.
+
+        Args:
+            firebase_client: Optional FirebaseClient instance. If None, attempts
+                to load it from the Firebase plugin registry entry.
+
+        Returns:
+            Self for method chaining
+        """
+        if firebase_client:
+            self._firebase = firebase_client
+        else:
+            firebase_plugin = self._plugin_registry.get_plugin("firebase")
+            if firebase_plugin and firebase_plugin.is_available():
+                try:
+                    self._firebase = firebase_plugin.get_client()
+                except Exception:
+                    self._firebase = None
+            else:
+                self._firebase = None
+        return self
+
 
     def build(self) -> WorkflowContext:
         """Build the WorkflowContext."""
@@ -209,5 +237,6 @@ class WorkflowContextBuilder:
             github=self._github,
             github_managers=self._plugin_managers.get("github"),
             jira=self._jira,
+            firebase=self._firebase,
             slack=self._slack,
         )

--- a/titan_cli/engine/context.py
+++ b/titan_cli/engine/context.py
@@ -41,6 +41,7 @@ class WorkflowContext:
     github: Optional[Any] = None
     github_managers: Optional[Any] = None
     jira: Optional[Any] = None
+    firebase: Optional[Any] = None
     slack: Optional[Any] = None
 
     # Workflow metadata (set by executor)

--- a/titan_cli/ui/tui/screens/plugin_config_wizard.py
+++ b/titan_cli/ui/tui/screens/plugin_config_wizard.py
@@ -206,7 +206,15 @@ class PluginConfigWizardScreen(BaseScreen):
         # For now, we'll create one step per field for simplicity
         # In the future, plugins could define custom step grouping
 
-        for field_name in self.properties.keys():
+        for field_name, field_schema in self.properties.items():
+            if field_schema.get("ui_hidden"):
+                logger.debug(
+                    "plugin_config_field_hidden",
+                    plugin=self.plugin_name,
+                    field=field_name,
+                )
+                continue
+
             self.steps.append({
                 "id": field_name,
                 "title": field_name.replace("_", " ").title(),


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Adds a new Firebase plugin to Titan that provides Google Cloud ADC authentication validation and Firebase Remote Config template reading capabilities. This is PR1 of the Firebase integration, establishing the foundation for future multi-brand Remote Config workflows.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Add `titan-plugin-firebase` package with `FirebasePlugin` class
- Implement `FirebaseClient` with ADC authentication methods (`is_available`, `get_active_account`, `get_adc_access_token`)
- Add Remote Config API client for reading templates with ETag support
- Create `firebase_login` step for validating ADC sessions
- Create `firebase_status` step for reporting authentication status
- Create `firebase_remoteconfig_get` step for reading Remote Config templates
- Add comprehensive plugin documentation (client API, workflow steps, built-in workflows)
- Register Firebase plugin in official plugin refs and workflow step paths

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
Unit tests cover FirebaseClient authentication methods, Remote Config API interactions, and all three workflow steps with various input combinations and error scenarios.

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

<!-- If logs were added, list them: -->
- `firebase_adc_available` (DEBUG) — ADC availability check result
- `firebase_remoteconfig_get_ok` (DEBUG) — project_id, etag, duration
- `firebase_remoteconfig_get_failed` (DEBUG) — project_id, error, duration

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)