### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/plugins/titan-plugin-git/pyproject.toml
+++ b/plugins/titan-plugin-git/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_git"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugins/titan-plugin-github/pyproject.toml
+++ b/plugins/titan-plugin-github/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_github"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugins/titan-plugin-jira/pyproject.toml
+++ b/plugins/titan-plugin-jira/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_jira"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 requests = ">=2.31.0"
 pydantic = ">=2.0.0"
 jinja2 = ">=3.0.0"

--- a/plugins/titan-plugin-slack/pyproject.toml
+++ b/plugins/titan-plugin-slack/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{include = "titan_plugin_slack"}]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 slack-sdk = ">=3.27.0"
 requests = ">=2.31.0"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2925,7 +2925,7 @@ files = []
 develop = true
 
 [package.dependencies]
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 
 [package.source]
 type = "directory"
@@ -2942,7 +2942,7 @@ files = []
 develop = true
 
 [package.dependencies]
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 
 [package.source]
 type = "directory"
@@ -2962,7 +2962,7 @@ develop = true
 jinja2 = ">=3.0.0"
 pydantic = ">=2.0.0"
 requests = ">=2.31.0"
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 
 [package.source]
 type = "directory"
@@ -2981,7 +2981,7 @@ develop = true
 [package.dependencies]
 requests = ">=2.31.0"
 slack-sdk = ">=3.27.0"
-titan-cli = ">=0.7.1"
+titan-cli = ">=0.7.2"
 
 [package.source]
 type = "directory"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "titan-cli"
-version = "0.7.1"
+version = "0.7.2"
 description = "Modular development tools orchestrator - Streamline your workflows with AI integration and intuitive terminal UI"
 authors = ["MasOrange Apps Team <apps-management-stores@masorange.es>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump `titan-cli` version to `0.7.2`
- Update plugin `titan-cli` dependency constraints

## What's included in 0.7.2

- fix: Respect explicit category field in workflow auto-detection (#249)
- fix: Correct reviewRequests field name for gh CLI JSON parsing (#248)
- feat: Add prompt-budget batching for AI thread resolution calls (#246)
- feat: Add GitHub Contents API and reviewer tracking (#247)

## Release

After this PR is merged, run the publish workflow from `master` to create the tag, publish to PyPI, and create the GitHub release.
