### PR TITLE
feat: Add prompt-budget batching for AI thread resolution calls

### DIFF
--- a/plugins/titan-plugin-github/tests/operations/test_thread_resolution_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_thread_resolution_operations.py
@@ -1,6 +1,7 @@
 from titan_plugin_github.models.review_models import ReferencedCommitContext, ThreadReviewContext
 from titan_plugin_github.models.view import UIComment, UICommentThread
 from titan_plugin_github.operations.thread_resolution_operations import (
+    batch_thread_review_contexts,
     build_thread_resolution_prompt,
     build_thread_review_candidates,
 )
@@ -85,3 +86,61 @@ def test_build_thread_resolution_prompt_includes_referenced_commit_context():
     assert "343e2e9" in prompt
     assert "src/BaseDialog.kt" in prompt
     assert "remove default state value" in prompt
+
+
+def _make_context(thread_id: str, *, body: str = "Please fix this") -> ThreadReviewContext:
+    return ThreadReviewContext(
+        thread_id=thread_id,
+        comment_id=1,
+        path="src/main.py",
+        line=1,
+        main_comment_body=body,
+        main_comment_author="reviewer",
+        all_replies=[{"author": "author", "body": "Fixed"}],
+        current_code_hunk="@@ -1,2 +1,2 @@\n-old\n+new\n",
+    )
+
+
+def test_batch_thread_review_contexts_returns_empty_for_no_contexts():
+    assert batch_thread_review_contexts([]) == []
+
+
+def test_batch_thread_review_contexts_respects_max_threads_per_batch():
+    contexts = [_make_context(f"thread_{i}") for i in range(10)]
+
+    batches = batch_thread_review_contexts(
+        contexts, max_prompt_chars=1_000_000, max_threads_per_batch=4
+    )
+
+    assert [len(batch) for batch in batches] == [4, 4, 2]
+    assert sum(len(batch) for batch in batches) == len(contexts)
+
+
+def test_batch_thread_review_contexts_splits_when_over_char_budget():
+    contexts = [_make_context(f"thread_{i}", body="x" * 500) for i in range(4)]
+
+    batches = batch_thread_review_contexts(
+        contexts, max_prompt_chars=800, max_threads_per_batch=4
+    )
+
+    # Each thread body alone (500 chars) plus prompt scaffolding exceeds the
+    # 800-char budget for anything but single-thread batches.
+    assert all(len(batch) == 1 for batch in batches)
+    assert sum(len(batch) for batch in batches) == len(contexts)
+
+
+def test_batch_thread_review_contexts_keeps_oversized_single_thread_alone():
+    huge_context = _make_context("thread_huge", body="x" * 50_000)
+
+    batches = batch_thread_review_contexts([huge_context], max_prompt_chars=100)
+
+    assert len(batches) == 1
+    assert batches[0] == [huge_context]
+
+
+def test_batch_thread_review_contexts_preserves_full_context_per_thread():
+    context = _make_context("thread_1")
+
+    batches = batch_thread_review_contexts([context], max_prompt_chars=1_000_000)
+
+    assert batches == [[context]]

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/thread_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/thread_resolution_operations.py
@@ -218,6 +218,57 @@ Respond ONLY with a valid JSON array matching this exact schema for each element
 Return ONLY the JSON array. No explanation, no markdown fences."""
 
 
+DEFAULT_THREAD_BATCH_MAX_PROMPT_CHARS = 20_000
+DEFAULT_THREAD_BATCH_MAX_THREADS = 8
+
+
+def batch_thread_review_contexts(
+    contexts: list[ThreadReviewContext],
+    max_prompt_chars: int = DEFAULT_THREAD_BATCH_MAX_PROMPT_CHARS,
+    max_threads_per_batch: int = DEFAULT_THREAD_BATCH_MAX_THREADS,
+) -> list[list[ThreadReviewContext]]:
+    """
+    Split thread contexts into batches that keep each AI call within a prompt budget.
+
+    Each thread keeps its full conversation, code hunk, and referenced commit
+    context untouched — batching only controls how many threads share one AI
+    call, so no per-thread content is trimmed. A thread that alone exceeds the
+    budget is still sent by itself rather than being degraded.
+
+    Args:
+        contexts: Enriched thread contexts from build_thread_review_contexts
+        max_prompt_chars: Target prompt size per batch (soft budget)
+        max_threads_per_batch: Upper bound on threads per batch regardless of size
+
+    Returns:
+        List of thread-context batches, each safe to pass to build_thread_resolution_prompt
+    """
+    if not contexts:
+        return []
+
+    queue = [
+        contexts[i : i + max_threads_per_batch]
+        for i in range(0, len(contexts), max_threads_per_batch)
+    ]
+    batches: list[list[ThreadReviewContext]] = []
+
+    while queue:
+        batch = queue.pop(0)
+        if len(batch) == 1:
+            batches.append(batch)
+            continue
+
+        if len(build_thread_resolution_prompt(batch)) <= max_prompt_chars:
+            batches.append(batch)
+            continue
+
+        midpoint = max(1, len(batch) // 2)
+        queue.insert(0, batch[midpoint:])
+        queue.insert(0, batch[:midpoint])
+
+    return batches
+
+
 def _threads_to_text(contexts: list[ThreadReviewContext]) -> str:
     if not contexts:
         return "(no threads to review)"

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -43,6 +43,7 @@ from ..operations.review_action_operations import (
     resolve_action_anchors,
 )
 from ..operations.thread_resolution_operations import (
+    batch_thread_review_contexts,
     build_thread_review_candidates as build_thread_review_candidates_operation,
     build_thread_review_contexts as build_thread_review_contexts_operation,
     build_thread_resolution_prompt,
@@ -2741,18 +2742,23 @@ def ai_thread_resolution(ctx: WorkflowContext) -> WorkflowResult:
     """
     AI call: decide what to do with each open thread.
 
-    Sends thread contexts (original comment + replies + current code) to the
+    Splits thread contexts into prompt-budget-bound batches (see
+    batch_thread_review_contexts) and sends each batch — original comment +
+    replies + current code + referenced commits, all untouched — to the
     selected headless CLI. The AI decides per thread: resolved / insist /
-    reply / skip.
+    reply / skip. Batches run sequentially and their decisions are aggregated;
+    a batch that fails (CLI error or parse error) is skipped without aborting
+    the remaining batches.
 
-    On CLI failure or parse failure, falls back to empty decisions (no actions).
+    On total failure (no batch produced usable output), falls back to empty
+    decisions (no actions).
 
     Requires (from ctx.data):
         thread_review_contexts (List[ThreadReviewContext])
         cli_preference (str): "claude" | "gemini" | "codex" | "auto"
 
     Outputs (saved to ctx.data):
-        raw_thread_decisions (list): Raw AI output before normalization
+        raw_thread_decisions (list): Raw AI output aggregated across batches, before normalization
 
     Returns:
         Success or Error
@@ -2779,46 +2785,90 @@ def ai_thread_resolution(ctx: WorkflowContext) -> WorkflowResult:
         ctx.textual.end_step("success")
         return Success("No decisions (no CLI available)", metadata={"raw_thread_decisions": []})
 
-    prompt = build_thread_resolution_prompt(contexts)
-
+    # Split into batches so one call never has to carry every open thread at
+    # once — each thread's full conversation/hunk/commit context stays intact,
+    # only the number of threads sharing a single AI call is bounded.
+    batches = batch_thread_review_contexts(contexts)
     cli_display = adapter.cli_name.value.capitalize()
-    thread_count = len(contexts)
-    adapter_started_at = time.monotonic()
-    with ctx.textual.loading(f"Asking {cli_display} to analyse {thread_count} thread(s)…"):
-        response = adapter.execute(prompt, cwd=project_root, timeout=300)
-    adapter_duration_seconds = time.monotonic() - adapter_started_at
-    logger.info(
-        "thread_resolution_adapter_call",
-        cli=adapter.cli_name.value,
-        thread_count=thread_count,
-        prompt_actual_chars=len(prompt),
-        duration_seconds=round(adapter_duration_seconds, 3),
-        exit_code=response.exit_code,
-        timed_out=response.exit_code == 124,
+    ctx.textual.dim_text(
+        f"Reviewing {len(contexts)} thread(s) in {len(batches)} batch(es) with {cli_display}"
     )
 
-    if not response.succeeded:
-        ctx.textual.warning_text(f"CLI call failed (exit {response.exit_code}) — no thread decisions")
-        if response.stderr:
-            ctx.textual.dim_text(response.stderr[:200])
-        ctx.data["raw_thread_decisions"] = []
+    aggregated_raw: list = []
+    any_batch_failed = False
+
+    for batch_index, batch in enumerate(batches, start=1):
+        batch_label = f"batch {batch_index}/{len(batches)}"
+        prompt = build_thread_resolution_prompt(batch)
+
+        _log_ai_prompt(
+            step_name="ai_thread_resolution",
+            cli_name=adapter.cli_name.value,
+            prompt=prompt,
+            batch_index=batch_index,
+            batch_count=len(batches),
+            thread_count=len(batch),
+        )
+
+        adapter_started_at = time.monotonic()
+        with ctx.textual.loading(
+            f"Asking {cli_display} to analyse {batch_label} ({len(batch)} thread(s))…"
+        ):
+            response = adapter.execute(prompt, cwd=project_root, timeout=300)
+        adapter_duration_seconds = time.monotonic() - adapter_started_at
+        logger.info(
+            "thread_resolution_adapter_call",
+            cli=adapter.cli_name.value,
+            batch_index=batch_index,
+            batch_count=len(batches),
+            thread_count=len(batch),
+            prompt_actual_chars=len(prompt),
+            duration_seconds=round(adapter_duration_seconds, 3),
+            exit_code=response.exit_code,
+            timed_out=response.exit_code == 124,
+        )
+        _log_ai_response(
+            step_name="ai_thread_resolution",
+            cli_name=adapter.cli_name.value,
+            stdout=response.stdout,
+            stderr=response.stderr,
+            exit_code=response.exit_code,
+            batch_index=batch_index,
+            batch_count=len(batches),
+        )
+
+        if not response.succeeded:
+            any_batch_failed = True
+            ctx.textual.warning_text(f"{batch_label}: CLI call failed (exit {response.exit_code}) — skipped")
+            if response.stderr:
+                ctx.textual.dim_text(response.stderr[:200])
+            continue
+
+        match extract_json_payload(response.stdout, kind="array"):
+            case ClientError(error_message=err):
+                any_batch_failed = True
+                ctx.textual.warning_text(f"{batch_label}: decisions parsing failed ({err}) — skipped")
+                continue
+            case ClientSuccess(data=raw):
+                aggregated_raw.extend(raw)
+
+    ctx.data["raw_thread_decisions"] = aggregated_raw
+
+    if not aggregated_raw:
+        status = "No decisions (all batches failed)" if any_batch_failed else "No decisions"
+        ctx.textual.warning_text(status)
         ctx.textual.end_step("success")
-        return Success("No decisions (CLI error)", metadata={"raw_thread_decisions": []})
+        return Success(status, metadata={"raw_thread_decisions": []})
 
-    # Parse JSON array response
-    match extract_json_payload(response.stdout, kind="array"):
-        case ClientError(error_message=err):
-            ctx.textual.warning_text(f"Thread decisions parsing failed ({err}) — no decisions")
-            ctx.data["raw_thread_decisions"] = []
-            ctx.textual.end_step("success")
-            return Success("No decisions (parse error)", metadata={"raw_thread_decisions": []})
-        case ClientSuccess(data=raw):
-            pass
-
-    ctx.data["raw_thread_decisions"] = raw
-    ctx.textual.success_text(f"✓ AI returned {len(raw)} thread decision(s)")
+    summary = f"✓ AI returned {len(aggregated_raw)} thread decision(s)"
+    if any_batch_failed:
+        summary += " (some batches failed — partial results)"
+    ctx.textual.success_text(summary)
     ctx.textual.end_step("success")
-    return Success("AI thread decisions retrieved", metadata={"raw_thread_decisions_count": len(raw)})
+    return Success(
+        "AI thread decisions retrieved",
+        metadata={"raw_thread_decisions_count": len(aggregated_raw)},
+    )
 
 
 def normalize_thread_decisions(ctx: WorkflowContext) -> WorkflowResult:

--- a/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr-thread-resolution.yaml
+++ b/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr-thread-resolution.yaml
@@ -1,4 +1,4 @@
-name: "Review PR (Thread Resolution)"
+name: "Thread Resolution"
 description: "AI-powered analysis of open PR threads: resolve, insist, or reply"
 
 steps:


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Introduces prompt-budget-aware batching for AI thread resolution calls, preventing a single call from carrying all open threads at once. Each thread retains its full context (comments, code hunk, referenced commits) — only the grouping into AI calls changes. Batches run sequentially and their decisions are aggregated, with per-batch failure isolation so one bad batch doesn't abort the rest.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- Added `batch_thread_review_contexts()` in `thread_resolution_operations.py` — splits thread contexts into batches respecting a character budget (`20_000` chars) and a thread count cap (`8` threads per batch) using a binary-split strategy
- Updated `ai_thread_resolution` step to iterate over batches, aggregate decisions, and skip failed batches without aborting remaining ones
- Renamed the workflow display name from "Review PR (Thread Resolution)" to "Thread Resolution" for clarity
- Added comprehensive unit tests covering: empty input, max-threads splitting, over-budget splitting, oversized single-thread passthrough, and context preservation

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New tests in `test_thread_resolution_operations.py` cover all batching edge cases: empty list returns `[]`, `max_threads_per_batch` cap is respected, oversized prompts are split via binary halving, a single thread exceeding the budget is still sent alone, and full thread context is preserved per batch.

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)