### PR TITLE
feat: Improve AI review batching with structured output and budget management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Titan CLI - Makefile
 # Development commands for initial setup
 
-.PHONY: help install dev-install test clean docs-serve docs-build docs-deploy
+.PHONY: help install dev-install test check-github clean docs-serve docs-build docs-deploy
 
 # Default target
 help:
@@ -10,6 +10,7 @@ help:
 	@echo "For Contributors:"
 	@echo "  make dev-install    Setup development environment (creates titan-dev)"
 	@echo "  make test           Run all tests"
+	@echo "  make check-github   Ruff + pytest for titan-plugin-github only"
 	@echo ""
 	@echo "For Users:"
 	@echo "  make install        Install production version (NOT recommended - use pipx)"
@@ -62,6 +63,11 @@ install:
 test:
 	@echo "🧪 Running all tests..."
 	poetry run pytest
+
+# Ruff + pytest for the GitHub plugin only (faster loop while working on it)
+check-github:
+	poetry run ruff check plugins/titan-plugin-github/
+	poetry run pytest plugins/titan-plugin-github/tests -q
 
 # Docs commands
 docs-serve:

--- a/plugins/titan-plugin-github/tests/operations/test_ai_response_parsing_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_ai_response_parsing_operations.py
@@ -1,0 +1,72 @@
+"""
+Tests for `extract_json_payload()`, the centralized JSON-extraction operation
+(review-batching-006) shared by `ai_review_plan`, `ai_review_findings`, and
+`ai_thread_resolution`. Replaces the previously duplicated
+`_strip_markdown_fences()`/`_extract_json_slice()` free functions (two call
+sites) and a third hand-rolled copy inside `ai_thread_resolution`.
+"""
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_plugin_github.operations.ai_response_parsing_operations import extract_json_payload
+
+
+def test_extract_json_payload_parses_plain_array():
+    result = extract_json_payload('[{"a": 1}, {"b": 2}]', kind="array")
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == [{"a": 1}, {"b": 2}]
+
+
+def test_extract_json_payload_parses_plain_object():
+    result = extract_json_payload('{"a": 1}', kind="object")
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == {"a": 1}
+
+
+def test_extract_json_payload_strips_markdown_fences_for_array():
+    text = '```json\n[{"a": 1}]\n```'
+
+    result = extract_json_payload(text, kind="array")
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == [{"a": 1}]
+
+
+def test_extract_json_payload_strips_markdown_fences_for_object():
+    text = '```json\n{"a": 1}\n```'
+
+    result = extract_json_payload(text, kind="object")
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == {"a": 1}
+
+
+def test_extract_json_payload_ignores_surrounding_prose():
+    text = 'Sure thing, here you go:\n[{"a": 1}]\nHope that helps!'
+
+    result = extract_json_payload(text, kind="array")
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == [{"a": 1}]
+
+
+def test_extract_json_payload_errors_when_no_array_found():
+    result = extract_json_payload("Sorry, I could not find any issues.", kind="array")
+
+    assert isinstance(result, ClientError)
+    assert "array" in result.error_message
+
+
+def test_extract_json_payload_errors_when_no_object_found():
+    result = extract_json_payload("Sorry, no plan today.", kind="object")
+
+    assert isinstance(result, ClientError)
+    assert "object" in result.error_message
+
+
+def test_extract_json_payload_errors_on_malformed_json():
+    result = extract_json_payload("[1, 2,]", kind="array")
+
+    assert isinstance(result, ClientError)
+    assert result.error_code == "JSON_PARSE_ERROR"

--- a/plugins/titan-plugin-github/tests/operations/test_ai_response_parsing_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_ai_response_parsing_operations.py
@@ -7,7 +7,11 @@ sites) and a third hand-rolled copy inside `ai_thread_resolution`.
 """
 
 from titan_cli.core.result import ClientError, ClientSuccess
-from titan_plugin_github.operations.ai_response_parsing_operations import extract_json_payload
+from titan_plugin_github.operations.ai_response_parsing_operations import (
+    REFORMAT_RETRY_TIMEOUT_SECONDS,
+    build_json_reformat_prompt,
+    extract_json_payload,
+)
 
 
 def test_extract_json_payload_parses_plain_array():
@@ -70,3 +74,16 @@ def test_extract_json_payload_errors_on_malformed_json():
 
     assert isinstance(result, ClientError)
     assert result.error_code == "JSON_PARSE_ERROR"
+
+
+def test_build_json_reformat_prompt_includes_previous_output_and_asks_for_json_only():
+    prompt = build_json_reformat_prompt("Reported one finding: fix the null check.", kind="array")
+
+    assert "Reported one finding: fix the null check." in prompt
+    assert "array" in prompt
+    assert "do not redo the analysis" in prompt.lower()
+
+
+def test_reformat_retry_timeout_is_distinct_from_the_full_analysis_timeout():
+    assert REFORMAT_RETRY_TIMEOUT_SECONDS < 300
+    assert REFORMAT_RETRY_TIMEOUT_SECONDS < 240

--- a/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
@@ -1,0 +1,111 @@
+"""
+Baseline regression test proving `build_review_context_package()` batches files
+according to `PromptBudgetManager.content_budget()` (review-batching-003
+extraction). Guards against silently reverting to the old inline
+`_content_budget()` free function.
+"""
+
+from titan_plugin_github.models.review_enums import ChecklistCategory, FileChangeStatus, FileReadMode, FileReviewPriority, PRSizeClass, ReviewStrategyType
+from titan_plugin_github.models.review_models import (
+    ChangeManifest,
+    ChangedFileEntry,
+    FileReviewPlan,
+    PullRequestManifest,
+    ReviewChecklistItem,
+    ReviewPlan,
+    ReviewStrategy,
+)
+from titan_plugin_github.operations.context_resolution_operations import build_review_context_package
+
+
+def make_diff(path: str, added_line: str) -> str:
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index abc..def 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -1,1 +1,2 @@\n"
+        f" context line\n"
+        f"+{added_line}\n"
+    )
+
+
+def make_manifest(paths: list[str]) -> ChangeManifest:
+    files = [
+        ChangedFileEntry(path=path, status=FileChangeStatus.MODIFIED, additions=1, deletions=0) for path in paths
+    ]
+    return ChangeManifest(
+        pr=PullRequestManifest(number=1, title="Test PR", base="main", head="feat/test", author="alex", description=""),
+        files=files,
+        total_additions=len(files),
+        total_deletions=0,
+    )
+
+
+def test_build_review_context_package_batches_by_manager_content_budget():
+    paths = ["a.py", "b.py", "c.py"]
+    diff = "".join(make_diff(path, "x" * 3000) for path in paths)
+    plan = ReviewPlan(
+        focus_files=[
+            FileReviewPlan(path=path, priority=FileReviewPriority.HIGH, read_mode=FileReadMode.HUNKS_ONLY)
+            for path in paths
+        ],
+        review_axes=[ChecklistCategory.FUNCTIONAL_CORRECTNESS],
+    )
+    manifest = make_manifest(paths)
+    checklist = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            name="Functional correctness",
+            description="Does it work",
+        )
+    ]
+    strategy = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=4000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+
+    package = build_review_context_package(plan, diff, manifest, checklist, comment_context=[], strategy=strategy)
+
+    # content_budget(strategy) == max(2500, 4000 - 3500) == 2500; each ~3000-char
+    # hunk alone exceeds that budget, so every file must land in its own batch.
+    assert len(package.batches) == 3
+    assert [batch.batch_id for batch in package.batches] == ["batch_1", "batch_2", "batch_3"]
+    assert [list(batch.files_context.keys()) for batch in package.batches] == [["a.py"], ["b.py"], ["c.py"]]
+
+
+def test_build_review_context_package_keeps_small_files_in_one_batch():
+    paths = ["a.py", "b.py", "c.py"]
+    diff = "".join(make_diff(path, "x" * 10) for path in paths)
+    plan = ReviewPlan(
+        focus_files=[
+            FileReviewPlan(path=path, priority=FileReviewPriority.HIGH, read_mode=FileReadMode.HUNKS_ONLY)
+            for path in paths
+        ],
+        review_axes=[ChecklistCategory.FUNCTIONAL_CORRECTNESS],
+    )
+    manifest = make_manifest(paths)
+    checklist = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            name="Functional correctness",
+            description="Does it work",
+        )
+    ]
+    strategy = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+
+    package = build_review_context_package(plan, diff, manifest, checklist, comment_context=[], strategy=strategy)
+
+    assert len(package.batches) == 1
+    assert set(package.batches[0].files_context.keys()) == set(paths)

--- a/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
@@ -153,3 +153,76 @@ def test_worktree_reference_entries_get_a_high_fixed_cost_and_split_batches():
     assert len(package.batches) == 2
     assert list(package.batches[0].files_context.keys()) == ["a.py"]
     assert list(package.batches[1].files_context.keys()) == ["b.py"]
+
+
+def test_worktree_reference_files_are_capped_at_one_per_batch_even_with_ample_budget():
+    """review-batching-005: even when the char budget alone would fit several
+    worktree_reference files in one batch, at most one is allowed per batch — each
+    additional one forces a new batch, since every worktree_reference file means another
+    full file read by the CLI regardless of prompt size."""
+    paths = ["a.py", "b.py", "c.py"]
+    diff = "".join(make_diff(path, "x" * 10) for path in paths)
+    plan = ReviewPlan(
+        focus_files=[
+            FileReviewPlan(path=path, priority=FileReviewPriority.HIGH, read_mode=FileReadMode.WORKTREE_REFERENCE)
+            for path in paths
+        ],
+        review_axes=[ChecklistCategory.FUNCTIONAL_CORRECTNESS],
+    )
+    manifest = make_manifest(paths)
+    checklist = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            name="Functional correctness",
+            description="Does it work",
+        )
+    ]
+    strategy = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=100_000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+
+    package = build_review_context_package(plan, diff, manifest, checklist, comment_context=[], strategy=strategy)
+
+    assert len(package.batches) == 3
+    assert [list(batch.files_context.keys()) for batch in package.batches] == [["a.py"], ["b.py"], ["c.py"]]
+
+
+def test_mixed_batch_closes_before_a_second_worktree_reference_file():
+    """A batch may hold inline files plus one worktree_reference file, but a second
+    worktree_reference file must start a new batch even though the char budget has room."""
+    plan = ReviewPlan(
+        focus_files=[
+            FileReviewPlan(path="inline.py", priority=FileReviewPriority.HIGH, read_mode=FileReadMode.HUNKS_ONLY),
+            FileReviewPlan(path="a.py", priority=FileReviewPriority.HIGH, read_mode=FileReadMode.WORKTREE_REFERENCE),
+            FileReviewPlan(path="b.py", priority=FileReviewPriority.HIGH, read_mode=FileReadMode.WORKTREE_REFERENCE),
+        ],
+        review_axes=[ChecklistCategory.FUNCTIONAL_CORRECTNESS],
+    )
+    diff = "".join(make_diff(path, "x" * 10) for path in ["inline.py", "a.py", "b.py"])
+    manifest = make_manifest(["inline.py", "a.py", "b.py"])
+    checklist = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            name="Functional correctness",
+            description="Does it work",
+        )
+    ]
+    strategy = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=100_000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+
+    package = build_review_context_package(plan, diff, manifest, checklist, comment_context=[], strategy=strategy)
+
+    assert len(package.batches) == 2
+    assert list(package.batches[0].files_context.keys()) == ["inline.py", "a.py"]
+    assert list(package.batches[1].files_context.keys()) == ["b.py"]

--- a/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
@@ -5,6 +5,7 @@ extraction). Guards against silently reverting to the old inline
 `_content_budget()` free function.
 """
 
+from titan_plugin_github.managers.prompt_budget_manager import get_prompt_budget_manager
 from titan_plugin_github.models.review_enums import ChecklistCategory, FileChangeStatus, FileReadMode, FileReviewPriority, PRSizeClass, ReviewStrategyType
 from titan_plugin_github.models.review_models import (
     ChangeManifest,
@@ -109,3 +110,46 @@ def test_build_review_context_package_keeps_small_files_in_one_batch():
 
     assert len(package.batches) == 1
     assert set(package.batches[0].files_context.keys()) == set(paths)
+
+
+def test_worktree_reference_entries_get_a_high_fixed_cost_and_split_batches():
+    """review-batching-004: worktree_reference used to cost ~800 chars, cheap enough that
+    several of them fit in one batch even though the CLI must read each file for real from
+    the worktree. Now they carry a fixed high cost, so they no longer group together under a
+    budget that would have fit them at the old estimate."""
+    paths = ["a.py", "b.py"]
+    diff = "".join(make_diff(path, "x" * 10) for path in paths)
+    plan = ReviewPlan(
+        focus_files=[
+            FileReviewPlan(path=path, priority=FileReviewPriority.HIGH, read_mode=FileReadMode.WORKTREE_REFERENCE)
+            for path in paths
+        ],
+        review_axes=[ChecklistCategory.FUNCTIONAL_CORRECTNESS],
+    )
+    manifest = make_manifest(paths)
+    checklist = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            name="Functional correctness",
+            description="Does it work",
+        )
+    ]
+    # Budget that would have fit two ~800-char entries (old estimate) but not two
+    # WORKTREE_REFERENCE_ESTIMATED_CHARS-sized ones.
+    strategy = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=2000 + 3500,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+
+    package = build_review_context_package(plan, diff, manifest, checklist, comment_context=[], strategy=strategy)
+
+    first_entry = package.batches[0].files_context["a.py"]
+    assert first_entry.worktree_reference is True
+    assert first_entry.approximate_chars == get_prompt_budget_manager().WORKTREE_REFERENCE_ESTIMATED_CHARS
+    assert len(package.batches) == 2
+    assert list(package.batches[0].files_context.keys()) == ["a.py"]
+    assert list(package.batches[1].files_context.keys()) == ["b.py"]

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -6,8 +6,11 @@ from titan_plugin_github.models.review_models import (
     PullRequestManifest,
     ReviewChecklistItem,
 )
+from titan_cli.core.result import ClientError, ClientSuccess
 from titan_plugin_github.operations.findings_operations import (
     build_findings_prompt_parts,
+    findings_json_schema,
+    parse_findings_response,
     summarize_findings_prompt_parts,
 )
 
@@ -109,3 +112,43 @@ def test_build_findings_prompt_parts_renders_worktree_reference():
     assert "Read from worktree instead of inline context." in parts["files_context"]
     assert "Changed regions to inspect first:" in parts["files_context"]
     assert "@@ -10,20 +10,30 @@" in parts["files_context"]
+
+
+# ---------------------------------------------------------------------------
+# findings_json_schema() / parse_findings_response()
+# ---------------------------------------------------------------------------
+
+
+def test_findings_json_schema_wraps_array_in_object_with_findings_key():
+    schema = findings_json_schema()
+
+    assert schema["type"] == "object"
+    assert schema["required"] == ["findings"]
+    assert schema["properties"]["findings"]["type"] == "array"
+
+
+def test_parse_findings_response_unstructured_parses_bare_array():
+    result = parse_findings_response('[{"title": "Bug"}]', structured=False)
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == [{"title": "Bug"}]
+
+
+def test_parse_findings_response_structured_unwraps_findings_key():
+    result = parse_findings_response('{"findings": [{"title": "Bug"}]}', structured=True)
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == [{"title": "Bug"}]
+
+
+def test_parse_findings_response_structured_errors_when_findings_key_missing():
+    result = parse_findings_response('{"other": []}', structured=True)
+
+    assert isinstance(result, ClientError)
+    assert result.error_code == "MISSING_FINDINGS_FIELD"
+
+
+def test_parse_findings_response_structured_falls_back_to_error_on_prose():
+    result = parse_findings_response("I refuse to call that tool.", structured=True)
+
+    assert isinstance(result, ClientError)

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -8,6 +8,7 @@ from titan_plugin_github.models.review_models import (
 )
 from titan_cli.core.result import ClientError, ClientSuccess
 from titan_plugin_github.operations.findings_operations import (
+    _annotate_diff_hunk,
     build_findings_prompt_parts,
     findings_json_schema,
     parse_findings_response,
@@ -112,6 +113,70 @@ def test_build_findings_prompt_parts_renders_worktree_reference():
     assert "Read from worktree instead of inline context." in parts["files_context"]
     assert "Changed regions to inspect first:" in parts["files_context"]
     assert "@@ -10,20 +10,30 @@" in parts["files_context"]
+
+
+# ---------------------------------------------------------------------------
+# _annotate_diff_hunk()
+# ---------------------------------------------------------------------------
+
+
+def test_annotate_diff_hunk_numbers_added_and_context_lines():
+    hunk = "@@ -10,2 +10,3 @@\n def bar():\n+    return 1\n-    return 0"
+
+    result = _annotate_diff_hunk(hunk)
+
+    assert "10 [CONTEXT] def bar():" in result
+    assert "11 [ADDED]     return 1" in result
+    assert "[DELETED - do not review]     return 0" in result
+
+
+def test_annotate_diff_hunk_does_not_number_surrounding_context_lines():
+    """Regression test: `expanded_hunks` entries prepend a raw, non-diff-prefixed
+    surrounding-context block before the real diff hunk (DiffContextManager.build_expanded_hunks).
+    Indented raw lines in that block must not be mislabeled as numbered [CONTEXT] diff lines."""
+    hunk = (
+        "@@ -10,2 +10,3 @@\n"
+        "# --- surrounding context (lines 8-12) ---\n"
+        "    def foo():\n"
+        "        pass\n"
+        "def bar():\n"
+        "# --- diff hunk ---\n"
+        " def bar():\n"
+        "+    return 1\n"
+        "-    return 0"
+    )
+
+    result = _annotate_diff_hunk(hunk)
+
+    assert "    def foo():" in result
+    assert "[CONTEXT]    def foo():" not in result
+    assert "        pass" in result
+    assert "[CONTEXT]        pass" not in result
+
+
+def test_annotate_diff_hunk_real_hunk_numbering_unaffected_by_surrounding_context():
+    """The actual diff-hunk lines after the '# --- diff hunk ---' marker must get the same
+    line numbers they would get without the surrounding-context preamble at all — the raw
+    preamble lines must not advance the line counter."""
+    plain_hunk = "@@ -10,2 +10,3 @@\n def bar():\n+    return 1\n-    return 0"
+    expanded_hunk = (
+        "@@ -10,2 +10,3 @@\n"
+        "# --- surrounding context (lines 8-12) ---\n"
+        "    def foo():\n"
+        "        pass\n"
+        "def bar():\n"
+        "# --- diff hunk ---\n"
+        " def bar():\n"
+        "+    return 1\n"
+        "-    return 0"
+    )
+
+    plain_result = _annotate_diff_hunk(plain_hunk)
+    expanded_result = _annotate_diff_hunk(expanded_hunk)
+
+    plain_diff_lines = plain_result.splitlines()[1:]  # drop the @@ header
+    expanded_diff_lines = expanded_result.splitlines()[-len(plain_diff_lines):]
+    assert expanded_diff_lines == plain_diff_lines
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -483,11 +483,13 @@ class _FakeFindingsAdapter:
         self.executed_prompts: list[str] = []
 
     supports_structured_output = False
+    supports_tool_restriction = False
+    supports_effort_control = False
 
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
         self.executed_prompts.append(prompt)
         return HeadlessResponse(stdout="[]", stderr="", exit_code=0)
 
@@ -547,6 +549,8 @@ class _FakeFencedAdapter:
 
     cli_name = SupportedCLI.CLAUDE
     supports_structured_output = False
+    supports_tool_restriction = False
+    supports_effort_control = False
 
     def __init__(self, stdout: str):
         self._stdout = stdout
@@ -554,7 +558,7 @@ class _FakeFencedAdapter:
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
         return HeadlessResponse(stdout=self._stdout, stderr="", exit_code=0)
 
 
@@ -591,6 +595,8 @@ class _FakeSequentialAdapter:
 
     cli_name = SupportedCLI.CLAUDE
     supports_structured_output = False
+    supports_tool_restriction = False
+    supports_effort_control = False
 
     def __init__(self, stdouts: list[str]):
         self._stdouts = list(stdouts)
@@ -599,8 +605,10 @@ class _FakeSequentialAdapter:
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
-        self.calls.append({"prompt": prompt, "cwd": cwd, "timeout": timeout})
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
+        self.calls.append(
+            {"prompt": prompt, "cwd": cwd, "timeout": timeout, "disallowed_tools": disallowed_tools, "effort": effort}
+        )
         stdout = self._stdouts[len(self.calls) - 1]
         return HeadlessResponse(stdout=stdout, stderr="", exit_code=0)
 
@@ -671,6 +679,8 @@ class _FakeStructuredOutputAdapter:
 
     cli_name = SupportedCLI.CLAUDE
     supports_structured_output = True
+    supports_tool_restriction = True
+    supports_effort_control = True
 
     def __init__(self, stdout: str):
         self._stdout = stdout
@@ -679,8 +689,17 @@ class _FakeStructuredOutputAdapter:
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
-        self.calls.append({"prompt": prompt, "cwd": cwd, "timeout": timeout, "json_schema": json_schema})
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "cwd": cwd,
+                "timeout": timeout,
+                "json_schema": json_schema,
+                "disallowed_tools": disallowed_tools,
+                "effort": effort,
+            }
+        )
         return HeadlessResponse(stdout=self._stdout, stderr="", exit_code=0)
 
 
@@ -741,6 +760,162 @@ def test_ai_review_findings_structured_output_retry_also_requests_schema(monkeyp
     assert len(fake_adapter.calls) == 2
     assert fake_adapter.calls[1]["json_schema"] is not None
     assert ctx.data["ai_findings_failed"] is True
+
+
+def test_ai_review_findings_restricts_tools_when_supported(monkeypatch):
+    """O-003/D-011 fix: when the adapter supports tool restriction, ai_review_findings must
+    deny Bash (and the other unneeded tools) so the CLI can't explore far beyond the batch's
+    worktree_reference files — Read/Grep/Glob stay implicitly available since they're not
+    in the denylist."""
+    from titan_plugin_github.operations.findings_operations import FINDINGS_DISALLOWED_TOOLS
+
+    fake_adapter = _FakeStructuredOutputAdapter('{"findings": [{"title": "Bug"}]}')
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.calls[0]["disallowed_tools"] == list(FINDINGS_DISALLOWED_TOOLS)
+
+
+def test_ai_review_findings_omits_disallowed_tools_when_unsupported(monkeypatch):
+    """Adapters without tool-restriction support (Codex, Gemini) must not receive a
+    disallowed_tools list — the step must not assume the capability is universal."""
+    fake_adapter = _FakeSequentialAdapter(['[{"title": "Bug"}]'])
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.calls[0]["disallowed_tools"] is None
+
+
+def test_ai_review_findings_reformat_retry_also_restricts_tools(monkeypatch):
+    """The reformat retry reuses the same adapter for a lighter-weight call with no
+    exploration need at all — it must still receive the same tool restriction."""
+    from titan_plugin_github.operations.findings_operations import FINDINGS_DISALLOWED_TOOLS
+
+    fake_adapter = _FakeStructuredOutputAdapter("I won't call that tool.")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    assert fake_adapter.calls[1]["disallowed_tools"] == list(FINDINGS_DISALLOWED_TOOLS)
+
+
+def _make_worktree_reference_batch(batch_id: str, path: str) -> FocusContextBatch:
+    return FocusContextBatch(
+        batch_id=batch_id,
+        files_context={
+            path: FileContextEntry(
+                path=path,
+                read_mode=FileReadMode.WORKTREE_REFERENCE,
+                worktree_reference=True,
+                review_hint="Read this file from the worktree.",
+                approximate_chars=100,
+            )
+        },
+    )
+
+
+def test_ai_review_findings_caps_effort_for_worktree_reference_batch(monkeypatch):
+    """O-003 fix: a real replay showed removing Bash alone didn't reduce duration — Claude
+    still took ~330s regardless of tool. Capping effort at FINDINGS_WORKTREE_REFERENCE_EFFORT
+    cut that to ~170s in the same replay while still finding a genuine bug an independent CLI
+    also found, so ai_review_findings must request it for worktree_reference batches."""
+    from titan_plugin_github.operations.findings_operations import FINDINGS_WORKTREE_REFERENCE_EFFORT
+
+    fake_adapter = _FakeStructuredOutputAdapter('{"findings": []}')
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_worktree_reference_batch("batch_1", "HomeScreen.kt")]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.calls[0]["effort"] == FINDINGS_WORKTREE_REFERENCE_EFFORT
+
+
+def test_ai_review_findings_omits_effort_when_no_worktree_reference(monkeypatch):
+    """A batch with only inline file content has no reason to explore, so it must keep the
+    adapter's default effort rather than unconditionally capping every findings call."""
+    fake_adapter = _FakeStructuredOutputAdapter('{"findings": []}')
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.calls[0]["effort"] is None
 
 
 def test_ai_thread_resolution_parses_markdown_fenced_response(monkeypatch):

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -482,10 +482,12 @@ class _FakeFindingsAdapter:
     def __init__(self):
         self.executed_prompts: list[str] = []
 
+    supports_structured_output = False
+
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None) -> HeadlessResponse:
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
         self.executed_prompts.append(prompt)
         return HeadlessResponse(stdout="[]", stderr="", exit_code=0)
 
@@ -544,6 +546,7 @@ class _FakeFencedAdapter:
     """Fake headless adapter returning a markdown-fenced JSON array, once."""
 
     cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = False
 
     def __init__(self, stdout: str):
         self._stdout = stdout
@@ -551,7 +554,7 @@ class _FakeFencedAdapter:
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None) -> HeadlessResponse:
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
         return HeadlessResponse(stdout=self._stdout, stderr="", exit_code=0)
 
 
@@ -587,6 +590,7 @@ class _FakeSequentialAdapter:
     """Fake headless adapter returning one canned stdout per call, in order."""
 
     cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = False
 
     def __init__(self, stdouts: list[str]):
         self._stdouts = list(stdouts)
@@ -595,7 +599,7 @@ class _FakeSequentialAdapter:
     def is_available(self) -> bool:
         return True
 
-    def execute(self, prompt: str, cwd=None, timeout=None) -> HeadlessResponse:
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
         self.calls.append({"prompt": prompt, "cwd": cwd, "timeout": timeout})
         stdout = self._stdouts[len(self.calls) - 1]
         return HeadlessResponse(stdout=stdout, stderr="", exit_code=0)
@@ -659,6 +663,83 @@ def test_ai_review_findings_marks_batch_failed_when_reformat_retry_also_fails(mo
 
     assert isinstance(result, Success)
     assert len(fake_adapter.calls) == 2
+    assert ctx.data["ai_findings_failed"] is True
+
+
+class _FakeStructuredOutputAdapter:
+    """Fake adapter simulating a CLI that supports --json-schema (like Claude)."""
+
+    cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = True
+
+    def __init__(self, stdout: str):
+        self._stdout = stdout
+        self.calls: list[dict] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None) -> HeadlessResponse:
+        self.calls.append({"prompt": prompt, "cwd": cwd, "timeout": timeout, "json_schema": json_schema})
+        return HeadlessResponse(stdout=self._stdout, stderr="", exit_code=0)
+
+
+def test_ai_review_findings_uses_structured_output_when_supported(monkeypatch):
+    """review-batching-008: when the adapter supports structured output, ai_review_findings
+    must request it (json_schema kwarg) and unwrap the {"findings": [...]} envelope,
+    instead of parsing a bare JSON array out of free text."""
+    fake_adapter = _FakeStructuredOutputAdapter('{"findings": [{"title": "Bug"}]}')
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == [{"title": "Bug"}]
+    assert ctx.data["ai_findings_failed"] is False
+    assert fake_adapter.calls[0]["json_schema"] is not None
+    assert fake_adapter.calls[0]["json_schema"]["required"] == ["findings"]
+
+
+def test_ai_review_findings_structured_output_retry_also_requests_schema(monkeypatch):
+    """If the model doesn't call the structured-output tool on the first try (rare), the
+    reformat retry must still request structured output — not silently downgrade to
+    free-text parsing."""
+    fake_adapter = _FakeStructuredOutputAdapter("I won't call that tool.")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    assert fake_adapter.calls[1]["json_schema"] is not None
     assert ctx.data["ai_findings_failed"] is True
 
 

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -14,12 +14,14 @@ from titan_plugin_github.models.review_models import (
     ReferencedCommitContext,
     ReviewStrategy,
     ThreadReviewCandidate,
+    ThreadReviewContext,
 )
 from titan_plugin_github.models.review_enums import FileChangeStatus
 from titan_plugin_github.models.view import UIComment, UICommentThread, UIFileChange, UIPullRequest
 import titan_plugin_github.steps.code_review_steps as code_review_steps
 from titan_plugin_github.steps.code_review_steps import (
     ai_review_findings,
+    ai_thread_resolution,
     build_thread_review_candidates,
     build_thread_review_contexts,
     fetch_pr_review_bundle,
@@ -536,3 +538,95 @@ def test_ai_review_findings_splits_oversized_batch_via_prompt_budget_manager(mon
     assert len(fake_adapter.executed_prompts) == 2
     assert ctx.data["raw_findings"] == []
     assert ctx.data["ai_findings_failed"] is False
+
+
+class _FakeFencedAdapter:
+    """Fake headless adapter returning a markdown-fenced JSON array, once."""
+
+    cli_name = SupportedCLI.CLAUDE
+
+    def __init__(self, stdout: str):
+        self._stdout = stdout
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None) -> HeadlessResponse:
+        return HeadlessResponse(stdout=self._stdout, stderr="", exit_code=0)
+
+
+def test_ai_review_findings_parses_markdown_fenced_response(monkeypatch):
+    """review-batching-006: ai_review_findings must go through the centralized
+    `extract_json_payload()` helper, which strips markdown fences — not a
+    bespoke inline parser."""
+    fake_adapter = _FakeFencedAdapter('```json\n[{"title": "Bug"}]\n```')
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == [{"title": "Bug"}]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_thread_resolution_parses_markdown_fenced_response(monkeypatch):
+    """review-batching-006: ai_thread_resolution used to hand-roll its own fence
+    stripping and JSON-slice extraction. It must now share the same
+    `extract_json_payload()` helper as ai_review_findings/ai_review_plan."""
+    fake_adapter = _FakeFencedAdapter('```json\n[{"thread_id": "t1", "decision": "resolved"}]\n```')
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["thread_review_contexts"] = [
+        ThreadReviewContext(
+            thread_id="t1",
+            comment_id=1,
+            main_comment_body="Please fix this",
+            main_comment_author="alex",
+        )
+    ]
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_thread_resolution(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_thread_decisions"] == [{"thread_id": "t1", "decision": "resolved"}]
+
+
+def test_ai_thread_resolution_falls_back_to_empty_decisions_on_parse_failure(monkeypatch):
+    fake_adapter = _FakeFencedAdapter("I could not analyse these threads.")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["thread_review_contexts"] = [
+        ThreadReviewContext(
+            thread_id="t1",
+            comment_id=1,
+            main_comment_body="Please fix this",
+            main_comment_author="alex",
+        )
+    ]
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_thread_resolution(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_thread_decisions"] == []

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -583,6 +583,85 @@ def test_ai_review_findings_parses_markdown_fenced_response(monkeypatch):
     assert ctx.data["ai_findings_failed"] is False
 
 
+class _FakeSequentialAdapter:
+    """Fake headless adapter returning one canned stdout per call, in order."""
+
+    cli_name = SupportedCLI.CLAUDE
+
+    def __init__(self, stdouts: list[str]):
+        self._stdouts = list(stdouts)
+        self.calls: list[dict] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None) -> HeadlessResponse:
+        self.calls.append({"prompt": prompt, "cwd": cwd, "timeout": timeout})
+        stdout = self._stdouts[len(self.calls) - 1]
+        return HeadlessResponse(stdout=stdout, stderr="", exit_code=0)
+
+
+def test_ai_review_findings_recovers_via_reformat_retry(monkeypatch):
+    """review-batching-007: when the model returns prose instead of JSON
+    (exit_code 0), ai_review_findings must retry once, asking the same CLI to
+    reformat its own previous output, using a short timeout distinct from the
+    300s analysis timeout — and recover the findings if the retry succeeds."""
+    fake_adapter = _FakeSequentialAdapter(
+        ["Reported one finding: fix the null check.", '```json\n[{"title": "Bug"}]\n```']
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == [{"title": "Bug"}]
+    assert ctx.data["ai_findings_failed"] is False
+    assert len(fake_adapter.calls) == 2
+    assert fake_adapter.calls[1]["timeout"] == 45
+    assert fake_adapter.calls[1]["timeout"] != fake_adapter.calls[0]["timeout"]
+
+
+def test_ai_review_findings_marks_batch_failed_when_reformat_retry_also_fails(monkeypatch):
+    fake_adapter = _FakeSequentialAdapter(
+        ["Reported one finding: fix the null check.", "Still no JSON here, sorry."]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    assert ctx.data["ai_findings_failed"] is True
+
+
 def test_ai_thread_resolution_parses_markdown_fenced_response(monkeypatch):
     """review-batching-006: ai_thread_resolution used to hand-roll its own fence
     stripping and JSON-slice extraction. It must now share the same

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -3,10 +3,23 @@ from unittest.mock import Mock
 from titan_cli.core.result import ClientError, ClientSuccess
 from titan_cli.engine import WorkflowContext
 from titan_cli.engine.results import Error, Exit, Success
-from titan_plugin_github.models.review_models import ChangeManifest, PullRequestManifest, ReferencedCommitContext, ThreadReviewCandidate
+from titan_cli.external_cli.adapters import HeadlessResponse
+from titan_cli.external_cli.adapters.base import SupportedCLI
+from titan_plugin_github.models.review_enums import FileReadMode, PRSizeClass, ReviewStrategyType
+from titan_plugin_github.models.review_models import (
+    ChangeManifest,
+    FileContextEntry,
+    FocusContextBatch,
+    PullRequestManifest,
+    ReferencedCommitContext,
+    ReviewStrategy,
+    ThreadReviewCandidate,
+)
 from titan_plugin_github.models.review_enums import FileChangeStatus
 from titan_plugin_github.models.view import UIComment, UICommentThread, UIFileChange, UIPullRequest
+import titan_plugin_github.steps.code_review_steps as code_review_steps
 from titan_plugin_github.steps.code_review_steps import (
+    ai_review_findings,
     build_thread_review_candidates,
     build_thread_review_contexts,
     fetch_pr_review_bundle,
@@ -457,3 +470,69 @@ def test_build_thread_review_contexts_ignores_unavailable_referenced_commits():
     )
     contexts = ctx.data["thread_review_contexts"]
     assert contexts[0].referenced_commits == []
+
+
+class _FakeFindingsAdapter:
+    """Fake headless adapter recording every prompt it was asked to execute."""
+
+    cli_name = SupportedCLI.CLAUDE
+
+    def __init__(self):
+        self.executed_prompts: list[str] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None) -> HeadlessResponse:
+        self.executed_prompts.append(prompt)
+        return HeadlessResponse(stdout="[]", stderr="", exit_code=0)
+
+
+def _make_findings_batch(batch_id: str, files_chars: dict[str, int]) -> FocusContextBatch:
+    return FocusContextBatch(
+        batch_id=batch_id,
+        files_context={
+            path: FileContextEntry(
+                path=path,
+                read_mode=FileReadMode.HUNKS_ONLY,
+                hunks=["x" * chars],
+                approximate_chars=chars,
+            )
+            for path, chars in files_chars.items()
+        },
+    )
+
+
+def test_ai_review_findings_splits_oversized_batch_via_prompt_budget_manager(monkeypatch):
+    """
+    review-batching-003 wiring test: `ai_review_findings` must route batch
+    fitting through `PromptBudgetManager.fit_batch_to_budget()` so an
+    over-budget batch gets split and both halves are still sent to the CLI.
+    """
+    fake_adapter = _FakeFindingsAdapter()
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [
+        _make_findings_batch("batch_1", {"a.py": 3000, "b.py": 3000})
+    ]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    # The oversized batch_1 must have been split into batch_1a/batch_1b, and
+    # both halves sent to the adapter independently (2 CLI calls, not 1).
+    assert len(fake_adapter.executed_prompts) == 2
+    assert ctx.data["raw_findings"] == []
+    assert ctx.data["ai_findings_failed"] is False

--- a/plugins/titan-plugin-github/tests/unit/test_prompt_budget_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_prompt_budget_manager.py
@@ -1,0 +1,181 @@
+"""
+Baseline regression tests for `PromptBudgetManager`.
+
+Pins the exact behavior extracted from the former free functions
+`_content_budget()` (context_resolution_operations.py) and
+`_fit_batch_to_budget()` (code_review_steps.py) so later heuristic changes
+(worktree_reference cost penalty, per-batch limits) can be measured against
+a known-good baseline.
+"""
+
+from titan_plugin_github.managers.prompt_budget_manager import (
+    PromptBudgetManager,
+    get_prompt_budget_manager,
+)
+from titan_plugin_github.models.review_enums import FileReadMode, PRSizeClass, ReviewStrategyType
+from titan_plugin_github.models.review_models import FileContextEntry, FocusContextBatch, ReviewStrategy
+
+
+def make_strategy(*, size_class: PRSizeClass, max_prompt_chars: int) -> ReviewStrategy:
+    return ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=size_class,
+        max_focus_files=10,
+        max_prompt_chars=max_prompt_chars,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+
+
+def make_entry(path: str, *, chars: int, worktree_reference: bool = False) -> FileContextEntry:
+    if worktree_reference:
+        return FileContextEntry(
+            path=path,
+            read_mode=FileReadMode.WORKTREE_REFERENCE,
+            worktree_reference=True,
+            review_hint="Read this file from the worktree.",
+            approximate_chars=chars,
+        )
+    return FileContextEntry(
+        path=path,
+        read_mode=FileReadMode.HUNKS_ONLY,
+        hunks=["x" * chars],
+        approximate_chars=chars,
+    )
+
+
+def make_batch(entries: dict[str, FileContextEntry], **overrides) -> FocusContextBatch:
+    return FocusContextBatch(batch_id="batch_1", files_context=entries, **overrides)
+
+
+# ---------------------------------------------------------------------------
+# content_budget()
+# ---------------------------------------------------------------------------
+
+
+def test_content_budget_reserves_more_for_large_prs():
+    manager = PromptBudgetManager()
+    small_strategy = make_strategy(size_class=PRSizeClass.SMALL, max_prompt_chars=20000)
+    large_strategy = make_strategy(size_class=PRSizeClass.LARGE, max_prompt_chars=20000)
+
+    assert manager.content_budget(small_strategy) == 20000 - 3500
+    assert manager.content_budget(large_strategy) == 20000 - 5000
+
+
+def test_content_budget_never_goes_below_floor():
+    manager = PromptBudgetManager()
+    strategy = make_strategy(size_class=PRSizeClass.HUGE, max_prompt_chars=4000)
+
+    assert manager.content_budget(strategy) == 2500
+
+
+def test_get_prompt_budget_manager_returns_shared_instance():
+    assert get_prompt_budget_manager() is get_prompt_budget_manager()
+
+
+# ---------------------------------------------------------------------------
+# fit_batch_to_budget()
+# ---------------------------------------------------------------------------
+
+
+def test_fit_batch_within_budget_is_unchanged():
+    manager = PromptBudgetManager()
+    batch = make_batch({"a.py": make_entry("a.py", chars=100)})
+    prompt_parts = {"prompt": "x" * 100}
+
+    fitted, changed = manager.fit_batch_to_budget(batch, prompt_parts, budget_chars=1000)
+
+    assert changed is False
+    assert len(fitted) == 1
+    assert fitted[0].batch_id == "batch_1"
+    assert fitted[0].prompt_actual_chars == 100
+
+
+def test_fit_batch_splits_multi_file_batch_in_half():
+    manager = PromptBudgetManager()
+    batch = make_batch(
+        {
+            "a.py": make_entry("a.py", chars=100),
+            "b.py": make_entry("b.py", chars=100),
+            "c.py": make_entry("c.py", chars=100),
+            "d.py": make_entry("d.py", chars=100),
+        }
+    )
+    prompt_parts = {"prompt": "x" * 5000}
+
+    fitted, changed = manager.fit_batch_to_budget(batch, prompt_parts, budget_chars=1000)
+
+    assert changed is True
+    assert len(fitted) == 2
+    assert fitted[0].batch_id == "batch_1a"
+    assert fitted[1].batch_id == "batch_1b"
+    assert list(fitted[0].files_context.keys()) == ["a.py", "b.py"]
+    assert list(fitted[1].files_context.keys()) == ["c.py", "d.py"]
+    assert fitted[0].degraded_context is True
+    assert fitted[1].degraded_context is True
+
+
+def test_fit_batch_degrades_single_file_to_worktree_reference():
+    manager = PromptBudgetManager()
+    batch = make_batch({"a.py": make_entry("a.py", chars=100)})
+    prompt_parts = {"prompt": "x" * 5000}
+
+    fitted, changed = manager.fit_batch_to_budget(batch, prompt_parts, budget_chars=1000)
+
+    assert changed is True
+    assert len(fitted) == 1
+    entry = fitted[0].files_context["a.py"]
+    assert entry.worktree_reference is True
+    assert entry.read_mode == FileReadMode.WORKTREE_REFERENCE
+    assert entry.full_content is None
+    assert entry.approximate_chars <= 800
+    assert fitted[0].degraded_context is True
+
+
+def test_fit_batch_drops_related_files_when_only_worktree_reference_left():
+    manager = PromptBudgetManager()
+    batch = make_batch(
+        {"a.py": make_entry("a.py", chars=100, worktree_reference=True)},
+        related_files={"b.py": "some related content"},
+    )
+    prompt_parts = {"prompt": "x" * 5000}
+
+    fitted, changed = manager.fit_batch_to_budget(batch, prompt_parts, budget_chars=1000)
+
+    assert changed is True
+    assert fitted[0].related_files == {}
+    assert fitted[0].degraded_context is True
+
+
+def test_fit_batch_drops_comment_context_when_related_files_already_empty():
+    from titan_plugin_github.models.review_enums import CommentContextKind
+    from titan_plugin_github.models.review_models import CommentContextEntry
+
+    manager = PromptBudgetManager()
+    batch = make_batch(
+        {"a.py": make_entry("a.py", chars=100, worktree_reference=True)},
+        comment_context=[
+            CommentContextEntry(kind=CommentContextKind.COMMENT, thread_id="t1", path="a.py", summary="hi")
+        ],
+    )
+    prompt_parts = {"prompt": "x" * 5000}
+
+    fitted, changed = manager.fit_batch_to_budget(batch, prompt_parts, budget_chars=1000)
+
+    assert changed is True
+    assert fitted[0].comment_context == []
+    assert fitted[0].degraded_context is True
+
+
+def test_fit_batch_marks_oversized_when_nothing_left_to_trim():
+    manager = PromptBudgetManager()
+    batch = make_batch({"a.py": make_entry("a.py", chars=100, worktree_reference=True)})
+    prompt_parts = {"prompt": "x" * 5000}
+
+    fitted, changed = manager.fit_batch_to_budget(batch, prompt_parts, budget_chars=1000)
+
+    assert changed is False
+    assert len(fitted) == 1
+    assert fitted[0].prompt_still_too_large is True
+    assert fitted[0].prompt_actual_chars == 5000
+    assert fitted[0].degraded_context is True

--- a/plugins/titan-plugin-github/tests/unit/test_prompt_budget_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_prompt_budget_manager.py
@@ -74,6 +74,51 @@ def test_get_prompt_budget_manager_returns_shared_instance():
 
 
 # ---------------------------------------------------------------------------
+# estimate_entry_chars()
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_entry_chars_uses_full_content_length():
+    manager = PromptBudgetManager()
+    entry = FileContextEntry(path="a.py", read_mode=FileReadMode.FULL_FILE, full_content="x" * 1234)
+
+    assert manager.estimate_entry_chars(entry) == 1234
+
+
+def test_estimate_entry_chars_sums_expanded_hunks():
+    manager = PromptBudgetManager()
+    entry = FileContextEntry(
+        path="a.py", read_mode=FileReadMode.EXPANDED_HUNKS, expanded_hunks=["x" * 100, "y" * 50]
+    )
+
+    assert manager.estimate_entry_chars(entry) == 150
+
+
+def test_estimate_entry_chars_sums_hunks():
+    manager = PromptBudgetManager()
+    entry = FileContextEntry(path="a.py", read_mode=FileReadMode.HUNKS_ONLY, hunks=["x" * 100, "y" * 50])
+
+    assert manager.estimate_entry_chars(entry) == 150
+
+
+def test_estimate_entry_chars_penalizes_worktree_reference_regardless_of_hint_size():
+    manager = PromptBudgetManager()
+    entry = FileContextEntry(
+        path="a.py", read_mode=FileReadMode.WORKTREE_REFERENCE, worktree_reference=True, review_hint="short"
+    )
+
+    assert manager.estimate_entry_chars(entry) == PromptBudgetManager.WORKTREE_REFERENCE_ESTIMATED_CHARS
+    assert manager.estimate_entry_chars(entry) > 800
+
+
+def test_estimate_entry_chars_returns_zero_for_empty_entry():
+    manager = PromptBudgetManager()
+    entry = FileContextEntry(path="a.py")
+
+    assert manager.estimate_entry_chars(entry) == 0
+
+
+# ---------------------------------------------------------------------------
 # fit_batch_to_budget()
 # ---------------------------------------------------------------------------
 

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -116,6 +116,11 @@ class DiffContextManager:
         Return diff hunks enriched with surrounding file context.
 
         Uses already-parsed hunk coordinates instead of reparsing @@ headers.
+
+        The "# --- diff hunk ---" marker below is parsed by
+        `findings_operations._annotate_diff_hunk`, which only applies diff-style line
+        annotation after it (the surrounding-context block above it is raw file content,
+        not diff-prefixed). Keep both in sync if this format changes.
         """
         hunks = self.get_hunks(path)
         if not hunks:

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/prompt_budget_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/prompt_budget_manager.py
@@ -6,16 +6,33 @@ policy previously duplicated as free functions in
 """
 
 from ..models.review_enums import FileReadMode, PRSizeClass
-from ..models.review_models import FocusContextBatch, ReviewStrategy
+from ..models.review_models import FileContextEntry, FocusContextBatch, ReviewStrategy
 
 
 class PromptBudgetManager:
     """Owns prompt-part sizing, batch fit/split decisions, and degradation policy."""
 
+    # A worktree_reference entry is just a short hint in the prompt text, but the CLI still
+    # has to open and analyze the real file from the worktree with its own tools, so its
+    # actual cost is much higher than its prompt-text size suggests.
+    WORKTREE_REFERENCE_ESTIMATED_CHARS = 5000
+
     def content_budget(self, strategy: ReviewStrategy) -> int:
         """Return the char budget available for file/related/comment context."""
         reserve = 5000 if strategy.size_class in {PRSizeClass.LARGE, PRSizeClass.HUGE} else 3500
         return max(2500, strategy.max_prompt_chars - reserve)
+
+    def estimate_entry_chars(self, entry: FileContextEntry) -> int:
+        """Estimate the prompt-budget cost of a resolved file context entry."""
+        if entry.full_content:
+            return len(entry.full_content)
+        if entry.expanded_hunks:
+            return sum(len(hunk) for hunk in entry.expanded_hunks)
+        if entry.hunks:
+            return sum(len(hunk) for hunk in entry.hunks)
+        if entry.worktree_reference:
+            return self.WORKTREE_REFERENCE_ESTIMATED_CHARS
+        return 0
 
     def fit_batch_to_budget(
         self,

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/prompt_budget_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/prompt_budget_manager.py
@@ -1,0 +1,96 @@
+"""Prompt-budget policy for GitHub AI review workflows.
+
+Centralizes the content-budget sizing and batch fit/split/degradation
+policy previously duplicated as free functions in
+`context_resolution_operations.py` and `code_review_steps.py`.
+"""
+
+from ..models.review_enums import FileReadMode, PRSizeClass
+from ..models.review_models import FocusContextBatch, ReviewStrategy
+
+
+class PromptBudgetManager:
+    """Owns prompt-part sizing, batch fit/split decisions, and degradation policy."""
+
+    def content_budget(self, strategy: ReviewStrategy) -> int:
+        """Return the char budget available for file/related/comment context."""
+        reserve = 5000 if strategy.size_class in {PRSizeClass.LARGE, PRSizeClass.HUGE} else 3500
+        return max(2500, strategy.max_prompt_chars - reserve)
+
+    def fit_batch_to_budget(
+        self,
+        batch: FocusContextBatch,
+        prompt_parts: dict[str, str],
+        budget_chars: int,
+    ) -> tuple[list[FocusContextBatch], bool]:
+        """Shrink or split a batch until it fits the prompt budget, or mark it oversized."""
+        prompt = prompt_parts["prompt"]
+        actual_chars = len(prompt)
+        if actual_chars <= budget_chars:
+            fitted = batch.model_copy(update={"prompt_actual_chars": actual_chars})
+            return [fitted], False
+
+        file_items = list(batch.files_context.items())
+        if len(file_items) > 1:
+            midpoint = max(1, len(file_items) // 2)
+            left = batch.model_copy(
+                update={
+                    "batch_id": f"{batch.batch_id}a",
+                    "files_context": dict(file_items[:midpoint]),
+                    "degraded_context": True,
+                }
+            )
+            right = batch.model_copy(
+                update={
+                    "batch_id": f"{batch.batch_id}b",
+                    "files_context": dict(file_items[midpoint:]),
+                    "degraded_context": True,
+                }
+            )
+            return [left, right], True
+
+        only_path, only_entry = file_items[0]
+        if not only_entry.worktree_reference:
+            degraded_entry = only_entry.model_copy(
+                update={
+                    "full_content": None,
+                    "expanded_hunks": [],
+                    "hunks": [],
+                    "read_mode": FileReadMode.WORKTREE_REFERENCE,
+                    "worktree_reference": True,
+                    "review_hint": only_entry.review_hint
+                    or "Read this file from the worktree and inspect the changed regions first.",
+                    "approximate_chars": min(800, only_entry.approximate_chars or 800),
+                }
+            )
+            return [
+                batch.model_copy(
+                    update={
+                        "files_context": {only_path: degraded_entry},
+                        "degraded_context": True,
+                    }
+                )
+            ], True
+
+        if batch.related_files:
+            return [batch.model_copy(update={"related_files": {}, "degraded_context": True})], True
+
+        if batch.comment_context:
+            return [batch.model_copy(update={"comment_context": [], "degraded_context": True})], True
+
+        oversized = batch.model_copy(
+            update={
+                "prompt_actual_chars": actual_chars,
+                "prompt_still_too_large": True,
+                "degraded_context": True,
+            }
+        )
+        return [oversized], False
+
+
+_default_manager = PromptBudgetManager()
+
+
+def get_prompt_budget_manager() -> PromptBudgetManager:
+    """Return the shared `PromptBudgetManager` instance."""
+    return _default_manager

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/ai_response_parsing_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/ai_response_parsing_operations.py
@@ -10,6 +10,10 @@ from typing import Literal, Union
 
 from titan_cli.core.result import ClientError, ClientResult, ClientSuccess
 
+# Distinct from the 300s/240s full-analysis timeouts: this retry only asks the CLI to
+# reformat text it already produced, not to redo the review.
+REFORMAT_RETRY_TIMEOUT_SECONDS = 45
+
 
 def extract_json_payload(text: str, kind: Literal["array", "object"]) -> ClientResult[Union[list, dict]]:
     """Strip markdown fences and parse the outermost JSON array/object out of CLI output."""
@@ -26,6 +30,18 @@ def extract_json_payload(text: str, kind: Literal["array", "object"]) -> ClientR
     except json.JSONDecodeError as e:
         return ClientError(error_message=str(e), error_code="JSON_PARSE_ERROR", log_level="warning")
     return ClientSuccess(data=payload)
+
+
+def build_json_reformat_prompt(previous_output: str, kind: Literal["array", "object"]) -> str:
+    """Build a short follow-up prompt asking the CLI to reformat its own prior output as JSON."""
+    noun = "array" if kind == "array" else "object"
+    return (
+        "Your previous response could not be parsed as JSON.\n\n"
+        f"--- Previous response ---\n{previous_output}\n--- End of previous response ---\n\n"
+        f"Reformat that response as a single valid JSON {noun} matching the schema you were "
+        "originally asked for. Do not redo the analysis and do not add any commentary — "
+        f"respond with ONLY the JSON {noun}, nothing before or after it."
+    )
 
 
 def _strip_markdown_fences(text: str) -> str:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/ai_response_parsing_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/ai_response_parsing_operations.py
@@ -1,0 +1,37 @@
+"""Operations for parsing structured JSON responses from AI CLI adapters.
+
+Centralizes the response-cleanup and JSON-extraction logic shared by every step that asks a
+headless CLI for a JSON array or object (ai_review_plan, ai_review_findings,
+ai_thread_resolution), so there is exactly one implementation to fix or extend.
+"""
+
+import json
+from typing import Literal, Union
+
+from titan_cli.core.result import ClientError, ClientResult, ClientSuccess
+
+
+def extract_json_payload(text: str, kind: Literal["array", "object"]) -> ClientResult[Union[list, dict]]:
+    """Strip markdown fences and parse the outermost JSON array/object out of CLI output."""
+    opening, closing = ("[", "]") if kind == "array" else ("{", "}")
+    cleaned = _strip_markdown_fences(text)
+    start = cleaned.find(opening)
+    end = cleaned.rfind(closing) + 1
+    if start == -1 or end == 0:
+        return ClientError(
+            error_message=f"No JSON {kind} found in response", error_code="NO_JSON_PAYLOAD", log_level="warning"
+        )
+    try:
+        payload = json.loads(cleaned[start:end])
+    except json.JSONDecodeError as e:
+        return ClientError(error_message=str(e), error_code="JSON_PARSE_ERROR", log_level="warning")
+    return ClientSuccess(data=payload)
+
+
+def _strip_markdown_fences(text: str) -> str:
+    """Remove outer markdown code fences from a CLI response."""
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.split("\n")
+    return "\n".join(lines[1:-1]) if len(lines) > 2 else stripped

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -304,7 +304,9 @@ def _build_worktree_hint(file_plan: FileReviewPlan) -> str:
     return (
         "Read this file from the worktree. Prioritize the changed regions first and validate: "
         f"{reasons}. Check especially for semantic mismatches, missing guarantees, state inconsistencies, "
-        "and behavior changes that remain executable but no longer mean the same thing. Cross-check nearby helpers, types, and tests if the changed region depends on them."
+        "and behavior changes that remain executable but no longer mean the same thing. You may check a few "
+        "directly related files (an imported type, a caller, a test) if genuinely needed to resolve a "
+        "specific doubt, but do not perform a broad, open-ended exploration of the codebase."
     )
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -135,8 +135,13 @@ def build_review_context_package(
     for file_plan in plan.focus_files:
         entry = _resolve_file_context(file_plan, diff, strategy, cwd, manager)
         entry_chars = entry.approximate_chars or get_prompt_budget_manager().estimate_entry_chars(entry)
+        # A worktree_reference file forces the CLI to read it from disk itself, which is
+        # expensive regardless of how cheap its prompt text looks — cap how many of them
+        # can stack up in a single batch, on top of the regular char-budget check.
+        exceeds_worktree_reference_limit = entry.worktree_reference and _batch_has_worktree_reference(current_files)
 
-        if current_files and strategy.batching_enabled and current_chars + entry_chars > content_budget:
+        exceeds_char_budget = current_chars + entry_chars > content_budget
+        if current_files and strategy.batching_enabled and (exceeds_char_budget or exceeds_worktree_reference_limit):
             batches.append(
                 FocusContextBatch(
                     batch_id=f"batch_{batch_index}",
@@ -309,6 +314,10 @@ def _estimate_related_chars(related_files: dict[str, str]) -> int:
 
 def _estimate_comment_chars(comment_context: list[CommentContextEntry]) -> int:
     return sum(len(entry.title) + len(entry.summary) for entry in comment_context)
+
+
+def _batch_has_worktree_reference(files_context: dict[str, FileContextEntry]) -> bool:
+    return any(entry.worktree_reference for entry in files_context.values())
 
 
 def _log_file_context(entry: FileContextEntry, path: str) -> FileContextEntry:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -6,7 +6,8 @@ from typing import Optional
 from titan_cli.core.logging import get_logger
 
 from ..managers.diff_context_manager import DiffContextManager, get_or_create_diff_manager
-from ..models.review_enums import ContextRequestType, FileReadMode
+from ..managers.prompt_budget_manager import get_prompt_budget_manager
+from ..models.review_enums import ContextRequestType, FileReadMode, PRSizeClass
 from ..models.review_models import (
     ChangeManifest,
     CommentContextEntry,
@@ -123,7 +124,7 @@ def build_review_context_package(
     checklist_applicable = [item for item in checklist if item.id in applicable_ids] or checklist[:2]
     related_files = resolve_context_requests(plan.extra_context_requests[:1], cwd)
     comment_context = comment_context[: strategy.max_comment_entries]
-    content_budget = _content_budget(strategy)
+    content_budget = get_prompt_budget_manager().content_budget(strategy)
 
     batches: list[FocusContextBatch] = []
     current_files: dict[str, FileContextEntry] = {}
@@ -270,13 +271,8 @@ def _estimate_entry_chars(entry: FileContextEntry) -> int:
     return 0
 
 
-def _content_budget(strategy: ReviewStrategy) -> int:
-    reserve = 5000 if strategy.size_class.value in {"large", "huge"} else 3500
-    return max(2500, strategy.max_prompt_chars - reserve)
-
-
 def _file_limits(strategy: ReviewStrategy, path: str) -> dict[str, int]:
-    is_large = strategy.size_class.value in {"large", "huge"}
+    is_large = strategy.size_class in {PRSizeClass.LARGE, PRSizeClass.HUGE}
     is_central = _looks_like_central_file(path)
     is_test = _is_test_file(path)
     return {

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -134,7 +134,7 @@ def build_review_context_package(
 
     for file_plan in plan.focus_files:
         entry = _resolve_file_context(file_plan, diff, strategy, cwd, manager)
-        entry_chars = entry.approximate_chars or _estimate_entry_chars(entry)
+        entry_chars = entry.approximate_chars or get_prompt_budget_manager().estimate_entry_chars(entry)
 
         if current_files and strategy.batching_enabled and current_chars + entry_chars > content_budget:
             batches.append(
@@ -254,21 +254,9 @@ def _resolve_file_context(
         worktree_reference=True,
         review_hint=_build_worktree_hint(file_plan),
         changed_hunk_headers=hunk_headers,
-        approximate_chars=min(800, 80 + sum(len(header) for header in hunk_headers)),
+        approximate_chars=get_prompt_budget_manager().WORKTREE_REFERENCE_ESTIMATED_CHARS,
     )
     return _log_file_context(resolved_entry, file_plan.path)
-
-
-def _estimate_entry_chars(entry: FileContextEntry) -> int:
-    if entry.full_content:
-        return len(entry.full_content)
-    if entry.expanded_hunks:
-        return sum(len(hunk) for hunk in entry.expanded_hunks)
-    if entry.hunks:
-        return sum(len(hunk) for hunk in entry.hunks)
-    if entry.worktree_reference:
-        return 80 + len(entry.review_hint) + sum(len(header) for header in entry.changed_hunk_headers)
-    return 0
 
 
 def _file_limits(strategy: ReviewStrategy, path: str) -> dict[str, int]:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -49,7 +49,7 @@ This is one bounded review batch. Review only the provided code and report actio
 ## Instructions
 {instructions}
 
-Respond ONLY with a valid JSON array matching this schema:
+Respond ONLY with a valid JSON array matching this schema. Do not include any prose before or after the JSON.
 {schema}
 """
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -189,6 +189,31 @@ def _finding_schema() -> str:
     )
 
 
+FINDINGS_DISALLOWED_TOOLS = ("Bash", "Edit", "Write", "NotebookEdit", "WebFetch", "WebSearch", "Agent")
+"""Tools removed from the CLI's session for `ai_review_findings` calls.
+
+A findings-review call never needs to modify files, fetch the web, or spawn a subagent, and
+`Bash` is the exact vector traced (D-011) to unbounded, mostly unproductive exploration —
+recursive shell greps/finds across whole directory trees, not scoped to the worktree the way
+`Read`/`Grep`/`Glob` are. Those three stay available: they cover the same legitimate
+cross-file lookups (an imported type, a caller, a test) through Claude Code's own bounded
+tools instead of arbitrary shell recursion.
+"""
+
+FINDINGS_WORKTREE_REFERENCE_EFFORT = "medium"
+"""Reasoning-effort tier for findings batches that include a worktree_reference file.
+
+Removing Bash alone (`FINDINGS_DISALLOWED_TOOLS`) didn't reduce O-003's duration/timeout —
+a real replay showed Claude still takes ~15 Read/Grep turns and ~330s regardless of which
+tool is available, while Codex/Gemini cover similar ground in far fewer output tokens and a
+fraction of the time. Capping effort at "medium" (vs. the session default) cut a real replay
+from ~330s/$1.10 to ~170s/$0.78 while still surfacing a genuine bug an independent CLI
+(Gemini) also found — "low" was faster still (~50s/$0.34) but missed that bug, so "medium" is
+the current balance. Provisional pending more real-PR data, same as
+`WORKTREE_REFERENCE_ESTIMATED_CHARS` (O-001).
+"""
+
+
 def findings_json_schema() -> dict[str, Any]:
     """JSON Schema for `--json-schema`, enforcing findings as a tool call instead of
     relying on the model to follow a "respond only with JSON" prompt instruction.

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -3,7 +3,10 @@
 import json
 from typing import Any
 
+from titan_cli.core.result import ClientError, ClientResult, ClientSuccess
+
 from ..models.review_models import Finding, FocusContextBatch, ReviewChecklistItem
+from .ai_response_parsing_operations import extract_json_payload
 from .prompt_formatting_operations import comment_context_to_json
 
 
@@ -184,6 +187,61 @@ def _finding_schema() -> str:
         ],
         indent=2,
     )
+
+
+def findings_json_schema() -> dict[str, Any]:
+    """JSON Schema for `--json-schema`, enforcing findings as a tool call instead of
+    relying on the model to follow a "respond only with JSON" prompt instruction.
+
+    Wrapped in an object because Anthropic's structured-output tool schema requires a
+    top-level "object" type; the array of findings lives under the "findings" key.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "findings": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "severity": {"type": "string", "enum": ["blocking", "important", "nit"]},
+                        "category": {"type": "string"},
+                        "path": {"type": "string"},
+                        "line": {"type": ["integer", "null"]},
+                        "title": {"type": "string"},
+                        "why": {"type": "string"},
+                        "evidence": {"type": "string"},
+                        "snippet": {"type": ["string", "null"]},
+                        "suggested_comment": {"type": "string"},
+                    },
+                    "required": ["severity", "category", "path", "title", "why", "evidence", "suggested_comment"],
+                },
+            }
+        },
+        "required": ["findings"],
+    }
+
+
+def parse_findings_response(stdout: str, *, structured: bool) -> ClientResult[list]:
+    """Parse a findings-batch CLI response.
+
+    When `structured` is True (the adapter enforced `findings_json_schema()`), stdout is
+    the schema envelope `{"findings": [...]}` and this unwraps the `findings` key.
+    Otherwise stdout is free text and this falls back to extracting a bare JSON array.
+    """
+    if not structured:
+        return extract_json_payload(stdout, kind="array")
+    match extract_json_payload(stdout, kind="object"):
+        case ClientSuccess(data=payload) if isinstance(payload, dict) and "findings" in payload:
+            return ClientSuccess(data=payload["findings"])
+        case ClientSuccess():
+            return ClientError(
+                error_message="Structured response missing 'findings' field",
+                error_code="MISSING_FINDINGS_FIELD",
+                log_level="warning",
+            )
+        case error:
+            return error
 
 
 def build_default_findings() -> list[Finding]:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -128,6 +128,9 @@ def _add_line_numbers(content: str) -> str:
     return "\n".join(f"{str(i + 1).rjust(width)} | {line}" for i, line in enumerate(lines))
 
 
+_DIFF_HUNK_MARKER = "# --- diff hunk ---"
+
+
 def _annotate_diff_hunk(hunk: str) -> str:
     import re
 
@@ -148,11 +151,23 @@ def _annotate_diff_hunk(hunk: str) -> str:
     if new_line_start is None:
         return "\n".join(lines)
 
-    result = [header_line] if header_line else []
+    # `expanded_hunks` entries (DiffContextManager.build_expanded_hunks) prepend a
+    # "surrounding context" block of raw file lines (no diff +/-/space prefixes) before the
+    # real diff hunk. Only the portion after the marker is actual diff content — annotating
+    # the preamble too would misread indented raw code lines as numbered [CONTEXT] diff lines
+    # and corrupt the line counter for everything that follows.
+    preamble: list[str] = []
+    diff_lines = lines
+    if _DIFF_HUNK_MARKER in lines:
+        marker_idx = lines.index(_DIFF_HUNK_MARKER)
+        preamble = lines[: marker_idx + 1]
+        diff_lines = lines[marker_idx + 1 :]
+
+    result = list(preamble) if preamble else ([header_line] if header_line else [])
     current_line = new_line_start
     width = len(str(current_line + 100))
 
-    for line in lines:
+    for line in diff_lines:
         if line.startswith("@@"):
             continue
         if line.startswith("---") or line.startswith("+++"):

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -6,6 +6,7 @@ AI analysis combined with project-specific skill guidelines.
 """
 import re
 import threading
+import time
 from difflib import SequenceMatcher
 from typing import List, Optional
 
@@ -1944,8 +1945,24 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 detail="prompt still too large",
             )
             continue
+        worktree_reference_count = sum(
+            1 for entry in batch.files_context.values() if entry.worktree_reference
+        )
+        adapter_started_at = time.monotonic()
         with ctx.textual.loading(f"Asking {cli_display} to review {len(batch.files_context)} file(s) in {batch.batch_id}…"):
             response = adapter.execute(prompt, cwd=project_root, timeout=300)
+        adapter_duration_seconds = time.monotonic() - adapter_started_at
+        logger.info(
+            "findings_batch_adapter_call",
+            batch_id=batch.batch_id,
+            cli=adapter.cli_name.value,
+            files_context=len(batch.files_context),
+            worktree_reference_count=worktree_reference_count,
+            prompt_actual_chars=len(prompt),
+            duration_seconds=round(adapter_duration_seconds, 3),
+            exit_code=response.exit_code,
+            timed_out=response.exit_code == 124,
+        )
         _log_ai_response(
             step_name="ai_review_findings",
             cli_name=adapter.cli_name.value,
@@ -2746,8 +2763,19 @@ def ai_thread_resolution(ctx: WorkflowContext) -> WorkflowResult:
 
     cli_display = adapter.cli_name.value.capitalize()
     thread_count = len(contexts)
+    adapter_started_at = time.monotonic()
     with ctx.textual.loading(f"Asking {cli_display} to analyse {thread_count} thread(s)…"):
         response = adapter.execute(prompt, cwd=project_root, timeout=300)
+    adapter_duration_seconds = time.monotonic() - adapter_started_at
+    logger.info(
+        "thread_resolution_adapter_call",
+        cli=adapter.cli_name.value,
+        thread_count=thread_count,
+        prompt_actual_chars=len(prompt),
+        duration_seconds=round(adapter_duration_seconds, 3),
+        exit_code=response.exit_code,
+        timed_out=response.exit_code == 124,
+    )
 
     if not response.succeeded:
         ctx.textual.warning_text(f"CLI call failed (exit {response.exit_code}) — no thread decisions")

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -26,6 +26,7 @@ from ..models.review_models import (
 )
 from ..models.review_profile_models import ReviewProfile
 from ..models.view import UICommentThread, UIPullRequest
+from ..operations.ai_response_parsing_operations import extract_json_payload
 from ..operations.code_review_operations import (
     select_files_for_review,
     compute_diff_stat,
@@ -288,24 +289,6 @@ def _show_review_plan_validation_summary(ctx: WorkflowContext, plan) -> None:
     ctx.textual.dim_text(
         f"Validated plan: {focus_count} focus file(s) · {axes_count} axes · {extra_count} extra context request(s)"
     )
-
-
-def _strip_markdown_fences(text: str) -> str:
-    """Remove outer markdown code fences from a CLI response."""
-    stripped = text.strip()
-    if not stripped.startswith("```"):
-        return stripped
-    lines = stripped.split("\n")
-    return "\n".join(lines[1:-1]) if len(lines) > 2 else stripped
-
-
-def _extract_json_slice(text: str, opening: str, closing: str, label: str) -> str:
-    """Extract the outermost JSON object or array substring from a response."""
-    start = text.find(opening)
-    end = text.rfind(closing) + 1
-    if start == -1 or end == 0:
-        raise ValueError(f"No JSON {label} found in response")
-    return text[start:end]
 
 
 def _filter_invalid_inline_comments(ctx: WorkflowContext, pr_number: int, payload: dict) -> tuple[dict, list[dict]]:
@@ -1350,7 +1333,6 @@ def ai_review_plan(ctx: WorkflowContext) -> WorkflowResult:
     )
     from ..models.review_models import ReviewPlan
     from pydantic import ValidationError
-    import json
 
     if strategy.strategy == ReviewStrategyType.DIRECT_FINDINGS:
         fallback = build_default_review_plan(
@@ -1439,11 +1421,18 @@ def ai_review_plan(ctx: WorkflowContext) -> WorkflowResult:
         return Success("Default review plan used (CLI error)", metadata={"review_plan": fallback})
 
     # Parse JSON response
-    try:
-        text = _strip_markdown_fences(response.stdout)
-        plan = ReviewPlan.model_validate_json(_extract_json_slice(text, "{", "}", "object"))
-    except (json.JSONDecodeError, ValidationError, ValueError) as e:
-        ctx.textual.warning_text(f"Plan parsing failed ({e}) — using default plan")
+    parse_error: Optional[str] = None
+    match extract_json_payload(response.stdout, kind="object"):
+        case ClientSuccess(data=payload):
+            try:
+                plan = ReviewPlan.model_validate(payload)
+            except ValidationError as e:
+                parse_error = str(e)
+        case ClientError(error_message=err):
+            parse_error = err
+
+    if parse_error is not None:
+        ctx.textual.warning_text(f"Plan parsing failed ({parse_error}) — using default plan")
         fallback = build_default_review_plan(
             candidates,
             excluded_files,
@@ -1804,7 +1793,6 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         build_findings_prompt_parts,
         summarize_findings_prompt_parts,
     )
-    import json
 
     adapter = _resolve_headless_adapter(cli_preference)
 
@@ -1925,10 +1913,8 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             )
             continue
 
-        try:
-            text = _strip_markdown_fences(response.stdout)
-            raw = json.loads(_extract_json_slice(text, "[", "]", "array"))
-            if isinstance(raw, list):
+        match extract_json_payload(response.stdout, kind="array"):
+            case ClientSuccess(data=raw) if isinstance(raw, list):
                 aggregated_raw.extend(raw)
                 _render_findings_batch_result(
                     ctx,
@@ -1936,15 +1922,17 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                     status="success",
                     findings_count=len(raw),
                 )
-        except (json.JSONDecodeError, ValueError) as e:
-            findings_failed = True
-            logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=str(e))
-            _render_findings_batch_result(
-                ctx,
-                batch.batch_id,
-                status="failed",
-                detail="parse error",
-            )
+            case ClientSuccess():
+                pass
+            case ClientError(error_message=err):
+                findings_failed = True
+                logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=err)
+                _render_findings_batch_result(
+                    ctx,
+                    batch.batch_id,
+                    status="failed",
+                    detail="parse error",
+                )
 
     if not aggregated_raw and strategy and strategy.suspicious_empty_findings:
         candidates = ctx.get("review_candidates", [])
@@ -2686,8 +2674,6 @@ def ai_thread_resolution(ctx: WorkflowContext) -> WorkflowResult:
         ctx.textual.end_step("skip")
         return Skip("No thread_review_contexts in context")
 
-    import json
-
     adapter = _resolve_headless_adapter(cli_preference)
 
     if not adapter:
@@ -2723,21 +2709,14 @@ def ai_thread_resolution(ctx: WorkflowContext) -> WorkflowResult:
         return Success("No decisions (CLI error)", metadata={"raw_thread_decisions": []})
 
     # Parse JSON array response
-    try:
-        text = response.stdout.strip()
-        if text.startswith("```"):
-            lines = text.split("\n")
-            text = "\n".join(lines[1:-1]) if len(lines) > 2 else text
-        start = text.find("[")
-        end = text.rfind("]") + 1
-        if start == -1 or end == 0:
-            raise ValueError("No JSON array found in response")
-        raw = json.loads(text[start:end])
-    except (json.JSONDecodeError, ValueError) as e:
-        ctx.textual.warning_text(f"Thread decisions parsing failed ({e}) — no decisions")
-        ctx.data["raw_thread_decisions"] = []
-        ctx.textual.end_step("success")
-        return Success("No decisions (parse error)", metadata={"raw_thread_decisions": []})
+    match extract_json_payload(response.stdout, kind="array"):
+        case ClientError(error_message=err):
+            ctx.textual.warning_text(f"Thread decisions parsing failed ({err}) — no decisions")
+            ctx.data["raw_thread_decisions"] = []
+            ctx.textual.end_step("success")
+            return Success("No decisions (parse error)", metadata={"raw_thread_decisions": []})
+        case ClientSuccess(data=raw):
+            pass
 
     ctx.data["raw_thread_decisions"] = raw
     ctx.textual.success_text(f"✓ AI returned {len(raw)} thread decision(s)")

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1633,16 +1633,24 @@ def _render_findings_batch_started(ctx: WorkflowContext, batch) -> None:
 
 
 def _retry_findings_batch_reformat(
-    adapter, previous_stdout: str, cwd: Optional[str], batch_id: str, structured: bool
+    adapter, previous_stdout: str, cwd: Optional[str], batch_id: str, structured: bool, effort: Optional[str] = None
 ):
     """Ask the same CLI to reformat its own previous output as a JSON array, without
     rerunning the full analysis, using a short timeout distinct from the main one."""
-    from ..operations.findings_operations import findings_json_schema, parse_findings_response
+    from ..operations.findings_operations import FINDINGS_DISALLOWED_TOOLS, findings_json_schema, parse_findings_response
 
     reformat_prompt = build_json_reformat_prompt(previous_stdout, kind="array")
     schema = findings_json_schema() if structured else None
+    disallowed_tools = list(FINDINGS_DISALLOWED_TOOLS) if adapter.supports_tool_restriction else None
     _log_ai_prompt("ai_review_findings_reformat_retry", adapter.cli_name.value, reformat_prompt, batch_id=batch_id)
-    response = adapter.execute(reformat_prompt, cwd=cwd, timeout=REFORMAT_RETRY_TIMEOUT_SECONDS, json_schema=schema)
+    response = adapter.execute(
+        reformat_prompt,
+        cwd=cwd,
+        timeout=REFORMAT_RETRY_TIMEOUT_SECONDS,
+        json_schema=schema,
+        disallowed_tools=disallowed_tools,
+        effort=effort if adapter.supports_effort_control else None,
+    )
     _log_ai_response(
         step_name="ai_review_findings_reformat_retry",
         cli_name=adapter.cli_name.value,
@@ -1821,6 +1829,8 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         return Error("No review_context_batches in context (run resolve_review_context first)")
 
     from ..operations.findings_operations import (
+        FINDINGS_DISALLOWED_TOOLS,
+        FINDINGS_WORKTREE_REFERENCE_EFFORT,
         build_default_findings,
         build_findings_prompt_parts,
         findings_json_schema,
@@ -1841,6 +1851,10 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     # instruction, which models frequently ignore in favor of a prose summary.
     use_structured_output = adapter.supports_structured_output
     findings_schema = findings_json_schema() if use_structured_output else None
+    # Removes Bash (and other unneeded tools) from the CLI's own session so it can't explore
+    # far beyond the batch's worktree_reference files (D-011/O-003) — Read/Grep/Glob stay
+    # available for the legitimate cross-file lookups the worktree_reference hint permits.
+    disallowed_tools = list(FINDINGS_DISALLOWED_TOOLS) if adapter.supports_tool_restriction else None
     cli_display = adapter.cli_name.value.capitalize()
     aggregated_raw = []
     findings_failed = False
@@ -1912,9 +1926,24 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         worktree_reference_count = sum(
             1 for entry in batch.files_context.values() if entry.worktree_reference
         )
+        # A worktree_reference batch is the one shape shown to reliably drive O-003's
+        # duration/timeout problem (D-011) — capping effort only here, not on every batch,
+        # leaves batches that already complete quickly untouched.
+        effort = (
+            FINDINGS_WORKTREE_REFERENCE_EFFORT
+            if worktree_reference_count and adapter.supports_effort_control
+            else None
+        )
         adapter_started_at = time.monotonic()
         with ctx.textual.loading(f"Asking {cli_display} to review {len(batch.files_context)} file(s) in {batch.batch_id}…"):
-            response = adapter.execute(prompt, cwd=project_root, timeout=300, json_schema=findings_schema)
+            response = adapter.execute(
+                prompt,
+                cwd=project_root,
+                timeout=300,
+                json_schema=findings_schema,
+                disallowed_tools=disallowed_tools,
+                effort=effort,
+            )
         adapter_duration_seconds = time.monotonic() - adapter_started_at
         logger.info(
             "findings_batch_adapter_call",
@@ -1927,6 +1956,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             exit_code=response.exit_code,
             timed_out=response.exit_code == 124,
             structured_output=use_structured_output,
+            effort=effort,
         )
         _log_ai_response(
             step_name="ai_review_findings",
@@ -1967,7 +1997,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             case ClientError(error_message=err):
                 logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=err)
                 match _retry_findings_batch_reformat(
-                    adapter, response.stdout, project_root, batch.batch_id, use_structured_output
+                    adapter, response.stdout, project_root, batch.batch_id, use_structured_output, effort
                 ):
                     case ClientSuccess(data=raw) if isinstance(raw, list):
                         aggregated_raw.extend(raw)

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -17,7 +17,8 @@ from titan_cli.external_cli.adapters import HEADLESS_ADAPTER_REGISTRY, get_headl
 from titan_cli.ui.tui.widgets import ChoiceOption, OptionItem, PromptChoice
 
 from ..managers.diff_context_manager import get_or_create_diff_manager
-from ..models.review_enums import FileReadMode, ReviewActionType, ReviewStrategyType, ThreadDecisionType
+from ..managers.prompt_budget_manager import get_prompt_budget_manager
+from ..models.review_enums import ReviewActionType, ReviewStrategyType, ThreadDecisionType
 from ..models.review_models import (
     PRClassification,
     ReferencedCommitContext,
@@ -305,72 +306,6 @@ def _extract_json_slice(text: str, opening: str, closing: str, label: str) -> st
     if start == -1 or end == 0:
         raise ValueError(f"No JSON {label} found in response")
     return text[start:end]
-
-
-def _fit_batch_to_budget(batch, prompt_parts: dict[str, str], budget_chars: int):
-    """Shrink or split a batch until it fits the prompt budget, or mark it oversized."""
-    prompt = prompt_parts["prompt"]
-    actual_chars = len(prompt)
-    if actual_chars <= budget_chars:
-        fitted = batch.model_copy(update={"prompt_actual_chars": actual_chars})
-        return [fitted], False
-
-    file_items = list(batch.files_context.items())
-    if len(file_items) > 1:
-        midpoint = max(1, len(file_items) // 2)
-        left = batch.model_copy(
-            update={
-                "batch_id": f"{batch.batch_id}a",
-                "files_context": dict(file_items[:midpoint]),
-                "degraded_context": True,
-            }
-        )
-        right = batch.model_copy(
-            update={
-                "batch_id": f"{batch.batch_id}b",
-                "files_context": dict(file_items[midpoint:]),
-                "degraded_context": True,
-            }
-        )
-        return [left, right], True
-
-    only_path, only_entry = file_items[0]
-    if not only_entry.worktree_reference:
-        degraded_entry = only_entry.model_copy(
-            update={
-                "full_content": None,
-                "expanded_hunks": [],
-                "hunks": [],
-                "read_mode": FileReadMode.WORKTREE_REFERENCE,
-                "worktree_reference": True,
-                "review_hint": only_entry.review_hint
-                or "Read this file from the worktree and inspect the changed regions first.",
-                "approximate_chars": min(800, only_entry.approximate_chars or 800),
-            }
-        )
-        return [
-            batch.model_copy(
-                update={
-                    "files_context": {only_path: degraded_entry},
-                    "degraded_context": True,
-                }
-            )
-        ], True
-
-    if batch.related_files:
-        return [batch.model_copy(update={"related_files": {}, "degraded_context": True})], True
-
-    if batch.comment_context:
-        return [batch.model_copy(update={"comment_context": [], "degraded_context": True})], True
-
-    oversized = batch.model_copy(
-        update={
-            "prompt_actual_chars": actual_chars,
-            "prompt_still_too_large": True,
-            "degraded_context": True,
-        }
-    )
-    return [oversized], False
 
 
 def _filter_invalid_inline_comments(ctx: WorkflowContext, pr_number: int, payload: dict) -> tuple[dict, list[dict]]:
@@ -1889,7 +1824,9 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         batch = batch_queue.pop(0)
         prompt_parts = build_findings_prompt_parts(batch)
         prompt = prompt_parts["prompt"]
-        fitted_batches, changed = _fit_batch_to_budget(batch, prompt_parts, strategy.max_prompt_chars)
+        fitted_batches, changed = get_prompt_budget_manager().fit_batch_to_budget(
+            batch, prompt_parts, strategy.max_prompt_chars
+        )
         if changed:
             logger.debug(
                 "findings_batch_rebalanced",

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -26,7 +26,11 @@ from ..models.review_models import (
 )
 from ..models.review_profile_models import ReviewProfile
 from ..models.view import UICommentThread, UIPullRequest
-from ..operations.ai_response_parsing_operations import extract_json_payload
+from ..operations.ai_response_parsing_operations import (
+    REFORMAT_RETRY_TIMEOUT_SECONDS,
+    build_json_reformat_prompt,
+    extract_json_payload,
+)
 from ..operations.code_review_operations import (
     select_files_for_review,
     compute_diff_stat,
@@ -1628,6 +1632,20 @@ def _render_findings_batch_started(ctx: WorkflowContext, batch) -> None:
         ctx.textual.dim_text(f"  {path}")
 
 
+def _retry_findings_batch_reformat(adapter, previous_stdout: str, cwd: Optional[str]):
+    """Ask the same CLI to reformat its own previous output as a JSON array, without
+    rerunning the full analysis, using a short timeout distinct from the main one."""
+    reformat_prompt = build_json_reformat_prompt(previous_stdout, kind="array")
+    response = adapter.execute(reformat_prompt, cwd=cwd, timeout=REFORMAT_RETRY_TIMEOUT_SECONDS)
+    if not response.succeeded:
+        return ClientError(
+            error_message=f"Reformat retry CLI call failed (exit {response.exit_code})",
+            error_code="REFORMAT_RETRY_FAILED",
+            log_level="warning",
+        )
+    return extract_json_payload(response.stdout, kind="array")
+
+
 def _render_findings_batch_split(ctx: WorkflowContext, batch_id: str, produced_batches: list[str]) -> None:
     """Render a batch split caused by prompt budget constraints."""
     ctx.textual.warning_text(
@@ -1925,14 +1943,30 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             case ClientSuccess():
                 pass
             case ClientError(error_message=err):
-                findings_failed = True
                 logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=err)
-                _render_findings_batch_result(
-                    ctx,
-                    batch.batch_id,
-                    status="failed",
-                    detail="parse error",
-                )
+                match _retry_findings_batch_reformat(adapter, response.stdout, project_root):
+                    case ClientSuccess(data=raw) if isinstance(raw, list):
+                        aggregated_raw.extend(raw)
+                        logger.debug(
+                            "findings_batch_reformat_recovered",
+                            batch_id=batch.batch_id,
+                            findings_count=len(raw),
+                        )
+                        _render_findings_batch_result(
+                            ctx,
+                            batch.batch_id,
+                            status="success",
+                            findings_count=len(raw),
+                        )
+                    case _:
+                        findings_failed = True
+                        logger.debug("findings_batch_reformat_failed", batch_id=batch.batch_id)
+                        _render_findings_batch_result(
+                            ctx,
+                            batch.batch_id,
+                            status="failed",
+                            detail="parse error",
+                        )
 
     if not aggregated_raw and strategy and strategy.suspicious_empty_findings:
         candidates = ctx.get("review_candidates", [])

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1675,6 +1675,11 @@ def _render_findings_batch_split(ctx: WorkflowContext, batch_id: str, produced_b
     )
 
 
+def _render_findings_batch_degraded(ctx: WorkflowContext, batch_id: str) -> None:
+    """Render an in-place context reduction (no new batches) caused by prompt budget constraints."""
+    ctx.textual.warning_text(f"{batch_id} exceeded prompt budget and was degraded to fit")
+
+
 def _render_findings_batch_result(
     ctx: WorkflowContext,
     batch_id: str,
@@ -1876,11 +1881,15 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 prompt_actual_chars=len(prompt),
                 prompt_budget_target_chars=strategy.max_prompt_chars,
             )
-            _render_findings_batch_split(
-                ctx,
-                batch.batch_id,
-                [candidate.batch_id for candidate in fitted_batches],
-            )
+            is_actual_split = len(fitted_batches) > 1 or fitted_batches[0].batch_id != batch.batch_id
+            if is_actual_split:
+                _render_findings_batch_split(
+                    ctx,
+                    batch.batch_id,
+                    [candidate.batch_id for candidate in fitted_batches],
+                )
+            else:
+                _render_findings_batch_degraded(ctx, batch.batch_id)
             batch_queue = fitted_batches + batch_queue
             continue
 

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1632,18 +1632,32 @@ def _render_findings_batch_started(ctx: WorkflowContext, batch) -> None:
         ctx.textual.dim_text(f"  {path}")
 
 
-def _retry_findings_batch_reformat(adapter, previous_stdout: str, cwd: Optional[str]):
+def _retry_findings_batch_reformat(
+    adapter, previous_stdout: str, cwd: Optional[str], batch_id: str, structured: bool
+):
     """Ask the same CLI to reformat its own previous output as a JSON array, without
     rerunning the full analysis, using a short timeout distinct from the main one."""
+    from ..operations.findings_operations import findings_json_schema, parse_findings_response
+
     reformat_prompt = build_json_reformat_prompt(previous_stdout, kind="array")
-    response = adapter.execute(reformat_prompt, cwd=cwd, timeout=REFORMAT_RETRY_TIMEOUT_SECONDS)
+    schema = findings_json_schema() if structured else None
+    _log_ai_prompt("ai_review_findings_reformat_retry", adapter.cli_name.value, reformat_prompt, batch_id=batch_id)
+    response = adapter.execute(reformat_prompt, cwd=cwd, timeout=REFORMAT_RETRY_TIMEOUT_SECONDS, json_schema=schema)
+    _log_ai_response(
+        step_name="ai_review_findings_reformat_retry",
+        cli_name=adapter.cli_name.value,
+        stdout=response.stdout,
+        stderr=response.stderr,
+        exit_code=response.exit_code,
+        batch_id=batch_id,
+    )
     if not response.succeeded:
         return ClientError(
             error_message=f"Reformat retry CLI call failed (exit {response.exit_code})",
             error_code="REFORMAT_RETRY_FAILED",
             log_level="warning",
         )
-    return extract_json_payload(response.stdout, kind="array")
+    return parse_findings_response(response.stdout, structured=structured)
 
 
 def _render_findings_batch_split(ctx: WorkflowContext, batch_id: str, produced_batches: list[str]) -> None:
@@ -1809,6 +1823,8 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     from ..operations.findings_operations import (
         build_default_findings,
         build_findings_prompt_parts,
+        findings_json_schema,
+        parse_findings_response,
         summarize_findings_prompt_parts,
     )
 
@@ -1820,6 +1836,11 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         ctx.textual.end_step("success")
         return Success("No findings (no CLI available)", metadata={"raw_findings": []})
 
+    # Structured output forces the CLI to return findings via a schema-validated tool
+    # call instead of relying on the model to follow a "respond only with JSON" prompt
+    # instruction, which models frequently ignore in favor of a prose summary.
+    use_structured_output = adapter.supports_structured_output
+    findings_schema = findings_json_schema() if use_structured_output else None
     cli_display = adapter.cli_name.value.capitalize()
     aggregated_raw = []
     findings_failed = False
@@ -1893,7 +1914,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         )
         adapter_started_at = time.monotonic()
         with ctx.textual.loading(f"Asking {cli_display} to review {len(batch.files_context)} file(s) in {batch.batch_id}…"):
-            response = adapter.execute(prompt, cwd=project_root, timeout=300)
+            response = adapter.execute(prompt, cwd=project_root, timeout=300, json_schema=findings_schema)
         adapter_duration_seconds = time.monotonic() - adapter_started_at
         logger.info(
             "findings_batch_adapter_call",
@@ -1905,6 +1926,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             duration_seconds=round(adapter_duration_seconds, 3),
             exit_code=response.exit_code,
             timed_out=response.exit_code == 124,
+            structured_output=use_structured_output,
         )
         _log_ai_response(
             step_name="ai_review_findings",
@@ -1931,7 +1953,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             )
             continue
 
-        match extract_json_payload(response.stdout, kind="array"):
+        match parse_findings_response(response.stdout, structured=use_structured_output):
             case ClientSuccess(data=raw) if isinstance(raw, list):
                 aggregated_raw.extend(raw)
                 _render_findings_batch_result(
@@ -1944,7 +1966,9 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 pass
             case ClientError(error_message=err):
                 logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=err)
-                match _retry_findings_batch_reformat(adapter, response.stdout, project_root):
+                match _retry_findings_batch_reformat(
+                    adapter, response.stdout, project_root, batch.batch_id, use_structured_output
+                ):
                     case ClientSuccess(data=raw) if isinstance(raw, list):
                         aggregated_raw.extend(raw)
                         logger.debug(

--- a/tests/external_cli/test_headless_adapters.py
+++ b/tests/external_cli/test_headless_adapters.py
@@ -174,6 +174,56 @@ class TestClaudeHeadlessAdapter(unittest.TestCase):
         self.assertEqual(response.stdout, "not json at all")
         self.assertTrue(response.succeeded)
 
+    def test_supports_tool_restriction(self):
+        self.assertTrue(self.adapter.supports_tool_restriction)
+
+    @patch("subprocess.run")
+    def test_execute_with_disallowed_tools_adds_flag(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
+        self.adapter.execute(
+            "review this", cwd="/tmp", timeout=45, disallowed_tools=["Bash", "Agent"]
+        )
+
+        mock_run.assert_called_once_with(
+            ["claude", "--print", "--disallowedTools=Bash,Agent", "review this"],
+            capture_output=True,
+            text=True,
+            cwd="/tmp",
+            timeout=45,
+        )
+
+    @patch("subprocess.run")
+    def test_execute_without_disallowed_tools_omits_flag(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
+        self.adapter.execute("review this")
+
+        called_cmd = mock_run.call_args.args[0]
+        self.assertNotIn("--disallowedTools", called_cmd)
+
+    def test_supports_effort_control(self):
+        self.assertTrue(self.adapter.supports_effort_control)
+
+    @patch("subprocess.run")
+    def test_execute_with_effort_adds_flag(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
+        self.adapter.execute("review this", cwd="/tmp", timeout=45, effort="medium")
+
+        mock_run.assert_called_once_with(
+            ["claude", "--print", "--effort", "medium", "review this"],
+            capture_output=True,
+            text=True,
+            cwd="/tmp",
+            timeout=45,
+        )
+
+    @patch("subprocess.run")
+    def test_execute_without_effort_omits_flag(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
+        self.adapter.execute("review this")
+
+        called_cmd = mock_run.call_args.args[0]
+        self.assertNotIn("--effort", called_cmd)
+
 
 # ── CodexHeadlessAdapter ──────────────────────────────────────────────────────
 
@@ -193,6 +243,28 @@ class TestCodexHeadlessAdapterStructuredOutput(unittest.TestCase):
 
         called_cmd = mock_run.call_args.args[0]
         self.assertNotIn("--json-schema", called_cmd)
+
+    def test_supports_tool_restriction_is_false(self):
+        self.assertFalse(self.adapter.supports_tool_restriction)
+
+    @patch("subprocess.run")
+    def test_execute_ignores_disallowed_tools(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        self.adapter.execute("prompt", disallowed_tools=["Bash", "Agent"])
+
+        called_cmd = mock_run.call_args.args[0]
+        self.assertNotIn("--disallowedTools", called_cmd)
+
+    def test_supports_effort_control_is_false(self):
+        self.assertFalse(self.adapter.supports_effort_control)
+
+    @patch("subprocess.run")
+    def test_execute_ignores_effort(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        self.adapter.execute("prompt", effort="medium")
+
+        called_cmd = mock_run.call_args.args[0]
+        self.assertNotIn("--effort", called_cmd)
 
 
 # ── GeminiHeadlessAdapter ─────────────────────────────────────────────────────
@@ -251,6 +323,38 @@ class TestGeminiHeadlessAdapter(unittest.TestCase):
     def test_execute_cli_not_found(self, _):
         response = self.adapter.execute("prompt")
         self.assertEqual(response.exit_code, 127)
+
+    def test_supports_tool_restriction_is_false(self):
+        self.assertFalse(self.adapter.supports_tool_restriction)
+
+    @patch("subprocess.run")
+    def test_execute_ignores_disallowed_tools(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="response\n", stderr="", returncode=0)
+        self.adapter.execute("my prompt", disallowed_tools=["Bash", "Agent"])
+
+        mock_run.assert_called_once_with(
+            ["gemini", "--prompt", "my prompt"],
+            capture_output=True,
+            text=True,
+            cwd=None,
+            timeout=60,
+        )
+
+    def test_supports_effort_control_is_false(self):
+        self.assertFalse(self.adapter.supports_effort_control)
+
+    @patch("subprocess.run")
+    def test_execute_ignores_effort(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="response\n", stderr="", returncode=0)
+        self.adapter.execute("my prompt", effort="medium")
+
+        mock_run.assert_called_once_with(
+            ["gemini", "--prompt", "my prompt"],
+            capture_output=True,
+            text=True,
+            cwd=None,
+            timeout=60,
+        )
 
 
 # ── Registry ──────────────────────────────────────────────────────────────────

--- a/tests/external_cli/test_headless_adapters.py
+++ b/tests/external_cli/test_headless_adapters.py
@@ -2,12 +2,14 @@
 Tests for external_cli.adapters — HeadlessCliAdapter implementations and registry.
 """
 
+import json
 import subprocess
 import unittest
 from unittest.mock import MagicMock, patch
 
 from titan_cli.external_cli.adapters.base import HeadlessResponse, SupportedCLI
 from titan_cli.external_cli.adapters.claude import ClaudeHeadlessAdapter
+from titan_cli.external_cli.adapters.codex import CodexHeadlessAdapter
 from titan_cli.external_cli.adapters.gemini import GeminiHeadlessAdapter
 from titan_cli.external_cli.adapters.registry import (
     HEADLESS_ADAPTER_REGISTRY,
@@ -107,6 +109,91 @@ class TestClaudeHeadlessAdapter(unittest.TestCase):
         response = self.adapter.execute("prompt")
         self.assertEqual(response.stdout, "Green text")
 
+    def test_supports_structured_output(self):
+        self.assertTrue(self.adapter.supports_structured_output)
+
+    @patch("subprocess.run")
+    def test_execute_with_json_schema_adds_output_format_flags(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"structured_output": {"findings": []}}),
+            stderr="",
+            returncode=0,
+        )
+        schema = {"type": "object", "properties": {"findings": {"type": "array"}}}
+        self.adapter.execute("review this", cwd="/tmp", timeout=45, json_schema=schema)
+
+        mock_run.assert_called_once_with(
+            ["claude", "--print", "--output-format", "json", "--json-schema", json.dumps(schema), "review this"],
+            capture_output=True,
+            text=True,
+            cwd="/tmp",
+            timeout=45,
+        )
+
+    @patch("subprocess.run")
+    def test_execute_with_json_schema_unwraps_structured_output(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"structured_output": {"findings": [{"title": "Bug"}]}, "is_error": False}),
+            stderr="",
+            returncode=0,
+        )
+        response = self.adapter.execute("prompt", json_schema={"type": "object"})
+
+        self.assertEqual(json.loads(response.stdout), {"findings": [{"title": "Bug"}]})
+        self.assertTrue(response.succeeded)
+
+    @patch("subprocess.run")
+    def test_execute_with_json_schema_falls_back_to_result_text_when_tool_not_called(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"result": "I won't call that tool.", "is_error": False}),
+            stderr="",
+            returncode=0,
+        )
+        response = self.adapter.execute("prompt", json_schema={"type": "object"})
+
+        self.assertEqual(response.stdout, "I won't call that tool.")
+        self.assertTrue(response.succeeded)
+
+    @patch("subprocess.run")
+    def test_execute_with_json_schema_surfaces_cli_error(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout=json.dumps({"is_error": True, "result": "API Error: 400 bad schema"}),
+            stderr="",
+            returncode=1,
+        )
+        response = self.adapter.execute("prompt", json_schema={"type": "object"})
+
+        self.assertFalse(response.succeeded)
+        self.assertIn("bad schema", response.stderr)
+
+    @patch("subprocess.run")
+    def test_execute_with_json_schema_falls_back_on_unparseable_envelope(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="not json at all", stderr="", returncode=0)
+        response = self.adapter.execute("prompt", json_schema={"type": "object"})
+
+        self.assertEqual(response.stdout, "not json at all")
+        self.assertTrue(response.succeeded)
+
+
+# ── CodexHeadlessAdapter ──────────────────────────────────────────────────────
+
+class TestCodexHeadlessAdapterStructuredOutput(unittest.TestCase):
+    """Codex has no structured-output support (yet) — json_schema must be a no-op."""
+
+    def setUp(self):
+        self.adapter = CodexHeadlessAdapter()
+
+    def test_supports_structured_output_is_false(self):
+        self.assertFalse(self.adapter.supports_structured_output)
+
+    @patch("subprocess.run")
+    def test_execute_ignores_json_schema(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        self.adapter.execute("prompt", json_schema={"type": "object"})
+
+        called_cmd = mock_run.call_args.args[0]
+        self.assertNotIn("--json-schema", called_cmd)
+
 
 # ── GeminiHeadlessAdapter ─────────────────────────────────────────────────────
 
@@ -126,6 +213,9 @@ class TestGeminiHeadlessAdapter(unittest.TestCase):
     def test_is_available_false(self, _):
         self.assertFalse(self.adapter.is_available())
 
+    def test_supports_structured_output_is_false(self):
+        self.assertFalse(self.adapter.supports_structured_output)
+
     @patch("subprocess.run")
     def test_execute_passes_prompt_with_flag(self, mock_run):
         mock_run.return_value = MagicMock(stdout="response\n", stderr="", returncode=0)
@@ -137,6 +227,19 @@ class TestGeminiHeadlessAdapter(unittest.TestCase):
             text=True,
             cwd="/repo",
             timeout=45,
+        )
+
+    @patch("subprocess.run")
+    def test_execute_ignores_json_schema(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="response\n", stderr="", returncode=0)
+        self.adapter.execute("my prompt", json_schema={"type": "object"})
+
+        mock_run.assert_called_once_with(
+            ["gemini", "--prompt", "my prompt"],
+            capture_output=True,
+            text=True,
+            cwd=None,
+            timeout=60,
         )
 
     @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="gemini", timeout=60))

--- a/titan_cli/external_cli/adapters/base.py
+++ b/titan_cli/external_cli/adapters/base.py
@@ -8,7 +8,7 @@ Titan interacts only with this generic interface.
 
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Optional
+from typing import Any, Optional
 from typing import Protocol, runtime_checkable
 
 
@@ -54,6 +54,12 @@ class HeadlessCliAdapter(Protocol):
         """The CLI identifier."""
         ...
 
+    @property
+    def supports_structured_output(self) -> bool:
+        """Whether this adapter can enforce a JSON Schema on the CLI's own response,
+        instead of relying on prompt instructions the model may not follow."""
+        ...
+
     def is_available(self) -> bool:
         """Return True if the CLI is installed and reachable."""
         ...
@@ -63,6 +69,7 @@ class HeadlessCliAdapter(Protocol):
         prompt: str,
         cwd: Optional[str] = None,
         timeout: int = 60,
+        json_schema: Optional[dict[str, Any]] = None,
     ) -> HeadlessResponse:
         """
         Run the CLI with the given prompt in headless mode.
@@ -71,8 +78,11 @@ class HeadlessCliAdapter(Protocol):
             prompt: The prompt to send to the CLI.
             cwd: Working directory for the subprocess.
             timeout: Seconds before the subprocess is killed.
+            json_schema: Optional JSON Schema (top-level type "object") to enforce on the
+                response. Ignored by adapters where `supports_structured_output` is False.
 
         Returns:
-            HeadlessResponse with stdout, stderr, and exit_code.
+            HeadlessResponse with stdout, stderr, and exit_code. When `json_schema` is
+            honored, stdout is the schema-validated JSON, with no surrounding prose.
         """
         ...

--- a/titan_cli/external_cli/adapters/base.py
+++ b/titan_cli/external_cli/adapters/base.py
@@ -60,6 +60,17 @@ class HeadlessCliAdapter(Protocol):
         instead of relying on prompt instructions the model may not follow."""
         ...
 
+    @property
+    def supports_tool_restriction(self) -> bool:
+        """Whether this adapter can enforce a tool denylist on the CLI's own session,
+        instead of relying on prompt instructions the model may not follow."""
+        ...
+
+    @property
+    def supports_effort_control(self) -> bool:
+        """Whether this adapter can set a reasoning-effort tier for the CLI's own session."""
+        ...
+
     def is_available(self) -> bool:
         """Return True if the CLI is installed and reachable."""
         ...
@@ -70,6 +81,8 @@ class HeadlessCliAdapter(Protocol):
         cwd: Optional[str] = None,
         timeout: int = 60,
         json_schema: Optional[dict[str, Any]] = None,
+        disallowed_tools: Optional[list[str]] = None,
+        effort: Optional[str] = None,
     ) -> HeadlessResponse:
         """
         Run the CLI with the given prompt in headless mode.
@@ -80,6 +93,11 @@ class HeadlessCliAdapter(Protocol):
             timeout: Seconds before the subprocess is killed.
             json_schema: Optional JSON Schema (top-level type "object") to enforce on the
                 response. Ignored by adapters where `supports_structured_output` is False.
+            disallowed_tools: Optional list of built-in tool names to remove from the CLI's
+                session entirely (e.g. ["Bash", "Agent"]). Ignored by adapters where
+                `supports_tool_restriction` is False.
+            effort: Optional reasoning-effort tier (e.g. "low", "medium", "high"). Ignored by
+                adapters where `supports_effort_control` is False.
 
         Returns:
             HeadlessResponse with stdout, stderr, and exit_code. When `json_schema` is

--- a/titan_cli/external_cli/adapters/claude.py
+++ b/titan_cli/external_cli/adapters/claude.py
@@ -31,6 +31,14 @@ class ClaudeHeadlessAdapter:
     def supports_structured_output(self) -> bool:
         return True
 
+    @property
+    def supports_tool_restriction(self) -> bool:
+        return True
+
+    @property
+    def supports_effort_control(self) -> bool:
+        return True
+
     def is_available(self) -> bool:
         return shutil.which("claude") is not None
 
@@ -40,10 +48,20 @@ class ClaudeHeadlessAdapter:
         cwd: Optional[str] = None,
         timeout: int = 60,
         json_schema: Optional[dict[str, Any]] = None,
+        disallowed_tools: Optional[list[str]] = None,
+        effort: Optional[str] = None,
     ) -> HeadlessResponse:
         cmd = ["claude", "--print"]
         if json_schema is not None:
             cmd += ["--output-format", "json", "--json-schema", json.dumps(json_schema)]
+        if disallowed_tools:
+            # --disallowedTools is a variadic flag with no natural terminator: passed as
+            # separate argv tokens, it keeps consuming words until the next recognized flag,
+            # swallowing the trailing prompt argument as if it were another tool name. A
+            # single comma-joined token avoids that ambiguity.
+            cmd += [f"--disallowedTools={','.join(disallowed_tools)}"]
+        if effort is not None:
+            cmd += ["--effort", effort]
         cmd.append(prompt)
         try:
             result = subprocess.run(

--- a/titan_cli/external_cli/adapters/claude.py
+++ b/titan_cli/external_cli/adapters/claude.py
@@ -106,6 +106,9 @@ class ClaudeHeadlessAdapter:
         except json.JSONDecodeError:
             return HeadlessResponse(stdout=self._sanitize(result.stdout), stderr=stderr, exit_code=result.returncode)
 
+        if not isinstance(envelope, dict):
+            return HeadlessResponse(stdout=self._sanitize(result.stdout), stderr=stderr, exit_code=result.returncode)
+
         if envelope.get("is_error"):
             return HeadlessResponse(
                 stdout="",

--- a/titan_cli/external_cli/adapters/claude.py
+++ b/titan_cli/external_cli/adapters/claude.py
@@ -4,10 +4,11 @@ Headless adapter for Claude CLI (claude).
 Uses `claude --print <prompt>` for non-interactive execution.
 """
 
+import json
 import re
 import shutil
 import subprocess
-from typing import Optional
+from typing import Any, Optional
 
 from .base import HeadlessResponse, SupportedCLI
 
@@ -26,6 +27,10 @@ class ClaudeHeadlessAdapter:
     def cli_name(self) -> SupportedCLI:
         return SupportedCLI.CLAUDE
 
+    @property
+    def supports_structured_output(self) -> bool:
+        return True
+
     def is_available(self) -> bool:
         return shutil.which("claude") is not None
 
@@ -34,8 +39,12 @@ class ClaudeHeadlessAdapter:
         prompt: str,
         cwd: Optional[str] = None,
         timeout: int = 60,
+        json_schema: Optional[dict[str, Any]] = None,
     ) -> HeadlessResponse:
-        cmd = ["claude", "--print", prompt]
+        cmd = ["claude", "--print"]
+        if json_schema is not None:
+            cmd += ["--output-format", "json", "--json-schema", json.dumps(json_schema)]
+        cmd.append(prompt)
         try:
             result = subprocess.run(
                 cmd,
@@ -43,11 +52,6 @@ class ClaudeHeadlessAdapter:
                 text=True,
                 cwd=cwd,
                 timeout=timeout,
-            )
-            return HeadlessResponse(
-                stdout=self._sanitize(result.stdout),
-                stderr=result.stderr.strip(),
-                exit_code=result.returncode,
             )
         except subprocess.TimeoutExpired:
             return HeadlessResponse(
@@ -61,6 +65,40 @@ class ClaudeHeadlessAdapter:
                 stderr="claude command not found",
                 exit_code=127,
             )
+
+        if json_schema is None:
+            return HeadlessResponse(
+                stdout=self._sanitize(result.stdout),
+                stderr=result.stderr.strip(),
+                exit_code=result.returncode,
+            )
+        return self._parse_structured_result(result)
+
+    def _parse_structured_result(self, result: subprocess.CompletedProcess) -> HeadlessResponse:
+        """Unwrap the `--output-format json` envelope for a structured-output call.
+
+        On success, the model's schema-validated answer is under `structured_output`;
+        this becomes stdout as compact JSON so downstream parsing sees no surrounding
+        prose. Falls back to the raw envelope's `result` text if the model didn't end up
+        calling the structured-output tool (e.g. it judged the request ambiguous).
+        """
+        stderr = result.stderr.strip()
+        try:
+            envelope = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return HeadlessResponse(stdout=self._sanitize(result.stdout), stderr=stderr, exit_code=result.returncode)
+
+        if envelope.get("is_error"):
+            return HeadlessResponse(
+                stdout="",
+                stderr=str(envelope.get("result") or stderr or "Claude CLI reported an error"),
+                exit_code=result.returncode or 1,
+            )
+
+        structured_output = envelope.get("structured_output")
+        if structured_output is None:
+            return HeadlessResponse(stdout=str(envelope.get("result", "")), stderr=stderr, exit_code=result.returncode)
+        return HeadlessResponse(stdout=json.dumps(structured_output), stderr=stderr, exit_code=result.returncode)
 
     def _sanitize(self, text: str) -> str:
         """Strip ANSI escape codes and trailing whitespace."""

--- a/titan_cli/external_cli/adapters/codex.py
+++ b/titan_cli/external_cli/adapters/codex.py
@@ -33,6 +33,14 @@ class CodexHeadlessAdapter:
     def supports_structured_output(self) -> bool:
         return False
 
+    @property
+    def supports_tool_restriction(self) -> bool:
+        return False
+
+    @property
+    def supports_effort_control(self) -> bool:
+        return False
+
     def is_available(self) -> bool:
         return shutil.which("codex") is not None
 
@@ -42,6 +50,8 @@ class CodexHeadlessAdapter:
         cwd: Optional[str] = None,
         timeout: int = 60,
         json_schema: Optional[dict[str, Any]] = None,
+        disallowed_tools: Optional[list[str]] = None,
+        effort: Optional[str] = None,
     ) -> HeadlessResponse:
         # Use flags for non-interactive headless execution:
         # - --json: machine-readable JSONL output

--- a/titan_cli/external_cli/adapters/codex.py
+++ b/titan_cli/external_cli/adapters/codex.py
@@ -9,7 +9,7 @@ import json
 import re
 import shutil
 import subprocess
-from typing import Optional
+from typing import Any, Optional
 
 from .base import HeadlessResponse, SupportedCLI
 
@@ -29,6 +29,10 @@ class CodexHeadlessAdapter:
     def cli_name(self) -> SupportedCLI:
         return SupportedCLI.CODEX
 
+    @property
+    def supports_structured_output(self) -> bool:
+        return False
+
     def is_available(self) -> bool:
         return shutil.which("codex") is not None
 
@@ -37,6 +41,7 @@ class CodexHeadlessAdapter:
         prompt: str,
         cwd: Optional[str] = None,
         timeout: int = 60,
+        json_schema: Optional[dict[str, Any]] = None,
     ) -> HeadlessResponse:
         # Use flags for non-interactive headless execution:
         # - --json: machine-readable JSONL output

--- a/titan_cli/external_cli/adapters/gemini.py
+++ b/titan_cli/external_cli/adapters/gemini.py
@@ -8,7 +8,7 @@ Gemini without opening an interactive session.
 import re
 import shutil
 import subprocess
-from typing import Optional
+from typing import Any, Optional
 
 from .base import HeadlessResponse, SupportedCLI
 
@@ -27,6 +27,10 @@ class GeminiHeadlessAdapter:
     def cli_name(self) -> SupportedCLI:
         return SupportedCLI.GEMINI
 
+    @property
+    def supports_structured_output(self) -> bool:
+        return False
+
     def is_available(self) -> bool:
         return shutil.which("gemini") is not None
 
@@ -35,6 +39,7 @@ class GeminiHeadlessAdapter:
         prompt: str,
         cwd: Optional[str] = None,
         timeout: int = 60,
+        json_schema: Optional[dict[str, Any]] = None,
     ) -> HeadlessResponse:
         cmd = ["gemini", "--prompt", prompt]
         try:

--- a/titan_cli/external_cli/adapters/gemini.py
+++ b/titan_cli/external_cli/adapters/gemini.py
@@ -31,6 +31,14 @@ class GeminiHeadlessAdapter:
     def supports_structured_output(self) -> bool:
         return False
 
+    @property
+    def supports_tool_restriction(self) -> bool:
+        return False
+
+    @property
+    def supports_effort_control(self) -> bool:
+        return False
+
     def is_available(self) -> bool:
         return shutil.which("gemini") is not None
 
@@ -40,6 +48,8 @@ class GeminiHeadlessAdapter:
         cwd: Optional[str] = None,
         timeout: int = 60,
         json_schema: Optional[dict[str, Any]] = None,
+        disallowed_tools: Optional[list[str]] = None,
+        effort: Optional[str] = None,
     ) -> HeadlessResponse:
         cmd = ["gemini", "--prompt", prompt]
         try:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR significantly improves the AI-powered code review pipeline by introducing structured JSON output enforcement, a centralized `PromptBudgetManager` for smarter batch fitting, and a reformat-retry mechanism for malformed AI responses. It also centralizes JSON parsing into a shared `extract_json_payload` operation, eliminates duplicated logic across review steps, and adds structured timing logs for AI adapter calls.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- **`PromptBudgetManager`**: Extracted batch-fitting and character budget logic into a dedicated manager (`prompt_budget_manager.py`) with regression tests; moved entry char estimation (including high fixed cost for worktree references) into this manager
- **One worktree reference per batch**: Enforced a hard limit of one worktree reference file per review batch to prevent oversized prompts
- **Structured output support**: Added JSON schema enforcement to headless AI adapters (`ai_review_plan`, `ai_review_findings`, `ai_thread_resolution`) so responses conform to expected shapes
- **Tool restriction & effort control**: Added support for disabling tool use and controlling reasoning effort in headless adapter calls
- **Centralized JSON parsing**: Replaced duplicated `_strip_markdown_fences()`/`_extract_json_slice()` free functions and hand-rolled copies with a single `extract_json_payload()` operation shared across all review steps
- **Reformat-retry mechanism**: When an AI response contains malformed JSON, a lightweight retry prompt is issued asking the model to reformat its previous output rather than redo the full analysis
- **Structured timing logs**: Added structured log events for AI adapter call durations in code review steps
- **`check-github` Makefile target**: Added a fast `ruff + pytest` loop for the GitHub plugin only (`make check-github`)

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [x] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New test files added:
- `test_ai_response_parsing_operations.py` — covers `extract_json_payload()` for plain arrays/objects, markdown fence stripping, prose-surrounded JSON, missing JSON, malformed JSON, and the reformat prompt builder; also validates the reformat retry timeout is below analysis-level thresholds
- `test_context_resolution_operations.py` — regression tests for `build_review_context_package()` batching behaviour driven by `PromptBudgetManager.content_budget()`, including small-file consolidation and per-file splitting when individual hunks exceed the budget

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- `ai_adapter_call_start` / `ai_adapter_call_complete` (INFO/DEBUG) — fires at the start and end of each headless AI adapter call in code review steps; includes provider, operation name, and wall-clock duration

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)