### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/plugins/titan-plugin-git/pyproject.toml
+++ b/plugins/titan-plugin-git/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_git"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugins/titan-plugin-github/pyproject.toml
+++ b/plugins/titan-plugin-github/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_github"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugins/titan-plugin-jira/pyproject.toml
+++ b/plugins/titan-plugin-jira/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_jira"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 requests = ">=2.31.0"
 pydantic = ">=2.0.0"
 jinja2 = ">=3.0.0"

--- a/plugins/titan-plugin-slack/pyproject.toml
+++ b/plugins/titan-plugin-slack/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_slack"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 slack-sdk = ">=3.27.0"
 requests = ">=2.31.0"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2925,7 +2925,7 @@ files = []
 develop = true
 
 [package.dependencies]
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 
 [package.source]
 type = "directory"
@@ -2942,7 +2942,7 @@ files = []
 develop = true
 
 [package.dependencies]
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 
 [package.source]
 type = "directory"
@@ -2962,7 +2962,7 @@ develop = true
 jinja2 = ">=3.0.0"
 pydantic = ">=2.0.0"
 requests = ">=2.31.0"
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 
 [package.source]
 type = "directory"
@@ -2979,8 +2979,9 @@ files = []
 develop = true
 
 [package.dependencies]
+requests = ">=2.31.0"
 slack-sdk = ">=3.27.0"
-titan-cli = ">=0.6.0"
+titan-cli = ">=0.7.0"
 
 [package.source]
 type = "directory"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "titan-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "Modular development tools orchestrator - Streamline your workflows with AI integration and intuitive terminal UI"
 authors = ["MasOrange Apps Team <apps-management-stores@masorange.es>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump `titan-cli` version to `0.7.0`
- Update plugin `titan-cli` dependency constraints

## What's included in 0.7.0

- chore: Add help-titan-cli to default Slack channels list (#242)
- feat: Add multi-channel Slack messaging support (#240)
- feat: Add Jira issue planning workflow with new steps (#239)
- feat: Improve AI review batching with structured output and budget management (#237)
- chore: Silence markdown-it-py debug logs in console handler (#238)
- feat: Add optional RC branch support (#212)
- docs: Add session bootstrap guidance to agent documentation (#235)
- feat: Add format_markdown_message step and wire post-message workflow (#234)
- feat: Add GitHub releases step and PR draft prompt (#233)
- feat: Add Slack plugin with OAuth, messaging, and AI summarization (#231)
- feat: Improve thread resolution with referenced commit context (#230)
- feat: Add file-scoped diff, commit, and AI message generation (#232)

## Release

After this PR is merged, run the publish workflow from `master` to create the tag, publish to PyPI, and create the GitHub release.
