### PR TITLE
chore: Add help-titan-cli to default Slack channels list

### DIFF
--- a/.titan/config.toml
+++ b/.titan/config.toml
@@ -46,4 +46,4 @@ granted_scopes = [
     "im:write",
     "mpim:write",
 ]
-default_channels = ["titan-cli", "chapter-apps-general", "chapter-apps-ios-ragnarok", "chapter-apps-android-ragnarok"]
+default_channels = ["titan-cli", "chapter-apps-general", "chapter-apps-ios-ragnarok", "chapter-apps-android-ragnarok", "help-titan-cli"]


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Adds the `help-titan-cli` Slack channel to the list of default channels in the Titan configuration. This ensures the channel is included when Titan sets up or manages default Slack channel memberships.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `"help-titan-cli"` to the `default_channels` list in `.titan/config.toml`

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [x] No new log events

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)