### PR TITLE
chore: Silence markdown-it-py debug logs in console handler

### DIFF
--- a/titan_cli/core/logging/config.py
+++ b/titan_cli/core/logging/config.py
@@ -214,6 +214,8 @@ def _setup_console_handler(log_level: int, is_dev: bool) -> None:
     # This prevents EVENT/SYSTEM spam in the console while keeping app logs visible
     logging.getLogger("textual").setLevel(logging.WARNING)
     logging.getLogger("rich").setLevel(logging.WARNING)
+    # Silence markdown-it-py's per-rule parsing debug logs (entering fence/list/etc.)
+    logging.getLogger("markdown_it").setLevel(logging.WARNING)
     logging.getLogger("slack_sdk").setLevel(logging.DEBUG if is_dev else logging.WARNING)
     logging.getLogger("slack_sdk.web.base_client").setLevel(
         logging.DEBUG if is_dev else logging.WARNING


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Suppresses verbose per-rule parsing debug logs emitted by `markdown-it-py` (e.g., "entering fence", "entering list") in the console handler by setting its log level to `WARNING`, consistent with how `textual` and `rich` loggers are already handled.

## 🔧 Changes Made
- Set `markdown_it` logger to `WARNING` level in `_setup_console_handler`
- Added inline comment explaining the suppression rationale

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [x] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)