### PR TITLE
fix: Correct reviewRequests field name for gh CLI JSON parsing

### DIFF
--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/pr_service.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/pr_service.py
@@ -56,7 +56,7 @@ class PRService:
                 "baseRefName", "headRefName", "additions", "deletions",
                 "changedFiles", "mergeable", "isDraft", "createdAt",
                 "updatedAt", "mergedAt", "reviews", "labels",
-                "statusCheckRollup", "reviewDecision",
+                "statusCheckRollup", "reviewDecision", "reviewRequests",
                 "isCrossRepository", "headRepositoryOwner", "headRepository",
             ]
 

--- a/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/network/rest/pull_request.py
@@ -99,8 +99,8 @@ class NetworkPullRequest:
         reviews_data = data.get("reviews", [])
         reviews = [NetworkReview.from_json(r) for r in reviews_data]
 
-        # Parse requested reviewers
-        requested_reviewers_data = data.get("requestedReviewers", [])
+        # Parse requested reviewers (gh CLI JSON field is "reviewRequests")
+        requested_reviewers_data = data.get("reviewRequests", [])
         requested_reviewers = [NetworkUser.from_json(r) for r in requested_reviewers_data]
 
         return cls(


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Fixes a field name mismatch when parsing requested reviewers from the `gh` CLI JSON output. The `gh` CLI returns reviewer data under `reviewRequests`, not `requestedReviewers`, causing requested reviewers to always appear empty.

## 🔧 Changes Made
- Added `reviewRequests` to the list of fields requested from the `gh` CLI JSON query
- Updated `NetworkPullRequest.from_json` to read `reviewRequests` instead of `requestedReviewers`

## 🧪 Testing
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

## 📊 Logs
- [x] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)