### PR TITLE
feat: Add GitHub Contents API and reviewer tracking

### DIFF
--- a/docs/plugins/github/client-api.md
+++ b/docs/plugins/github/client-api.md
@@ -561,6 +561,60 @@ Returns a `ClientResult[UIRelease]` with `body` populated with the release notes
 
 ---
 
+## Contents operations
+
+Browse a repository's file tree through the GitHub Contents API, without cloning it locally. Both methods default to the client's own configured repo, but accept `repo_owner`/`repo_name` to read from a different repository.
+
+### List a directory
+
+Lists the entries of a directory in a repository.
+
+**Call:**
+
+```python
+client.list_repository_directory(
+    "services/backend",
+    ref="main",
+    repo_owner="example-org",
+    repo_name="other-repo",
+)
+```
+
+**Parameters:**
+
+- `path`: Required. Directory path relative to the repo root. Pass `""` for the repo root.
+- `ref`: Optional. Branch, tag, or commit SHA to read from. Defaults to the repo's default branch.
+- `repo_owner`: Optional. Overrides the client's configured repo owner for this call.
+- `repo_name`: Optional. Overrides the client's configured repo name for this call.
+
+Returns a `ClientResult[List[dict]]`. Each entry is shaped like `{"name": str, "path": str, "type": "dir" | "file"}`. Returns `ClientError` (`NOT_A_DIRECTORY`) if `path` points to a file instead of a directory, and `ClientError` (`NOT_FOUND`) if the path doesn't exist.
+
+### Check whether a path exists
+
+Checks whether a path exists in a repository.
+
+**Call:**
+
+```python
+client.path_exists(
+    "Dockerfile",
+    ref="main",
+    repo_owner="example-org",
+    repo_name="other-repo",
+)
+```
+
+**Parameters:**
+
+- `path`: Required. Path relative to the repo root.
+- `ref`: Optional. Branch, tag, or commit SHA to check against. Defaults to the repo's default branch.
+- `repo_owner`: Optional. Overrides the client's configured repo owner for this call.
+- `repo_name`: Optional. Overrides the client's configured repo name for this call.
+
+Returns a `ClientResult[bool]` — `ClientSuccess(data=False)` for a missing path, not a `ClientError`.
+
+---
+
 ## Team operations
 
 ### List team members

--- a/docs/plugins/github/client-api.md
+++ b/docs/plugins/github/client-api.md
@@ -95,6 +95,28 @@ client.get_pull_request(123)
 
 - `pr_number`: Required. Pull request number.
 
+**Returns:**
+
+A `UIPullRequest` object with the following fields:
+
+- `number`: PR number
+- `title`: PR title  
+- `body`: PR description
+- `status_icon`: Status emoji (🟢 open, 🔴 closed, 🟣 merged, 📝 draft)
+- `state`: PR state (OPEN, CLOSED, MERGED)
+- `author_name`: GitHub username of PR author
+- `head_ref`: Source branch name
+- `base_ref`: Target branch name
+- `branch_info`: Formatted branch information (e.g., "feature/xyz → main")
+- `stats`: Formatted change statistics (e.g., "+123 -45")
+- `files_changed`: Number of files changed
+- `is_mergeable`: Whether the PR can be merged
+- `is_draft`: Whether the PR is a draft
+- `review_summary`: Formatted review status (e.g., "✅ 2 approved")
+- `labels`: List of label names
+- `requested_reviewers`: GitHub usernames of all users requested to review
+- `pending_reviewers`: GitHub usernames of users who haven't reviewed yet
+
 ### List pull requests pending review
 
 Returns PRs that still need your review.

--- a/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
+++ b/plugins/titan-plugin-github/tests/unit/test_pr_mapper.py
@@ -276,6 +276,44 @@ class TestFromRestPR:
         assert ui_pr.formatted_created_at == ""
         assert ui_pr.formatted_updated_at == ""
 
+    def test_maps_requested_reviewers_and_pending_reviewers(self):
+        """Test that requested and pending reviewers are correctly mapped"""
+        # Arrange
+        author = NetworkUser(login="author")
+        reviewer1 = NetworkUser(login="reviewer1", name="Reviewer One")
+        reviewer2 = NetworkUser(login="reviewer2", name="Reviewer Two")
+        reviewer3 = NetworkUser(login="reviewer3", name="Reviewer Three")
+
+        rest_pr = NetworkPullRequest(
+            number=1,
+            title="PR",
+            body="",
+            state="OPEN",
+            isDraft=False,
+            author=author,
+            headRefName="feature",
+            baseRefName="main",
+            mergeable="MERGEABLE",
+            additions=0,
+            deletions=0,
+            changedFiles=0,
+            reviews=[
+                Mock(state="APPROVED", user=reviewer1),
+                Mock(state="CHANGES_REQUESTED", user=reviewer2),
+            ],
+            labels=[],
+            requestedReviewers=[reviewer1, reviewer2, reviewer3],
+            createdAt="2025-01-15T10:00:00Z",
+            updatedAt="2025-01-15T10:00:00Z",
+        )
+
+        # Act
+        ui_pr = from_rest_pr(rest_pr)
+
+        # Assert
+        assert ui_pr.requested_reviewers == ["reviewer1", "reviewer2", "reviewer3"]
+        assert ui_pr.pending_reviewers == ["reviewer3"]
+
 
 class TestPRSelectionOperations:
     def test_build_pr_selection_description_base(self):

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/github_client.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/github_client.py
@@ -14,7 +14,7 @@ from titan_cli.core.plugins.models import GitHubPluginConfig
 from titan_plugin_git.clients.git_client import GitClient
 
 from .network import GHNetwork, GraphQLNetwork
-from .services import PRService, ReviewService, IssueService, TeamService, ReleaseService
+from .services import PRService, ReviewService, IssueService, TeamService, ReleaseService, ContentsService
 from ..models.review_models import ReferencedCommitContext
 from ..models.view import UIPullRequest, UICommentThread, UIIssue, UIPRMergeResult, UIReview, UIFileChange, UIPRCreated, UIRelease
 
@@ -77,6 +77,7 @@ class GitHubClient:
         self._issue_service = IssueService(self._gh_network)
         self._team_service = TeamService(self._gh_network)
         self._release_service = ReleaseService(self._gh_network)
+        self._contents_service = ContentsService(self._gh_network)
 
     def get_pr_template(self) -> Optional[str]:
         """Get the PR template if available."""
@@ -314,6 +315,46 @@ class GitHubClient:
     def get_release(self, tag_name: str) -> ClientResult[UIRelease]:
         """Get a single GitHub release, including its full notes body."""
         return self._release_service.get_release(tag_name)
+
+    # ============================================================================
+    # Contents Operations
+    # ============================================================================
+
+    def list_repository_directory(
+        self,
+        path: str,
+        ref: Optional[str] = None,
+        *,
+        repo_owner: Optional[str] = None,
+        repo_name: Optional[str] = None,
+    ) -> ClientResult[List[Dict[str, Any]]]:
+        """
+        List the entries of a directory in a repository.
+
+        Defaults to this client's own repo; pass repo_owner/repo_name to read
+        from a different repository without instantiating a new client.
+        """
+        return self._contents_service.list_directory(
+            path, ref, repo_owner=repo_owner, repo_name=repo_name
+        )
+
+    def path_exists(
+        self,
+        path: str,
+        ref: Optional[str] = None,
+        *,
+        repo_owner: Optional[str] = None,
+        repo_name: Optional[str] = None,
+    ) -> ClientResult[bool]:
+        """
+        Check whether a path exists in a repository.
+
+        Defaults to this client's own repo; pass repo_owner/repo_name to check
+        against a different repository without instantiating a new client.
+        """
+        return self._contents_service.path_exists(
+            path, ref, repo_owner=repo_owner, repo_name=repo_name
+        )
 
     # ============================================================================
     # Team Operations

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/__init__.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/__init__.py
@@ -10,6 +10,7 @@ from .review_service import ReviewService
 from .issue_service import IssueService
 from .team_service import TeamService
 from .release_service import ReleaseService
+from .contents_service import ContentsService
 
 __all__ = [
     "PRService",
@@ -17,4 +18,5 @@ __all__ = [
     "IssueService",
     "TeamService",
     "ReleaseService",
+    "ContentsService",
 ]

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/contents_service.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/contents_service.py
@@ -1,0 +1,144 @@
+# plugins/titan-plugin-github/titan_plugin_github/clients/services/contents_service.py
+"""
+Contents Service
+
+Business logic for navigating a GitHub repository's contents (Contents API).
+Uses gh CLI through the network layer.
+"""
+
+import json
+from typing import List, Optional
+from urllib.parse import quote, urlencode
+
+from titan_cli.core.result import ClientResult, ClientSuccess, ClientError
+from titan_cli.core.logging import log_client_operation
+
+from ..network import GHNetwork
+from ...exceptions import GitHubAPIError
+
+
+class ContentsService:
+    """
+    Service for GitHub repository contents operations.
+
+    Lets callers navigate a repository's tree (list a directory, check whether
+    a path exists) without cloning it locally.
+    """
+
+    def __init__(self, gh_network: GHNetwork):
+        """
+        Initialize contents service.
+
+        Args:
+            gh_network: GHNetwork instance for REST/CLI operations
+        """
+        self.gh = gh_network
+
+    def _contents_endpoint(
+        self,
+        path: str,
+        ref: Optional[str],
+        repo_owner: Optional[str],
+        repo_name: Optional[str],
+    ) -> List[str]:
+        owner = repo_owner or self.gh.repo_owner
+        name = repo_name or self.gh.repo_name
+        clean_path = "/".join(quote(segment) for segment in path.strip("/").split("/") if segment)
+
+        endpoint = f"repos/{owner}/{name}/contents"
+        if clean_path:
+            endpoint = f"{endpoint}/{clean_path}"
+        if ref:
+            endpoint = f"{endpoint}?{urlencode({'ref': ref})}"
+
+        return ["api", endpoint]
+
+    @staticmethod
+    def _is_not_found(error: GitHubAPIError) -> bool:
+        return "404" in (error.stderr or "")
+
+    @log_client_operation()
+    def list_directory(
+        self,
+        path: str,
+        ref: Optional[str] = None,
+        *,
+        repo_owner: Optional[str] = None,
+        repo_name: Optional[str] = None,
+    ) -> ClientResult[List[dict]]:
+        """
+        List the entries of a directory in a repository.
+
+        Args:
+            path: Directory path relative to the repo root ("" for repo root)
+            ref: Optional branch/tag/commit SHA to read from (defaults to the repo's default branch)
+            repo_owner: Optional owner override (defaults to the client's configured repo)
+            repo_name: Optional repo name override (defaults to the client's configured repo)
+
+        Returns:
+            ClientResult[List[dict]] with entries shaped like
+            {"name": str, "path": str, "type": "dir" | "file"}
+        """
+        try:
+            args = self._contents_endpoint(path, ref, repo_owner, repo_name)
+            output = self.gh.run_command(args)
+            data = json.loads(output)
+
+            if isinstance(data, dict):
+                return ClientError(
+                    error_message=f"'{path}' is a file, not a directory",
+                    error_code="NOT_A_DIRECTORY",
+                )
+
+            entries = [
+                {"name": item["name"], "path": item["path"], "type": item["type"]}
+                for item in data
+            ]
+
+            return ClientSuccess(
+                data=entries,
+                message=f"Retrieved {len(entries)} entries from '{path or '/'}'"
+            )
+
+        except json.JSONDecodeError as e:
+            return ClientError(
+                error_message=f"Failed to parse contents data: {e}",
+                error_code="JSON_PARSE_ERROR",
+            )
+        except GitHubAPIError as e:
+            if self._is_not_found(e):
+                return ClientError(
+                    error_message=f"Path '{path}' not found",
+                    error_code="NOT_FOUND",
+                )
+            return ClientError(error_message=str(e), error_code="API_ERROR")
+
+    @log_client_operation()
+    def path_exists(
+        self,
+        path: str,
+        ref: Optional[str] = None,
+        *,
+        repo_owner: Optional[str] = None,
+        repo_name: Optional[str] = None,
+    ) -> ClientResult[bool]:
+        """
+        Check whether a path exists in a repository.
+
+        Args:
+            path: Path relative to the repo root
+            ref: Optional branch/tag/commit SHA to check against (defaults to the repo's default branch)
+            repo_owner: Optional owner override (defaults to the client's configured repo)
+            repo_name: Optional repo name override (defaults to the client's configured repo)
+
+        Returns:
+            ClientResult[bool]
+        """
+        try:
+            args = self._contents_endpoint(path, ref, repo_owner, repo_name)
+            self.gh.run_command(args)
+            return ClientSuccess(data=True, message=f"'{path}' exists")
+        except GitHubAPIError as e:
+            if self._is_not_found(e):
+                return ClientSuccess(data=False, message=f"'{path}' does not exist")
+            return ClientError(error_message=str(e), error_code="API_ERROR")

--- a/plugins/titan-plugin-github/titan_plugin_github/models/mappers/pr_mapper.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/mappers/pr_mapper.py
@@ -35,6 +35,13 @@ def from_rest_pr(rest_pr: NetworkPullRequest) -> UIPullRequest:
     # Extract label names from label objects
     label_names = [label.get("name", "") for label in rest_pr.labels]
 
+    # Extract requested reviewers
+    requested_reviewers = [user.login for user in rest_pr.requestedReviewers]
+
+    # Calculate pending reviewers (requested but not yet reviewed)
+    reviewed_logins = {review.user.login for review in rest_pr.reviews if review.state != "PENDING"}
+    pending_reviewers = [login for login in requested_reviewers if login not in reviewed_logins]
+
     return UIPullRequest(
         number=rest_pr.number,
         title=rest_pr.title,
@@ -58,6 +65,8 @@ def from_rest_pr(rest_pr: NetworkPullRequest) -> UIPullRequest:
         is_cross_repository=rest_pr.isCrossRepository,
         head_repository_owner=rest_pr.headRepositoryOwnerLogin,
         head_repository_name=rest_pr.headRepositoryName,
+        requested_reviewers=requested_reviewers,
+        pending_reviewers=pending_reviewers,
     )
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
@@ -48,6 +48,7 @@ class NetworkPullRequest:
         mergedAt: Merge timestamp if merged (ISO 8601, camelCase as in API)
         reviews: List of reviews
         labels: List of label objects with 'name' field
+        requestedReviewers: List of users requested to review the PR
     """
     number: int
     title: str

--- a/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
@@ -71,6 +71,7 @@ class NetworkPullRequest:
     isCrossRepository: bool = False
     headRepositoryOwnerLogin: Optional[str] = None
     headRepositoryName: Optional[str] = None
+    requestedReviewers: List[NetworkUser] = field(default_factory=list)  # Users requested to review
 
     @classmethod
     def from_json(cls, data: Dict[str, Any]) -> 'NetworkPullRequest':
@@ -96,6 +97,10 @@ class NetworkPullRequest:
         # Parse reviews
         reviews_data = data.get("reviews", [])
         reviews = [NetworkReview.from_json(r) for r in reviews_data]
+
+        # Parse requested reviewers
+        requested_reviewers_data = data.get("requestedReviewers", [])
+        requested_reviewers = [NetworkUser.from_json(r) for r in requested_reviewers_data]
 
         return cls(
             number=data.get("number", 0),
@@ -128,6 +133,7 @@ class NetworkPullRequest:
             isCrossRepository=data.get("isCrossRepository", False),
             headRepositoryOwnerLogin=(data.get("headRepositoryOwner") or {}).get("login"),
             headRepositoryName=(data.get("headRepository") or {}).get("name"),
+            requestedReviewers=requested_reviewers,
         )
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/models/view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/view.py
@@ -137,6 +137,10 @@ class UIPullRequest:
 
     All fields are pre-formatted and ready for widget rendering.
     Computed/derived fields are calculated once during construction.
+
+    Fields:
+        requested_reviewers: All GitHub logins of users requested to review
+        pending_reviewers: Logins of reviewers who haven't submitted a review yet
     """
     number: int
     title: str

--- a/plugins/titan-plugin-github/titan_plugin_github/models/view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/view.py
@@ -10,7 +10,7 @@ Network models contain raw API data; view models contain UI-ready data.
 These models are GitHub-specific and live in the GitHub plugin, not in the core.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
 from .pr_enums import PRState
@@ -160,6 +160,8 @@ class UIPullRequest:
     is_cross_repository: bool = False
     head_repository_owner: Optional[str] = None
     head_repository_name: Optional[str] = None
+    requested_reviewers: List[str] = field(default_factory=list)  # All requested reviewer logins
+    pending_reviewers: List[str] = field(default_factory=list)  # Reviewers who haven't reviewed yet
 
 
 @dataclass


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Adds a `ContentsService` exposing `list_repository_directory` and `path_exists` on `GitHubClient` to browse repository file trees via the GitHub Contents API without cloning. Also extends `UIPullRequest` with `requested_reviewers` and `pending_reviewers` fields to track review assignment status.

## 🔧 Changes Made
- Added `ContentsService` with `list_directory` and `path_exists` methods backed by the GitHub Contents API
- Exposed `list_repository_directory` and `path_exists` on `GitHubClient`, both accepting optional `repo_owner`/`repo_name` overrides
- Added `requested_reviewers` and `pending_reviewers` fields to `UIPullRequest`, mapped from `requestedReviewers` and review states in `from_rest_pr`
- Added unit test covering reviewer mapping logic (requested vs. pending differentiation)
- Updated plugin documentation with `UIPullRequest` field reference and full Contents API section

## 🧪 Testing
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

New test `test_maps_requested_reviewers_and_pending_reviewers` verifies that `requested_reviewers` contains all requested users and `pending_reviewers` contains only those who haven't yet submitted a review (APPROVED or CHANGES_REQUESTED).

## 📊 Logs
- [x] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)