### PR TITLE
fix: Respect explicit category field in workflow auto-detection

### DIFF
--- a/titan_cli/core/workflows/workflow_filter_service.py
+++ b/titan_cli/core/workflows/workflow_filter_service.py
@@ -30,7 +30,14 @@ class WorkflowFilterService:
             Project workflow using GitHub steps -> "Github"
             Project workflow using Jira steps -> "Jira"
             Project workflow with no plugins -> "Custom"
+            Workflow with explicit `category:` in its YAML -> that category, verbatim
         """
+        # An explicit `category:` in the workflow YAML always wins over auto-detection.
+        # Lets a workflow that incidentally uses a plugin step (e.g. `github`) stay
+        # grouped under its own project/team category instead of that plugin's tab.
+        if wf_info.category:
+            return wf_info.category
+
         # If it's already from a plugin, extract the name
         if wf_info.source.startswith("plugin:"):
             plugin_name = wf_info.source.split(":", 1)[1]


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Adds an early-exit check in `WorkflowFilterService.get_category()` so that any workflow with an explicit `category:` field in its YAML is returned verbatim, bypassing the plugin-based auto-detection logic entirely.

## 🔧 Changes Made
- Added a guard clause in `get_category()` that returns `wf_info.category` immediately if it is set
- Updated the docstring to document the new explicit-category precedence rule

## 🧪 Testing
- [ ] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->

## 📊 Logs
- [x] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [ ] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)