### PR TITLE
feat: Add shared OAuth manager for plugin credential coordination

### DIFF
--- a/docs/concepts/oauth-manager.md
+++ b/docs/concepts/oauth-manager.md
@@ -1,0 +1,47 @@
+# OAuth Manager
+
+Titan centralizes plugin OAuth coordination in `titan_cli.core.oauth`.
+
+The manager is provider-neutral: plugins describe the credential they need with
+an `OAuthRequest`, and the manager resolves an `OAuthCredential` from environment
+variables, Titan's OAuth token store, legacy secret keys, or a registered OAuth
+provider.
+
+## Current Scope
+
+- Async API: `OAuthManager.get_credential(...)`
+- Blocking wrappers for today's synchronous workflow executor
+- Provider-neutral events through `OAuthEventSink`
+- Queue-backed event sink for a future shared runtime event queue
+- One SecretManager JSON blob per OAuth credential
+- Credential-scoped locks for refresh/login coordination
+
+Provider adapters live outside the manager. A plugin can register a provider for
+browser login, device login, service-specific refresh, or any other OAuth flow
+without coupling the core manager to that product.
+
+## Refresh Strategy
+
+Provider-backed token sets should store `expires_at`.
+
+Before returning a credential, the manager checks whether the token is still
+valid outside the configured refresh margin. The default margin is 300 seconds.
+If the token is expired or near expiry and a refresh token exists, the manager:
+
+1. Acquires the credential lock.
+2. Reads storage again in case another worker already refreshed it.
+3. Calls the provider refresh method only if refresh is still needed.
+4. Stores the refreshed token set as a single blob.
+5. Emits safe lifecycle events without token values.
+
+This prevents duplicate refreshes when several workflows, screens, or future
+headless jobs ask for the same credential concurrently.
+
+## Planned Evolution
+
+Plugins that currently own bespoke OAuth flows should migrate to this manager
+incrementally.
+
+That future work should keep UI concerns outside `titan_cli.core.oauth`: a TUI,
+CLI prompt, server process, or headless runner should observe the same events and
+decide how to present authorization, errors, retries, and progress.

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -68,6 +68,18 @@ class FakeSecretManager:
         self.delete_calls.append((key, scope))
 
 
+class FailingSecretManager(FakeSecretManager):
+    def set(
+        self,
+        key: str,
+        value: str,
+        namespace: str = "titan",
+        scope: str = "user",
+    ) -> None:
+        self.set_calls.append((key, value, scope))
+        raise RuntimeError("keyring unavailable")
+
+
 def _manager(
     secrets: FakeSecretManager,
     tmp_path,
@@ -95,6 +107,25 @@ def _request(**overrides) -> OAuthRequest:
     }
     defaults.update(overrides)
     return OAuthRequest(**defaults)
+
+
+def _store_token_payload(
+    secrets: FakeSecretManager,
+    request: OAuthRequest,
+    token_set: OAuthTokenSet,
+    *,
+    scope: str = "user",
+) -> tuple[OAuthTokenStore, str]:
+    store = OAuthTokenStore(secrets)
+    secret_key = store.build_secret_key(request)
+    payload = json.dumps(
+        token_set.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    secrets.values[secret_key] = payload
+    secrets.scoped_values[(scope, "titan", secret_key)] = payload
+    return store, secret_key
 
 
 def _unsafe_oauth_token_set(**overrides) -> OAuthTokenSet:
@@ -925,6 +956,112 @@ def test_oauth_manager_saves_one_json_blob(tmp_path) -> None:
     assert [call[0] for call in secrets.set_calls] == [secret_key]
 
 
+def test_oauth_manager_save_token_set_write_failure_emits_storage_failure(
+    tmp_path,
+) -> None:
+    secrets = FailingSecretManager()
+    manager = _manager(secrets, tmp_path)
+    sink = CollectingOAuthEventSink()
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        manager.save_token_set_blocking(
+            _request(),
+            OAuthTokenSet(access_token="manual-token"),
+            sink=sink,
+        )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert [event.type for event in sink.events] == ["oauth.storage.failed"]
+    assert dict(sink.events[0].metadata) == {"phase": "storage"}
+
+
+def test_oauth_manager_refresh_write_failure_emits_refresh_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FailingSecretManager()
+    request = _request()
+    store, _secret_key = _store_token_payload(
+        secrets,
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    sink = CollectingOAuthEventSink()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        asyncio.run(manager.get_credential(request, sink=sink))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert [event.type for event in sink.events] == [
+        "oauth.resolve.started",
+        "oauth.lock.acquired",
+        "oauth.refresh.started",
+        "oauth.refresh.failed",
+    ]
+    assert dict(sink.events[-1].metadata) == {"phase": "storage"}
+
+
+def test_oauth_manager_authorization_write_failure_emits_authorize_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FailingSecretManager()
+
+    class AuthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run")
+
+        async def authorize(self, request, sink):
+            return OAuthTokenSet(
+                access_token="login-token",
+                refresh_token="refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    sink = CollectingOAuthEventSink()
+    manager = _manager(
+        secrets,
+        tmp_path,
+        providers={"google": AuthorizingProvider()},
+    )
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        asyncio.run(manager.get_credential(_request(interactive=True), sink=sink))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert [event.type for event in sink.events] == [
+        "oauth.resolve.started",
+        "oauth.lock.acquired",
+        "oauth.authorize.started",
+        "oauth.authorize.failed",
+    ]
+    assert dict(sink.events[-1].metadata) == {"phase": "storage"}
+
+
 def test_oauth_token_store_wraps_json_serialization_errors() -> None:
     store = OAuthTokenStore(FakeSecretManager())
     token_set = OAuthTokenSet(
@@ -939,17 +1076,7 @@ def test_oauth_token_store_wraps_json_serialization_errors() -> None:
 
 
 def test_oauth_token_store_wraps_secret_write_errors() -> None:
-    class BrokenSecretManager(FakeSecretManager):
-        def set(
-            self,
-            key: str,
-            value: str,
-            namespace: str = "titan",
-            scope: str = "user",
-        ) -> None:
-            raise RuntimeError("keyring unavailable")
-
-    store = OAuthTokenStore(BrokenSecretManager())
+    store = OAuthTokenStore(FailingSecretManager())
 
     with pytest.raises(OAuthStorageError) as exc_info:
         store.write(_request(), OAuthTokenSet(access_token="manual-token"))

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -16,6 +16,7 @@ from titan_cli.core.oauth import (
     OAuthLockTimeout,
     OAuthManager,
     OAuthRequest,
+    OAuthStorageError,
     OAuthTokenInvalidError,
     OAuthTokenRefreshError,
     OAuthTokenSet,
@@ -890,6 +891,38 @@ def test_oauth_manager_saves_one_json_blob(tmp_path) -> None:
     stored_payload = json.loads(secrets.values[secret_key])
     assert stored_payload["access_token"] == "manual-token"
     assert [call[0] for call in secrets.set_calls] == [secret_key]
+
+
+def test_oauth_token_store_wraps_json_serialization_errors() -> None:
+    store = OAuthTokenStore(FakeSecretManager())
+    token_set = OAuthTokenSet(
+        access_token="manual-token",
+        metadata={"bad": object()},
+    )
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        store.write(_request(), token_set)
+
+    assert isinstance(exc_info.value.__cause__, TypeError)
+
+
+def test_oauth_token_store_wraps_secret_write_errors() -> None:
+    class BrokenSecretManager(FakeSecretManager):
+        def set(
+            self,
+            key: str,
+            value: str,
+            namespace: str = "titan",
+            scope: str = "user",
+        ) -> None:
+            raise RuntimeError("keyring unavailable")
+
+    store = OAuthTokenStore(BrokenSecretManager())
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        store.write(_request(), OAuthTokenSet(access_token="manual-token"))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
 def test_oauth_lock_async_acquire_cancellation_does_not_leak_lock(tmp_path) -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1,0 +1,805 @@
+import asyncio
+import errno
+import json
+import threading
+import time
+
+import pytest
+
+import titan_cli.core.oauth.locks as oauth_locks
+from titan_cli.core.oauth import (
+    CollectingOAuthEventSink,
+    OAuthAuthenticationRequired,
+    OAuthAuthorizationError,
+    OAuthEvent,
+    OAuthLockManager,
+    OAuthManager,
+    OAuthRequest,
+    OAuthTokenInvalidError,
+    OAuthTokenSet,
+    OAuthTokenStore,
+    QueuedOAuthEventSink,
+)
+from titan_cli.core.secrets import ResolvedSecret
+
+
+class FakeSecretManager:
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
+        self.values = dict(initial or {})
+        self.scoped_values: dict[tuple[str, str, str], str] = {
+            ("user", "titan", key): value for key, value in self.values.items()
+        }
+        self.set_calls: list[tuple[str, str, str]] = []
+        self.delete_calls: list[tuple[str, str]] = []
+
+    def get(self, key: str, namespace: str = "titan") -> str | None:
+        resolved = self.get_with_scope(key, namespace=namespace)
+        return resolved.value if resolved else None
+
+    def get_with_scope(
+        self,
+        key: str,
+        namespace: str = "titan",
+    ) -> ResolvedSecret | None:
+        for scope in ("env", "project", "user"):
+            scoped_key = (scope, namespace, key)
+            if scoped_key in self.scoped_values:
+                return ResolvedSecret(self.scoped_values[scoped_key], scope)
+        return None
+
+    def set(
+        self,
+        key: str,
+        value: str,
+        namespace: str = "titan",
+        scope: str = "user",
+    ) -> None:
+        self.values[key] = value
+        self.scoped_values[(scope, namespace, key)] = value
+        self.set_calls.append((key, value, scope))
+
+    def delete(self, key: str, namespace: str = "titan", scope: str = "user") -> None:
+        self.scoped_values.pop((scope, namespace, key), None)
+        if scope == "user":
+            self.values.pop(key, None)
+        self.delete_calls.append((key, scope))
+
+
+def _manager(
+    secrets: FakeSecretManager,
+    tmp_path,
+    *,
+    providers=None,
+) -> OAuthManager:
+    return OAuthManager(
+        secrets,
+        providers=providers,
+        lock_manager=OAuthLockManager(
+            lock_dir=tmp_path,
+            enable_file_locks=False,
+        ),
+    )
+
+
+def _request(**overrides) -> OAuthRequest:
+    defaults = {
+        "provider": "google",
+        "connection_id": "sample:demo",
+        "scopes": ["resource.read"],
+        "legacy_secret_keys": ["demo_legacy_access_token"],
+        "access_token_env_var": "OAUTH_ACCESS_TOKEN",
+        "subject": "demo",
+    }
+    defaults.update(overrides)
+    return OAuthRequest(**defaults)
+
+
+def test_oauth_request_normalizes_scalar_scope_and_legacy_secret_key() -> None:
+    request = OAuthRequest(
+        provider="google",
+        connection_id="sample:demo",
+        scopes="openid",
+        legacy_secret_keys="legacy_access_token",
+    )
+
+    assert request.scopes == ("openid",)
+    assert request.legacy_secret_keys == ("legacy_access_token",)
+
+
+def test_oauth_token_set_normalizes_scalar_scope() -> None:
+    token_set = OAuthTokenSet(access_token="access-token", scopes="openid")
+
+    assert token_set.scopes == ("openid",)
+
+
+def test_oauth_token_set_from_dict_rejects_non_string_refresh_token() -> None:
+    with pytest.raises(ValueError, match="refresh_token"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "refresh_token": 123,
+            }
+        )
+
+
+def test_oauth_token_set_from_dict_rejects_non_string_scope_element() -> None:
+    with pytest.raises(ValueError, match=r"scopes\[1\]"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "scopes": ["openid", 123],
+            }
+        )
+
+
+def test_oauth_manager_prefers_environment_token(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("OAUTH_ACCESS_TOKEN", "env-token")
+    manager = _manager(
+        FakeSecretManager({"demo_legacy_access_token": "legacy-token"}),
+        tmp_path,
+    )
+    sink = CollectingOAuthEventSink()
+
+    credential = asyncio.run(manager.get_credential(_request(), sink=sink))
+
+    assert credential.access_token == "env-token"
+    assert credential.source == "OAUTH_ACCESS_TOKEN"
+    assert sink.events[-1].type == "oauth.resolve.succeeded"
+    assert sink.events[-1].metadata == {"source": "OAUTH_ACCESS_TOKEN"}
+
+
+def test_oauth_manager_uses_stored_oauth_blob(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="stored-token",
+            expires_at=int(time.time()) + 3600,
+        ),
+    )
+    manager = OAuthManager(
+        secrets,
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "stored-token"
+    assert credential.source == "oauth-cache"
+
+
+def test_oauth_manager_refreshes_token_inside_expiry_margin(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="refresh-token",
+            expires_at=int(time.time()) + 120,
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+
+
+@pytest.mark.parametrize("storage_scope", ["env", "project"])
+def test_oauth_manager_refresh_preserves_original_storage_scope(
+    monkeypatch,
+    tmp_path,
+    storage_scope,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="refresh-token",
+            expires_at=int(time.time()) + 120,
+        ),
+        scope=storage_scope,
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+    assert secrets.set_calls[-1][0] == secret_key
+    assert secrets.set_calls[-1][2] == storage_scope
+    stored_payload = json.loads(
+        secrets.scoped_values[(storage_scope, "titan", secret_key)]
+    )
+    assert stored_payload["access_token"] == "fresh-token"
+
+
+def test_oauth_manager_refreshes_before_legacy_secret(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager({"demo_legacy_access_token": "legacy-token"})
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+
+
+def test_oauth_manager_reads_legacy_secret_key(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    manager = _manager(
+        FakeSecretManager({"demo_legacy_access_token": " legacy-token "}),
+        tmp_path,
+    )
+
+    credential = asyncio.run(manager.get_credential(_request()))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_legacy_access_token"
+
+
+def test_oauth_manager_interactive_uses_legacy_before_authorization(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+
+    class AuthorizingProvider:
+        def __init__(self) -> None:
+            self.authorize_calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run")
+
+        async def authorize(self, request, sink):
+            self.authorize_calls += 1
+            return OAuthTokenSet(access_token="browser-token")
+
+    provider = AuthorizingProvider()
+    manager = _manager(
+        FakeSecretManager({"demo_legacy_access_token": " legacy-token "}),
+        tmp_path,
+        providers={"google": provider},
+    )
+
+    credential = asyncio.run(manager.get_credential(_request(interactive=True)))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_legacy_access_token"
+    assert provider.authorize_calls == 0
+
+
+def test_oauth_manager_refresh_failure_checks_legacy_before_authorization(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager({"demo_legacy_access_token": " legacy-token "})
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshThenAuthorizeProvider:
+        def __init__(self) -> None:
+            self.refresh_calls = 0
+            self.authorize_calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.refresh_calls += 1
+            raise RuntimeError("temporary refresh failure")
+
+        async def authorize(self, request, sink):
+            self.authorize_calls += 1
+            return OAuthTokenSet(access_token="browser-token")
+
+    provider = RefreshThenAuthorizeProvider()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_legacy_access_token"
+    assert provider.refresh_calls == 1
+    assert provider.authorize_calls == 0
+
+
+def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    manager = _manager(FakeSecretManager(), tmp_path)
+
+    with pytest.raises(OAuthAuthenticationRequired):
+        asyncio.run(manager.get_credential(_request()))
+
+
+def test_oauth_manager_wraps_authorization_errors(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+
+    class BrokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run")
+
+        async def authorize(self, request, sink):
+            raise RuntimeError("browser failed")
+
+    manager = _manager(
+        FakeSecretManager(),
+        tmp_path,
+        providers={"google": BrokenProvider()},
+    )
+    request = _request(interactive=True)
+
+    with pytest.raises(OAuthAuthorizationError, match="browser failed"):
+        asyncio.run(manager.get_credential(request))
+
+
+def test_oauth_manager_refreshes_only_once_under_concurrency(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.calls += 1
+            await asyncio.sleep(0.02)
+            return OAuthTokenSet(
+                access_token=f"fresh-token-{self.calls}",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    provider = RefreshProvider()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    async def resolve_many():
+        return await asyncio.gather(
+            *(manager.get_credential(request) for _ in range(8))
+        )
+
+    credentials = asyncio.run(resolve_many())
+
+    assert provider.calls == 1
+    assert {credential.access_token for credential in credentials} == {"fresh-token-1"}
+
+
+def test_oauth_manager_interactive_authorizes_after_refresh_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="old-refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class ReauthorizingProvider:
+        def __init__(self) -> None:
+            self.refresh_calls = 0
+            self.authorize_calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.refresh_calls += 1
+            raise RuntimeError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            self.authorize_calls += 1
+            return OAuthTokenSet(
+                access_token="new-login-token",
+                refresh_token="new-refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    provider = ReauthorizingProvider()
+    sink = CollectingOAuthEventSink()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request, sink=sink))
+
+    assert credential.access_token == "new-login-token"
+    assert credential.source == "oauth-login"
+    assert provider.refresh_calls == 1
+    assert provider.authorize_calls == 1
+    stored_payload = json.loads(secrets.values[old_secret_key])
+    assert stored_payload["refresh_token"] == "new-refresh-token"
+    assert "oauth.refresh.stale_deleted" not in [event.type for event in sink.events]
+    assert secrets.delete_calls == []
+
+
+def test_oauth_manager_keeps_stored_token_when_refresh_and_relogin_fail(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="old-refresh-token",
+            expires_at=1,
+        ),
+    )
+    old_payload = secrets.scoped_values[("user", "titan", old_secret_key)]
+
+    class BrokenReauthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise RuntimeError("temporary network failure")
+
+        async def authorize(self, request, sink):
+            raise OAuthAuthorizationError("user cancelled")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": BrokenReauthorizingProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    with pytest.raises(OAuthAuthorizationError, match="user cancelled"):
+        asyncio.run(manager.get_credential(request))
+
+    assert secrets.delete_calls == []
+    assert secrets.scoped_values[("user", "titan", old_secret_key)] == old_payload
+
+
+@pytest.mark.parametrize("storage_scope", ["env", "project"])
+def test_oauth_manager_deletes_explicitly_invalid_token_before_relogin(
+    monkeypatch,
+    tmp_path,
+    storage_scope,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="old-refresh-token",
+            expires_at=1,
+        ),
+        scope=storage_scope,
+    )
+
+    class ReauthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise OAuthTokenInvalidError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            return OAuthTokenSet(
+                access_token="new-login-token",
+                refresh_token="new-refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": ReauthorizingProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "new-login-token"
+    assert secrets.delete_calls[-1] == (old_secret_key, storage_scope)
+    assert secrets.set_calls[-1][0] == old_secret_key
+    assert secrets.set_calls[-1][2] == storage_scope
+    assert ("user", "titan", old_secret_key) not in secrets.scoped_values
+    stored_payload = json.loads(
+        secrets.scoped_values[(storage_scope, "titan", old_secret_key)]
+    )
+    assert stored_payload["refresh_token"] == "new-refresh-token"
+
+
+def test_oauth_manager_saves_one_json_blob(tmp_path) -> None:
+    secrets = FakeSecretManager()
+    manager = _manager(secrets, tmp_path)
+    request = _request()
+
+    secret_key = manager.save_token_set_blocking(
+        request,
+        OAuthTokenSet(access_token="manual-token"),
+    )
+
+    assert secret_key.startswith("oauth_google_")
+    stored_payload = json.loads(secrets.values[secret_key])
+    assert stored_payload["access_token"] == "manual-token"
+    assert [call[0] for call in secrets.set_calls] == [secret_key]
+
+
+def test_oauth_lock_async_acquire_cancellation_does_not_leak_lock(tmp_path) -> None:
+    async def exercise_cancelled_acquire() -> None:
+        manager = OAuthLockManager(
+            lock_dir=tmp_path,
+            enable_file_locks=False,
+            poll_interval_seconds=0.01,
+        )
+        held_lock = manager.acquire_blocking("sample:demo", timeout_seconds=1)
+        pending_acquire = asyncio.create_task(
+            manager.acquire("sample:demo", timeout_seconds=1)
+        )
+
+        await asyncio.sleep(0.05)
+        pending_acquire.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending_acquire
+
+        held_lock.release()
+        await asyncio.sleep(0.05)
+        next_lock = await manager.acquire("sample:demo", timeout_seconds=0.2)
+        next_lock.release()
+
+    asyncio.run(exercise_cancelled_acquire())
+
+
+def test_oauth_lock_file_lock_uses_remaining_timeout(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    captured_timeouts = []
+
+    class FakeFileLock:
+        def __init__(
+            self,
+            path,
+            *,
+            timeout_seconds,
+            poll_interval_seconds,
+        ) -> None:
+            captured_timeouts.append(timeout_seconds)
+
+        def acquire(self, cancel_event=None) -> None:
+            return None
+
+        def release(self) -> None:
+            return None
+
+    monkeypatch.setattr(oauth_locks, "_FileLock", FakeFileLock)
+    manager = OAuthLockManager(
+        lock_dir=tmp_path,
+        enable_file_locks=True,
+        poll_interval_seconds=0.01,
+    )
+    thread_lock = manager._get_thread_lock("sample:demo")
+    thread_lock.acquire()
+
+    def release_thread_lock() -> None:
+        time.sleep(0.05)
+        thread_lock.release()
+
+    releaser = threading.Thread(target=release_thread_lock)
+    releaser.start()
+    held_lock = manager.acquire_blocking("sample:demo", timeout_seconds=0.5)
+    held_lock.release()
+    releaser.join()
+
+    assert captured_timeouts
+    assert 0 < captured_timeouts[0] < 0.5
+
+
+def test_file_lock_retries_lock_contention_error(tmp_path) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+    attempts = 0
+
+    def try_acquire_once() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+
+    lock._try_acquire_once = try_acquire_once
+
+    lock.acquire()
+
+    assert attempts == 2
+    lock.release()
+
+
+def test_file_lock_windows_byte_initialization_does_not_grow_file(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    lock_path = tmp_path / "oauth.lock"
+    lock = oauth_locks._FileLock(
+        lock_path,
+        timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+    monkeypatch.setattr(oauth_locks.os, "name", "nt")
+
+    lock._handle = open(lock_path, "a+")
+    try:
+        lock._ensure_windows_lock_byte()
+        lock._ensure_windows_lock_byte()
+    finally:
+        lock._close_handle()
+
+    assert lock_path.read_text() == "0"
+
+
+def test_file_lock_propagates_non_contention_oserror(tmp_path) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=1,
+        poll_interval_seconds=0,
+    )
+
+    def try_acquire_once() -> None:
+        raise OSError(errno.ENOSPC, "no space left on device")
+
+    lock._try_acquire_once = try_acquire_once
+
+    with pytest.raises(OSError) as exc_info:
+        lock.acquire()
+
+    assert exc_info.value.errno == errno.ENOSPC
+    assert lock._handle is None
+
+
+def test_queued_oauth_event_sink_drains_events() -> None:
+    sink = QueuedOAuthEventSink()
+
+    sink.emit(OAuthEvent(type="oauth.resolve.started", operation_id="op-1"))
+    sink.emit(OAuthEvent(type="oauth.resolve.succeeded", operation_id="op-1"))
+
+    assert [event.type for event in sink.drain()] == [
+        "oauth.resolve.started",
+        "oauth.resolve.succeeded",
+    ]
+    assert sink.get(block=False) is None
+
+
+def test_queued_oauth_event_sink_drops_new_events_when_full() -> None:
+    sink = QueuedOAuthEventSink(maxsize=1)
+
+    sink.emit(OAuthEvent(type="oauth.resolve.started", operation_id="op-1"))
+    sink.emit(OAuthEvent(type="oauth.resolve.succeeded", operation_id="op-1"))
+
+    assert [event.type for event in sink.drain()] == ["oauth.resolve.started"]
+    assert sink.dropped_count == 1
+
+
+def test_oauth_manager_queue_overflow_does_not_abort_resolution(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("OAUTH_ACCESS_TOKEN", "env-token")
+    manager = _manager(FakeSecretManager(), tmp_path)
+    sink = QueuedOAuthEventSink(maxsize=1)
+
+    credential = asyncio.run(manager.get_credential(_request(), sink=sink))
+
+    assert credential.access_token == "env-token"
+    assert sink.dropped_count >= 1

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1225,12 +1225,14 @@ def test_file_lock_retries_lock_contention_error(tmp_path) -> None:
         poll_interval_seconds=0,
     )
     attempts = 0
+    original_try_acquire_once = lock._try_acquire_once
 
     def try_acquire_once() -> None:
         nonlocal attempts
         attempts += 1
         if attempts == 1:
             raise BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+        original_try_acquire_once()
 
     lock._try_acquire_once = try_acquire_once
 

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -16,6 +16,7 @@ from titan_cli.core.oauth import (
     OAuthManager,
     OAuthRequest,
     OAuthTokenInvalidError,
+    OAuthTokenRefreshError,
     OAuthTokenSet,
     OAuthTokenStore,
     QueuedOAuthEventSink,
@@ -436,6 +437,61 @@ def test_oauth_manager_refresh_failure_checks_legacy_before_authorization(
     assert credential.source == "keyring:demo_legacy_access_token"
     assert provider.refresh_calls == 1
     assert provider.authorize_calls == 0
+
+
+@pytest.mark.parametrize(
+    "failure_factory",
+    [
+        pytest.param(
+            lambda: OAuthTokenInvalidError("refresh token revoked"),
+            id="invalid-token",
+        ),
+        pytest.param(
+            lambda: OAuthTokenRefreshError("provider unavailable"),
+            id="oauth-refresh-error",
+        ),
+        pytest.param(
+            lambda: RuntimeError("temporary refresh failure"),
+            id="unexpected-error",
+        ),
+    ],
+)
+def test_oauth_manager_noninteractive_refresh_failure_uses_legacy_secret(
+    monkeypatch,
+    tmp_path,
+    failure_factory,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager({"demo_legacy_access_token": " legacy-token "})
+    request = _request(interactive=False)
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class BrokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise failure_factory()
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": BrokenProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_legacy_access_token"
 
 
 def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -616,6 +616,95 @@ def test_oauth_manager_noninteractive_refresh_failure_uses_legacy_secret(
     assert credential.source == "keyring:demo_legacy_access_token"
 
 
+@pytest.mark.parametrize("storage_scope", ["user", "env", "project"])
+def test_oauth_manager_noninteractive_invalid_token_deletes_before_legacy_fallback(
+    monkeypatch,
+    tmp_path,
+    storage_scope,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager({"demo_legacy_access_token": " legacy-token "})
+    request = _request(interactive=False)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="revoked-refresh-token",
+            expires_at=1,
+        ),
+        scope=storage_scope,
+    )
+
+    class InvalidTokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise OAuthTokenInvalidError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": InvalidTokenProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == "keyring:demo_legacy_access_token"
+    assert secrets.delete_calls[-1] == (old_secret_key, storage_scope)
+    assert (storage_scope, "titan", old_secret_key) not in secrets.scoped_values
+
+
+def test_oauth_manager_noninteractive_invalid_token_deletes_before_error(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=False)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="revoked-refresh-token",
+            expires_at=1,
+        ),
+        scope="project",
+    )
+
+    class InvalidTokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise OAuthTokenInvalidError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    sink = CollectingOAuthEventSink()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": InvalidTokenProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    with pytest.raises(OAuthTokenInvalidError):
+        asyncio.run(manager.get_credential(request, sink=sink))
+
+    assert secrets.delete_calls[-1] == (old_secret_key, "project")
+    assert ("project", "titan", old_secret_key) not in secrets.scoped_values
+    assert [event.type for event in sink.events] == [
+        "oauth.resolve.started",
+        "oauth.lock.acquired",
+        "oauth.refresh.started",
+        "oauth.refresh.failed",
+        "oauth.refresh.stale_deleted",
+    ]
+
+
 def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
     manager = _manager(FakeSecretManager(), tmp_path)
@@ -1359,6 +1448,42 @@ def test_oauth_event_metadata_is_immutable_snapshot() -> None:
         event.metadata["token"] = "secret"
     with pytest.raises(TypeError):
         event.metadata["nested"]["safe"] = "mutated"
+
+
+def test_oauth_event_metadata_redacts_token_fields_recursively() -> None:
+    event = OAuthEvent(
+        type="oauth.provider.debug",
+        operation_id="op-1",
+        metadata={
+            "access_token": "raw-access-token",
+            "nested": {
+                "refresh_token": "raw-refresh-token",
+                "safe": "value",
+            },
+            "items": [
+                {
+                    "token": "raw-list-token",
+                    "label": "kept",
+                }
+            ],
+            "tuple_items": (
+                {
+                    "id_token": "raw-id-token",
+                    "audience": "kept",
+                },
+            ),
+            "set_items": frozenset({"safe"}),
+        },
+    )
+
+    assert event.metadata["access_token"] == "<redacted>"
+    assert event.metadata["nested"]["refresh_token"] == "<redacted>"
+    assert event.metadata["nested"]["safe"] == "value"
+    assert event.metadata["items"][0]["token"] == "<redacted>"
+    assert event.metadata["items"][0]["label"] == "kept"
+    assert event.metadata["tuple_items"][0]["id_token"] == "<redacted>"
+    assert event.metadata["tuple_items"][0]["audience"] == "kept"
+    assert event.metadata["set_items"] == frozenset({"safe"})
 
 
 def test_queued_oauth_event_sink_drops_new_events_when_full() -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -97,6 +97,22 @@ def _request(**overrides) -> OAuthRequest:
     return OAuthRequest(**defaults)
 
 
+def _unsafe_oauth_token_set(**overrides) -> OAuthTokenSet:
+    defaults = {
+        "access_token": "",
+        "refresh_token": None,
+        "expires_at": None,
+        "token_type": "Bearer",
+        "scopes": (),
+        "metadata": {},
+    }
+    defaults.update(overrides)
+    token_set = object.__new__(OAuthTokenSet)
+    for key, value in defaults.items():
+        object.__setattr__(token_set, key, value)
+    return token_set
+
+
 def test_oauth_request_normalizes_scalar_scope_and_legacy_secret_key() -> None:
     request = OAuthRequest(
         provider="google",
@@ -327,6 +343,14 @@ def test_oauth_manager_refresh_preserves_omitted_refresh_token(
 @pytest.mark.parametrize(
     "token_factory",
     [
+        pytest.param(
+            lambda: _unsafe_oauth_token_set(access_token=""),
+            id="empty-access-token",
+        ),
+        pytest.param(
+            lambda: _unsafe_oauth_token_set(access_token="   "),
+            id="blank-access-token",
+        ),
         pytest.param(
             lambda: OAuthTokenSet(
                 access_token="fresh-token",
@@ -593,6 +617,14 @@ def test_oauth_manager_wraps_authorization_errors(monkeypatch, tmp_path) -> None
 @pytest.mark.parametrize(
     "token_factory",
     [
+        pytest.param(
+            lambda: _unsafe_oauth_token_set(access_token=""),
+            id="empty-access-token",
+        ),
+        pytest.param(
+            lambda: _unsafe_oauth_token_set(access_token="   "),
+            id="blank-access-token",
+        ),
         pytest.param(
             lambda: OAuthTokenSet(
                 access_token="login-token",

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -114,6 +114,17 @@ def test_oauth_token_set_normalizes_scalar_scope() -> None:
     assert token_set.scopes == ("openid",)
 
 
+@pytest.mark.parametrize("access_token", ["", "   "])
+def test_oauth_token_set_rejects_empty_access_token(access_token: str) -> None:
+    with pytest.raises(ValueError, match="access_token"):
+        OAuthTokenSet(access_token=access_token)
+
+
+def test_oauth_token_set_rejects_non_string_access_token() -> None:
+    with pytest.raises(ValueError, match="access_token"):
+        OAuthTokenSet(access_token=123)
+
+
 def test_oauth_token_set_from_dict_rejects_non_string_refresh_token() -> None:
     with pytest.raises(ValueError, match="refresh_token"):
         OAuthTokenSet.from_dict(
@@ -315,10 +326,6 @@ def test_oauth_manager_refresh_preserves_omitted_refresh_token(
 @pytest.mark.parametrize(
     "token_factory",
     [
-        pytest.param(
-            lambda: OAuthTokenSet(access_token=""),
-            id="empty-access-token",
-        ),
         pytest.param(
             lambda: OAuthTokenSet(
                 access_token="fresh-token",
@@ -585,10 +592,6 @@ def test_oauth_manager_wraps_authorization_errors(monkeypatch, tmp_path) -> None
 @pytest.mark.parametrize(
     "token_factory",
     [
-        pytest.param(
-            lambda: OAuthTokenSet(access_token=""),
-            id="empty-access-token",
-        ),
         pytest.param(
             lambda: OAuthTokenSet(
                 access_token="login-token",

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -746,6 +746,70 @@ def test_oauth_manager_refreshes_only_once_under_concurrency(
     assert {credential.access_token for credential in credentials} == {"fresh-token-1"}
 
 
+def test_oauth_manager_refreshes_once_across_managers_with_file_locks(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            refresh_token="refresh-token",
+            expires_at=1,
+        ),
+    )
+
+    class RefreshProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def refresh(self, request, token_set, sink):
+            self.calls += 1
+            await asyncio.sleep(0.05)
+            return OAuthTokenSet(
+                access_token=f"fresh-token-{self.calls}",
+                refresh_token=token_set.refresh_token,
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    provider = RefreshProvider()
+    lock_dir = tmp_path / "locks"
+    manager_one = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=OAuthTokenStore(secrets),
+        lock_manager=OAuthLockManager(lock_dir=lock_dir, enable_file_locks=True),
+    )
+    manager_two = OAuthManager(
+        secrets,
+        providers={"google": provider},
+        token_store=OAuthTokenStore(secrets),
+        lock_manager=OAuthLockManager(lock_dir=lock_dir, enable_file_locks=True),
+    )
+
+    async def resolve_with_separate_managers():
+        return await asyncio.gather(
+            manager_one.get_credential(request),
+            manager_two.get_credential(request),
+        )
+
+    credentials = asyncio.run(resolve_with_separate_managers())
+
+    assert provider.calls == 1
+    assert {credential.access_token for credential in credentials} == {"fresh-token-1"}
+    assert {credential.source for credential in credentials} == {
+        "oauth-cache",
+        "oauth-refresh",
+    }
+
+
 def test_oauth_manager_interactive_authorizes_after_refresh_failure(
     monkeypatch,
     tmp_path,

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -311,6 +311,64 @@ def test_oauth_manager_refresh_preserves_omitted_refresh_token(
     assert stored_payload["scopes"] == ["resource.read"]
 
 
+@pytest.mark.parametrize(
+    "token_factory",
+    [
+        pytest.param(
+            lambda: OAuthTokenSet(access_token=""),
+            id="empty-access-token",
+        ),
+        pytest.param(
+            lambda: OAuthTokenSet(
+                access_token="fresh-token",
+                refresh_token="refresh-token",
+                expires_at=int(time.time()) + 120,
+            ),
+            id="expires-inside-refresh-margin",
+        ),
+        pytest.param(lambda: object(), id="wrong-type"),
+    ],
+)
+def test_oauth_manager_rejects_invalid_refresh_result_without_writing(
+    monkeypatch,
+    tmp_path,
+    token_factory,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="refresh-token",
+            expires_at=int(time.time()) + 120,
+        ),
+    )
+    initial_set_call_count = len(secrets.set_calls)
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return token_factory()
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    with pytest.raises(OAuthTokenRefreshError):
+        asyncio.run(manager.get_credential(request))
+
+    assert len(secrets.set_calls) == initial_set_call_count
+
+
 def test_oauth_manager_refreshes_before_legacy_secret(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
     secrets = FakeSecretManager({"demo_legacy_access_token": "legacy-token"})
@@ -521,6 +579,51 @@ def test_oauth_manager_wraps_authorization_errors(monkeypatch, tmp_path) -> None
 
     with pytest.raises(OAuthAuthorizationError, match="browser failed"):
         asyncio.run(manager.get_credential(request))
+
+
+@pytest.mark.parametrize(
+    "token_factory",
+    [
+        pytest.param(
+            lambda: OAuthTokenSet(access_token=""),
+            id="empty-access-token",
+        ),
+        pytest.param(
+            lambda: OAuthTokenSet(
+                access_token="login-token",
+                refresh_token="refresh-token",
+                expires_at=int(time.time()) + 120,
+            ),
+            id="expires-inside-refresh-margin",
+        ),
+        pytest.param(lambda: object(), id="wrong-type"),
+    ],
+)
+def test_oauth_manager_rejects_invalid_authorization_result_without_writing(
+    monkeypatch,
+    tmp_path,
+    token_factory,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+
+    class InvalidAuthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run")
+
+        async def authorize(self, request, sink):
+            return token_factory()
+
+    secrets = FakeSecretManager()
+    manager = _manager(
+        secrets,
+        tmp_path,
+        providers={"google": InvalidAuthorizingProvider()},
+    )
+
+    with pytest.raises(OAuthAuthorizationError):
+        asyncio.run(manager.get_credential(_request(interactive=True)))
+
+    assert secrets.set_calls == []
 
 
 def test_oauth_manager_refreshes_only_once_under_concurrency(

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -13,6 +13,7 @@ from titan_cli.core.oauth import (
     OAuthAuthorizationError,
     OAuthEvent,
     OAuthLockManager,
+    OAuthLockTimeout,
     OAuthManager,
     OAuthRequest,
     OAuthTokenInvalidError,
@@ -978,6 +979,31 @@ def test_file_lock_retries_lock_contention_error(tmp_path) -> None:
 
     assert attempts == 2
     lock.release()
+
+
+def test_file_lock_timeout_is_hard_bound_when_poll_interval_exceeds_timeout(
+    tmp_path,
+) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.1,
+    )
+    attempts = 0
+
+    def try_acquire_once() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+
+    lock._try_acquire_once = try_acquire_once
+
+    with pytest.raises(OAuthLockTimeout):
+        lock.acquire()
+
+    assert attempts == 1
+    assert lock._handle is None
 
 
 def test_file_lock_windows_byte_initialization_does_not_grow_file(

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -529,6 +529,55 @@ def test_oauth_manager_interactive_authorizes_after_refresh_failure(
     assert secrets.delete_calls == []
 
 
+@pytest.mark.parametrize("storage_scope", ["env", "project"])
+def test_oauth_manager_relogin_preserves_scope_for_token_without_refresh_token(
+    monkeypatch,
+    tmp_path,
+    storage_scope,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request(interactive=True)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-token",
+            expires_at=1,
+        ),
+        scope=storage_scope,
+    )
+
+    class ReauthorizingProvider:
+        async def refresh(self, request, token_set, sink):
+            raise AssertionError("refresh should not run without refresh_token")
+
+        async def authorize(self, request, sink):
+            return OAuthTokenSet(
+                access_token="new-login-token",
+                refresh_token="new-refresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": ReauthorizingProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "new-login-token"
+    assert secrets.set_calls[-1][0] == old_secret_key
+    assert secrets.set_calls[-1][2] == storage_scope
+    assert ("user", "titan", old_secret_key) not in secrets.scoped_values
+    stored_payload = json.loads(
+        secrets.scoped_values[(storage_scope, "titan", old_secret_key)]
+    )
+    assert stored_payload["access_token"] == "new-login-token"
+
+
 def test_oauth_manager_keeps_stored_token_when_refresh_and_relogin_fail(
     monkeypatch,
     tmp_path,

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1096,6 +1096,17 @@ def test_queued_oauth_event_sink_drains_events() -> None:
     assert sink.get(block=False) is None
 
 
+def test_queued_oauth_event_sink_nonblocking_get_ignores_timeout() -> None:
+    sink = QueuedOAuthEventSink()
+
+    assert sink.get(block=False, timeout=1) is None
+
+    event = OAuthEvent(type="oauth.resolve.started", operation_id="op-1")
+    sink.emit(event)
+
+    assert sink.get(block=False, timeout=1) == event
+
+
 def test_oauth_event_metadata_is_immutable_snapshot() -> None:
     metadata = {
         "source": "oauth-cache",

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1096,6 +1096,35 @@ def test_queued_oauth_event_sink_drains_events() -> None:
     assert sink.get(block=False) is None
 
 
+def test_oauth_event_metadata_is_immutable_snapshot() -> None:
+    metadata = {
+        "source": "oauth-cache",
+        "nested": {"safe": "value"},
+        "items": ["first"],
+    }
+
+    event = OAuthEvent(
+        type="oauth.resolve.succeeded",
+        operation_id="op-1",
+        metadata=metadata,
+    )
+    metadata["source"] = "mutated"
+    metadata["token"] = "secret"
+    metadata["nested"]["safe"] = "mutated"
+    metadata["items"].append("second")
+
+    assert event.metadata == {
+        "source": "oauth-cache",
+        "nested": {"safe": "value"},
+        "items": ("first",),
+    }
+    assert "token" not in event.metadata
+    with pytest.raises(TypeError):
+        event.metadata["token"] = "secret"
+    with pytest.raises(TypeError):
+        event.metadata["nested"]["safe"] = "mutated"
+
+
 def test_queued_oauth_event_sink_drops_new_events_when_full() -> None:
     sink = QueuedOAuthEventSink(maxsize=1)
 

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -265,6 +265,51 @@ def test_oauth_manager_refresh_preserves_original_storage_scope(
     assert stored_payload["access_token"] == "fresh-token"
 
 
+def test_oauth_manager_refresh_preserves_omitted_refresh_token(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="stable-refresh-token",
+            expires_at=int(time.time()) + 120,
+            scopes=("resource.read",),
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                expires_at=int(time.time()) + 3600,
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    assert credential.source == "oauth-refresh"
+    stored_payload = json.loads(secrets.values[secret_key])
+    assert stored_payload["refresh_token"] == "stable-refresh-token"
+    assert stored_payload["scopes"] == ["resource.read"]
+
+
 def test_oauth_manager_refreshes_before_legacy_secret(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
     secrets = FakeSecretManager({"demo_legacy_access_token": "legacy-token"})

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -341,6 +341,7 @@ def test_oauth_manager_refresh_preserves_omitted_refresh_token(
             refresh_token="stable-refresh-token",
             expires_at=int(time.time()) + 120,
             scopes=("resource.read",),
+            metadata={"subject": "demo-user"},
         ),
     )
 
@@ -369,6 +370,61 @@ def test_oauth_manager_refresh_preserves_omitted_refresh_token(
     stored_payload = json.loads(secrets.values[secret_key])
     assert stored_payload["refresh_token"] == "stable-refresh-token"
     assert stored_payload["scopes"] == ["resource.read"]
+    assert stored_payload["metadata"] == {"subject": "demo-user"}
+
+
+def test_oauth_manager_refresh_merges_metadata_with_refreshed_precedence(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    request = _request()
+    store = OAuthTokenStore(secrets)
+    secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="almost-expired-token",
+            refresh_token="stable-refresh-token",
+            expires_at=int(time.time()) + 120,
+            metadata={
+                "subject": "old-user",
+                "tenant": "masmovil",
+            },
+        ),
+    )
+
+    class RefreshProvider:
+        async def refresh(self, request, token_set, sink):
+            return OAuthTokenSet(
+                access_token="fresh-token",
+                expires_at=int(time.time()) + 3600,
+                metadata={
+                    "subject": "new-user",
+                    "issuer": "google",
+                },
+            )
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    manager = OAuthManager(
+        secrets,
+        providers={"google": RefreshProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+        refresh_margin_seconds=300,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "fresh-token"
+    stored_payload = json.loads(secrets.values[secret_key])
+    assert stored_payload["metadata"] == {
+        "subject": "new-user",
+        "tenant": "masmovil",
+        "issuer": "google",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -176,6 +176,25 @@ def test_oauth_request_normalizes_scalar_scope_and_legacy_secret_key() -> None:
     assert request.legacy_secret_keys == ("legacy_access_token",)
 
 
+def test_oauth_request_sorts_scopes_but_preserves_legacy_secret_key_order() -> None:
+    request = OAuthRequest(
+        provider="google",
+        connection_id="sample:demo",
+        scopes=["z.scope", "a.scope", "z.scope"],
+        legacy_secret_keys=[
+            " z_primary_access_token ",
+            "a_fallback_access_token",
+            "z_primary_access_token",
+        ],
+    )
+
+    assert request.scopes == ("a.scope", "z.scope")
+    assert request.legacy_secret_keys == (
+        "z_primary_access_token",
+        "a_fallback_access_token",
+    )
+
+
 def test_oauth_request_normalizes_storage_context() -> None:
     request = OAuthRequest(
         provider="google",
@@ -623,6 +642,33 @@ def test_oauth_manager_reads_legacy_secret_key(monkeypatch, tmp_path) -> None:
 
     assert credential.access_token == "legacy-token"
     assert credential.source == "keyring:demo_legacy_access_token"
+
+
+def test_oauth_manager_respects_legacy_secret_key_precedence(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    request = _request(
+        legacy_secret_keys=[
+            "z_primary_access_token",
+            "a_fallback_access_token",
+        ],
+    )
+    manager = _manager(
+        FakeSecretManager(
+            {
+                "z_primary_access_token": "primary-token",
+                "a_fallback_access_token": "fallback-token",
+            }
+        ),
+        tmp_path,
+    )
+
+    credential = asyncio.run(manager.get_credential(request))
+
+    assert credential.access_token == "primary-token"
+    assert credential.source == "keyring:z_primary_access_token"
 
 
 def test_oauth_manager_interactive_uses_legacy_before_authorization(

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1184,6 +1184,28 @@ def test_oauth_manager_save_token_set_write_failure_emits_storage_failure(
     assert dict(sink.events[0].metadata) == {"phase": "storage"}
 
 
+def test_oauth_manager_save_token_set_rejects_invalid_scope_without_saved_event(
+    tmp_path,
+) -> None:
+    secrets = FakeSecretManager()
+    manager = _manager(secrets, tmp_path)
+    sink = CollectingOAuthEventSink()
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        manager.save_token_set_blocking(
+            _request(),
+            OAuthTokenSet(access_token="manual-token"),
+            scope="invalid",
+            sink=sink,
+        )
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert "OAuth storage scope must be one of" in str(exc_info.value.__cause__)
+    assert secrets.set_calls == []
+    assert [event.type for event in sink.events] == ["oauth.storage.failed"]
+    assert dict(sink.events[0].metadata) == {"phase": "storage"}
+
+
 def test_oauth_manager_refresh_write_failure_emits_refresh_failure(
     monkeypatch,
     tmp_path,
@@ -1291,6 +1313,21 @@ def test_oauth_token_store_wraps_secret_write_errors() -> None:
         store.write(_request(), OAuthTokenSet(access_token="manual-token"))
 
     assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_oauth_token_store_wraps_invalid_scope_without_writing() -> None:
+    secrets = FakeSecretManager()
+    store = OAuthTokenStore(secrets)
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        store.write(
+            _request(),
+            OAuthTokenSet(access_token="manual-token"),
+            scope="invalid",
+        )
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert secrets.set_calls == []
 
 
 def test_oauth_lock_async_acquire_cancellation_does_not_leak_lock(tmp_path) -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -80,6 +80,12 @@ class FailingSecretManager(FakeSecretManager):
         raise RuntimeError("keyring unavailable")
 
 
+class FailingDeleteSecretManager(FakeSecretManager):
+    def delete(self, key: str, namespace: str = "titan", scope: str = "user") -> None:
+        self.delete_calls.append((key, scope))
+        raise RuntimeError("project secrets unavailable")
+
+
 def _manager(
     secrets: FakeSecretManager,
     tmp_path,
@@ -781,6 +787,57 @@ def test_oauth_manager_noninteractive_invalid_token_deletes_before_error(
     ]
 
 
+def test_oauth_manager_invalid_token_delete_failure_emits_storage_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FailingDeleteSecretManager(
+        {"demo_legacy_access_token": " legacy-token "},
+    )
+    request = _request(interactive=False)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="revoked-refresh-token",
+            expires_at=1,
+        ),
+        scope="project",
+    )
+
+    class InvalidTokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise OAuthTokenInvalidError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    sink = CollectingOAuthEventSink()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": InvalidTokenProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        asyncio.run(manager.get_credential(request, sink=sink))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert secrets.delete_calls[-1] == (old_secret_key, "project")
+    assert ("project", "titan", old_secret_key) in secrets.scoped_values
+    assert [event.type for event in sink.events] == [
+        "oauth.resolve.started",
+        "oauth.lock.acquired",
+        "oauth.refresh.started",
+        "oauth.refresh.failed",
+        "oauth.refresh.failed",
+    ]
+    assert dict(sink.events[-1].metadata) == {"phase": "storage"}
+
+
 def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
     manager = _manager(FakeSecretManager(), tmp_path)
@@ -1331,6 +1388,15 @@ def test_oauth_token_store_wraps_secret_write_errors() -> None:
 
     with pytest.raises(OAuthStorageError) as exc_info:
         store.write(_request(), OAuthTokenSet(access_token="manual-token"))
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_oauth_token_store_wraps_secret_delete_errors() -> None:
+    store = OAuthTokenStore(FailingDeleteSecretManager())
+
+    with pytest.raises(OAuthStorageError) as exc_info:
+        store.delete(_request(), scope="project")
 
     assert isinstance(exc_info.value.__cause__, RuntimeError)
 

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -193,6 +193,26 @@ def test_oauth_token_set_from_dict_rejects_non_string_scope_element() -> None:
         )
 
 
+@pytest.mark.parametrize("refresh_margin_seconds", [-1, 1.5, "300", True])
+def test_oauth_manager_rejects_invalid_refresh_margin_seconds(
+    refresh_margin_seconds: object,
+) -> None:
+    with pytest.raises(ValueError, match="refresh_margin_seconds"):
+        OAuthManager(
+            FakeSecretManager(),
+            refresh_margin_seconds=refresh_margin_seconds,
+        )
+
+
+def test_oauth_manager_accepts_zero_refresh_margin_seconds() -> None:
+    manager = OAuthManager(
+        FakeSecretManager(),
+        refresh_margin_seconds=0,
+    )
+
+    assert manager.refresh_margin_seconds == 0
+
+
 def test_oauth_manager_prefers_environment_token(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("OAUTH_ACCESS_TOKEN", "env-token")
     manager = _manager(

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -267,6 +267,18 @@ def test_oauth_token_set_rejects_non_string_access_token() -> None:
         OAuthTokenSet(access_token=123)
 
 
+@pytest.mark.parametrize("token_type", [None, True, 123, object()])
+def test_oauth_token_set_rejects_non_string_token_type(token_type: object) -> None:
+    with pytest.raises(ValueError, match="token_type"):
+        OAuthTokenSet(access_token="access-token", token_type=token_type)
+
+
+@pytest.mark.parametrize("metadata", ["bad", [("source", "provider")], 123])
+def test_oauth_token_set_rejects_non_mapping_metadata(metadata: object) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        OAuthTokenSet(access_token="access-token", metadata=metadata)
+
+
 @pytest.mark.parametrize(
     "expires_at",
     [True, False, 123.45, "123.45", "", "   ", object()],
@@ -292,6 +304,32 @@ def test_oauth_token_set_from_dict_rejects_non_string_scope_element() -> None:
             {
                 "access_token": "access-token",
                 "scopes": ["openid", 123],
+            }
+        )
+
+
+@pytest.mark.parametrize("token_type", [None, True, 123, object()])
+def test_oauth_token_set_from_dict_rejects_non_string_token_type(
+    token_type: object,
+) -> None:
+    with pytest.raises(ValueError, match="token_type"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "token_type": token_type,
+            }
+        )
+
+
+@pytest.mark.parametrize("metadata", [None, "bad", [("source", "provider")], 123])
+def test_oauth_token_set_from_dict_rejects_non_mapping_metadata(
+    metadata: object,
+) -> None:
+    with pytest.raises(ValueError, match="metadata"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "metadata": metadata,
             }
         )
 

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -1014,14 +1014,20 @@ def test_oauth_manager_invalid_token_delete_failure_emits_storage_failure(
     assert isinstance(exc_info.value.__cause__, RuntimeError)
     assert secrets.delete_calls[-1] == (old_secret_key, "project")
     assert ("project", "titan", old_secret_key) in secrets.scoped_values
-    assert [event.type for event in sink.events] == [
-        "oauth.resolve.started",
-        "oauth.lock.acquired",
-        "oauth.refresh.started",
-        "oauth.refresh.failed",
-        "oauth.refresh.failed",
+    assert [
+        (event.type, event.message, dict(event.metadata)) for event in sink.events
+    ] == [
+        ("oauth.resolve.started", "Resolving OAuth credential.", {}),
+        ("oauth.lock.acquired", "OAuth credential lock acquired.", {}),
+        ("oauth.refresh.started", "Refreshing OAuth credential.", {}),
+        ("oauth.refresh.failed", "OAuth refresh failed.", {}),
+        (
+            "oauth.refresh.failed",
+            "Stale OAuth credential could not be deleted.",
+            {"phase": "storage"},
+        ),
     ]
-    assert dict(sink.events[-1].metadata) == {"phase": "storage"}
+    assert "oauth.refresh.stale_deleted" not in [event.type for event in sink.events]
 
 
 def test_oauth_manager_invalid_token_delete_must_remove_before_stale_deleted(
@@ -1774,10 +1780,13 @@ def test_file_lock_timeout_zero_times_out_after_contended_attempt(tmp_path) -> N
 
     lock._try_acquire_once = try_acquire_once
 
+    started_at = time.monotonic()
     with pytest.raises(OAuthLockTimeout):
         lock.acquire()
+    elapsed = time.monotonic() - started_at
 
     assert attempts == 1
+    assert elapsed < 0.05
     assert lock._handle is None
 
 
@@ -1914,22 +1923,22 @@ def test_oauth_event_metadata_is_immutable_snapshot() -> None:
 
     assert event.metadata == {
         "source": "oauth-cache",
-        "nested": {"safe": "value"},
-        "items": ("first",),
     }
     assert "token" not in event.metadata
+    assert "nested" not in event.metadata
+    assert "items" not in event.metadata
     with pytest.raises(TypeError):
         event.metadata["token"] = "secret"
-    with pytest.raises(TypeError):
-        event.metadata["nested"]["safe"] = "mutated"
 
 
-def test_oauth_event_metadata_redacts_token_fields_recursively() -> None:
+def test_oauth_event_metadata_redacts_sensitive_fields_and_drops_unknowns() -> None:
     event = OAuthEvent(
         type="oauth.provider.debug",
         operation_id="op-1",
         metadata={
             "access_token": "raw-access-token",
+            "authorization": "Bearer raw-access-token",
+            "client_secret": "raw-client-secret",
             "nested": {
                 "refresh_token": "raw-refresh-token",
                 "safe": "value",
@@ -1951,13 +1960,52 @@ def test_oauth_event_metadata_redacts_token_fields_recursively() -> None:
     )
 
     assert event.metadata["access_token"] == "<redacted>"
-    assert event.metadata["nested"]["refresh_token"] == "<redacted>"
-    assert event.metadata["nested"]["safe"] == "value"
-    assert event.metadata["items"][0]["token"] == "<redacted>"
-    assert event.metadata["items"][0]["label"] == "kept"
-    assert event.metadata["tuple_items"][0]["id_token"] == "<redacted>"
-    assert event.metadata["tuple_items"][0]["audience"] == "kept"
-    assert event.metadata["set_items"] == frozenset({"safe"})
+    assert event.metadata["authorization"] == "<redacted>"
+    assert event.metadata["client_secret"] == "<redacted>"
+    assert "nested" not in event.metadata
+    assert "items" not in event.metadata
+    assert "tuple_items" not in event.metadata
+    assert "set_items" not in event.metadata
+
+
+def test_oauth_event_sanitizes_external_message_and_authorization_metadata() -> None:
+    raw_token = "raw-access-token"
+
+    event = OAuthEvent(
+        type="oauth.provider.debug",
+        operation_id="op-1",
+        message=raw_token,
+        metadata={
+            "authorization": raw_token,
+            "debug": raw_token,
+            "source": raw_token,
+        },
+    )
+
+    assert event.message == "<redacted>"
+    assert event.metadata["authorization"] == "<redacted>"
+    assert event.metadata["source"] == "<redacted>"
+    assert "debug" not in event.metadata
+
+
+def test_oauth_event_preserves_safe_lifecycle_message_and_metadata() -> None:
+    event = OAuthEvent(
+        type="oauth.resolve.succeeded",
+        operation_id="op-1",
+        message="OAuth credential resolved.",
+        metadata={
+            "source": "OAUTH_ACCESS_TOKEN",
+            "phase": "storage",
+            "secret_key": "oauth_google_demo_access_token",
+        },
+    )
+
+    assert event.message == "OAuth credential resolved."
+    assert event.metadata == {
+        "source": "OAUTH_ACCESS_TOKEN",
+        "phase": "storage",
+        "secret_key": "oauth_google_demo_access_token",
+    }
 
 
 def test_queued_oauth_event_sink_drops_new_events_when_full() -> None:

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -725,6 +725,35 @@ def test_oauth_manager_reads_legacy_secret_key(monkeypatch, tmp_path) -> None:
     assert credential.source == "keyring:demo_legacy_access_token"
 
 
+@pytest.mark.parametrize(
+    ("scope", "expected_source"),
+    [
+        ("env", "env:DEMO_LEGACY_ACCESS_TOKEN"),
+        ("project", "project:demo_legacy_access_token"),
+    ],
+)
+def test_oauth_manager_reports_legacy_secret_source_scope(
+    monkeypatch,
+    tmp_path,
+    scope,
+    expected_source,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = FakeSecretManager()
+    secrets.scoped_values[
+        (scope, "titan", "demo_legacy_access_token")
+    ] = " legacy-token "
+    sink = CollectingOAuthEventSink()
+    manager = _manager(secrets, tmp_path)
+
+    credential = asyncio.run(manager.get_credential(_request(), sink=sink))
+
+    assert credential.access_token == "legacy-token"
+    assert credential.source == expected_source
+    assert sink.events[-1].type == "oauth.resolve.succeeded"
+    assert dict(sink.events[-1].metadata) == {"source": expected_source}
+
+
 def test_oauth_manager_respects_legacy_secret_key_precedence(
     monkeypatch,
     tmp_path,

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -246,6 +246,16 @@ def test_oauth_token_set_normalizes_scalar_scope() -> None:
     assert token_set.scopes == ("openid",)
 
 
+def test_oauth_token_set_normalizes_string_expires_at() -> None:
+    token_set = OAuthTokenSet(
+        access_token="access-token",
+        expires_at="9999999999",
+    )
+
+    assert token_set.expires_at == 9999999999
+    assert token_set.is_valid(now=0, refresh_margin_seconds=0)
+
+
 @pytest.mark.parametrize("access_token", ["", "   "])
 def test_oauth_token_set_rejects_empty_access_token(access_token: str) -> None:
     with pytest.raises(ValueError, match="access_token"):
@@ -255,6 +265,15 @@ def test_oauth_token_set_rejects_empty_access_token(access_token: str) -> None:
 def test_oauth_token_set_rejects_non_string_access_token() -> None:
     with pytest.raises(ValueError, match="access_token"):
         OAuthTokenSet(access_token=123)
+
+
+@pytest.mark.parametrize(
+    "expires_at",
+    [True, False, 123.45, "123.45", "", "   ", object()],
+)
+def test_oauth_token_set_rejects_invalid_expires_at(expires_at: object) -> None:
+    with pytest.raises(ValueError, match="expires_at"):
+        OAuthTokenSet(access_token="access-token", expires_at=expires_at)
 
 
 def test_oauth_token_set_from_dict_rejects_non_string_refresh_token() -> None:
@@ -273,6 +292,30 @@ def test_oauth_token_set_from_dict_rejects_non_string_scope_element() -> None:
             {
                 "access_token": "access-token",
                 "scopes": ["openid", 123],
+            }
+        )
+
+
+def test_oauth_token_set_from_dict_normalizes_string_expires_at() -> None:
+    token_set = OAuthTokenSet.from_dict(
+        {
+            "access_token": "access-token",
+            "expires_at": "9999999999",
+        }
+    )
+
+    assert token_set.expires_at == 9999999999
+
+
+@pytest.mark.parametrize("expires_at", [True, False, 123.45, "123.45"])
+def test_oauth_token_set_from_dict_rejects_invalid_expires_at(
+    expires_at: object,
+) -> None:
+    with pytest.raises(ValueError, match="expires_at"):
+        OAuthTokenSet.from_dict(
+            {
+                "access_token": "access-token",
+                "expires_at": expires_at,
             }
         )
 

--- a/tests/core/test_oauth_manager.py
+++ b/tests/core/test_oauth_manager.py
@@ -22,6 +22,7 @@ from titan_cli.core.oauth import (
     OAuthTokenSet,
     OAuthTokenStore,
     QueuedOAuthEventSink,
+    build_oauth_credential_key,
 )
 from titan_cli.core.secrets import ResolvedSecret
 
@@ -49,6 +50,14 @@ class FakeSecretManager:
             if scoped_key in self.scoped_values:
                 return ResolvedSecret(self.scoped_values[scoped_key], scope)
         return None
+
+    def get_from_scope(
+        self,
+        key: str,
+        namespace: str = "titan",
+        scope: str = "user",
+    ) -> str | None:
+        return self.scoped_values.get((scope, namespace, key))
 
     def set(
         self,
@@ -84,6 +93,11 @@ class FailingDeleteSecretManager(FakeSecretManager):
     def delete(self, key: str, namespace: str = "titan", scope: str = "user") -> None:
         self.delete_calls.append((key, scope))
         raise RuntimeError("project secrets unavailable")
+
+
+class SwallowingDeleteSecretManager(FakeSecretManager):
+    def delete(self, key: str, namespace: str = "titan", scope: str = "user") -> None:
+        self.delete_calls.append((key, scope))
 
 
 def _manager(
@@ -160,6 +174,51 @@ def test_oauth_request_normalizes_scalar_scope_and_legacy_secret_key() -> None:
 
     assert request.scopes == ("openid",)
     assert request.legacy_secret_keys == ("legacy_access_token",)
+
+
+def test_oauth_request_normalizes_storage_context() -> None:
+    request = OAuthRequest(
+        provider="google",
+        connection_id="sample:demo",
+        storage_context="  /workspace/ragnarok-ios  ",
+    )
+
+    assert request.storage_context == "/workspace/ragnarok-ios"
+
+
+def test_oauth_storage_context_partitions_credential_key() -> None:
+    global_request = _request(storage_context=None)
+    ragnarok_request = _request(storage_context="/workspace/ragnarok-ios")
+    other_project_request = _request(storage_context="/workspace/other-ios")
+
+    global_key = build_oauth_credential_key(global_request)
+    ragnarok_key = build_oauth_credential_key(ragnarok_request)
+    other_project_key = build_oauth_credential_key(other_project_request)
+
+    assert global_key != ragnarok_key
+    assert ragnarok_key != other_project_key
+
+
+def test_oauth_storage_context_partitions_user_scope_storage() -> None:
+    secrets = FakeSecretManager()
+    store = OAuthTokenStore(secrets)
+    ragnarok_request = _request(storage_context="/workspace/ragnarok-ios")
+    other_project_request = _request(storage_context="/workspace/other-ios")
+
+    ragnarok_key = store.write(
+        ragnarok_request,
+        OAuthTokenSet(access_token="ragnarok-token"),
+        scope="user",
+    )
+    other_project_key = store.write(
+        other_project_request,
+        OAuthTokenSet(access_token="other-token"),
+        scope="user",
+    )
+
+    assert ragnarok_key != other_project_key
+    assert json.loads(secrets.values[ragnarok_key])["access_token"] == "ragnarok-token"
+    assert json.loads(secrets.values[other_project_key])["access_token"] == "other-token"
 
 
 def test_oauth_token_set_normalizes_scalar_scope() -> None:
@@ -838,6 +897,56 @@ def test_oauth_manager_invalid_token_delete_failure_emits_storage_failure(
     assert dict(sink.events[-1].metadata) == {"phase": "storage"}
 
 
+def test_oauth_manager_invalid_token_delete_must_remove_before_stale_deleted(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
+    secrets = SwallowingDeleteSecretManager(
+        {"demo_legacy_access_token": " legacy-token "},
+    )
+    request = _request(interactive=False)
+    store = OAuthTokenStore(secrets)
+    old_secret_key = store.write(
+        request,
+        OAuthTokenSet(
+            access_token="expired-oauth-token",
+            refresh_token="revoked-refresh-token",
+            expires_at=1,
+        ),
+        scope="user",
+    )
+
+    class InvalidTokenProvider:
+        async def refresh(self, request, token_set, sink):
+            raise OAuthTokenInvalidError("refresh token revoked")
+
+        async def authorize(self, request, sink):
+            raise AssertionError("authorize should not run")
+
+    sink = CollectingOAuthEventSink()
+    manager = OAuthManager(
+        secrets,
+        providers={"google": InvalidTokenProvider()},
+        token_store=store,
+        lock_manager=OAuthLockManager(lock_dir=tmp_path, enable_file_locks=False),
+    )
+
+    with pytest.raises(OAuthStorageError, match="was not deleted"):
+        asyncio.run(manager.get_credential(request, sink=sink))
+
+    assert secrets.delete_calls[-1] == (old_secret_key, "user")
+    assert ("user", "titan", old_secret_key) in secrets.scoped_values
+    assert [event.type for event in sink.events] == [
+        "oauth.resolve.started",
+        "oauth.lock.acquired",
+        "oauth.refresh.started",
+        "oauth.refresh.failed",
+        "oauth.refresh.failed",
+    ]
+    assert dict(sink.events[-1].metadata) == {"phase": "storage"}
+
+
 def test_oauth_manager_raises_when_no_credential(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("OAUTH_ACCESS_TOKEN", raising=False)
     manager = _manager(FakeSecretManager(), tmp_path)
@@ -1401,6 +1510,23 @@ def test_oauth_token_store_wraps_secret_delete_errors() -> None:
     assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
+def test_oauth_token_store_requires_delete_postcondition() -> None:
+    secrets = SwallowingDeleteSecretManager()
+    store = OAuthTokenStore(secrets)
+    request = _request()
+    secret_key = store.write(
+        request,
+        OAuthTokenSet(access_token="manual-token"),
+        scope="user",
+    )
+
+    with pytest.raises(OAuthStorageError, match="was not deleted"):
+        store.delete(request, scope="user")
+
+    assert secrets.delete_calls[-1] == (secret_key, "user")
+    assert ("user", "titan", secret_key) in secrets.scoped_values
+
+
 def test_oauth_token_store_wraps_invalid_scope_without_writing() -> None:
     secrets = FakeSecretManager()
     store = OAuthTokenStore(secrets)
@@ -1484,6 +1610,48 @@ def test_oauth_lock_file_lock_uses_remaining_timeout(
 
     assert captured_timeouts
     assert 0 < captured_timeouts[0] < 0.5
+
+
+def test_file_lock_timeout_zero_attempts_uncontended_lock_once(tmp_path) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=0,
+        poll_interval_seconds=0.1,
+    )
+    attempts = 0
+
+    def try_acquire_once() -> None:
+        nonlocal attempts
+        attempts += 1
+
+    lock._try_acquire_once = try_acquire_once
+
+    lock.acquire()
+
+    assert attempts == 1
+    lock.release()
+
+
+def test_file_lock_timeout_zero_times_out_after_contended_attempt(tmp_path) -> None:
+    lock = oauth_locks._FileLock(
+        tmp_path / "oauth.lock",
+        timeout_seconds=0,
+        poll_interval_seconds=0.1,
+    )
+    attempts = 0
+
+    def try_acquire_once() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise BlockingIOError(errno.EAGAIN, "resource temporarily unavailable")
+
+    lock._try_acquire_once = try_acquire_once
+
+    with pytest.raises(OAuthLockTimeout):
+        lock.acquire()
+
+    assert attempts == 1
+    assert lock._handle is None
 
 
 def test_file_lock_retries_lock_contention_error(tmp_path) -> None:

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -144,6 +144,31 @@ def test_project_scope_updates_process_env_when_it_mirrors_project(
     assert resolved.scope == "project"
 
 
+def test_project_scope_updates_stay_coherent_across_instances(
+    tmp_project_path,
+    mock_env,
+):
+    first = SecretManager(project_path=tmp_project_path)
+    second = SecretManager(project_path=tmp_project_path)
+
+    first.set("project_token", "first_value", scope="project")
+    second.set("project_token", "final_value", scope="project")
+
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    assert "PROJECT_TOKEN='final_value'" in secrets_file.read_text()
+    assert os.environ["PROJECT_TOKEN"] == "final_value"
+
+    first_resolved = first.get_with_scope("project_token")
+    second_resolved = second.get_with_scope("project_token")
+
+    assert first_resolved is not None
+    assert first_resolved.value == "final_value"
+    assert first_resolved.scope == "project"
+    assert second_resolved is not None
+    assert second_resolved.value == "final_value"
+    assert second_resolved.scope == "project"
+
+
 def test_project_scope_does_not_update_real_env_even_when_values_match(
     tmp_project_path,
     mock_env,

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -4,11 +4,13 @@ import os
 
 from titan_cli.core.secrets import SecretManager
 
+
 # Fixture for a temporary project path
 @pytest.fixture
 def tmp_project_path(tmp_path):
     (tmp_path / ".titan").mkdir()
     return tmp_path
+
 
 # Fixture for mocking os.environ
 @pytest.fixture
@@ -16,19 +18,24 @@ def mock_env():
     with patch.dict(os.environ, clear=True):
         yield
 
+
 # Fixture for mocking keyring
 @pytest.fixture
 def mock_keyring():
-    with patch('keyring.get_password') as mock_get, \
-         patch('keyring.set_password') as mock_set, \
-         patch('keyring.delete_password') as mock_delete:
+    with (
+        patch("keyring.get_password") as mock_get,
+        patch("keyring.set_password") as mock_set,
+        patch("keyring.delete_password") as mock_delete,
+    ):
         yield mock_get, mock_set, mock_delete
+
 
 # Fixture for mocking dotenv
 @pytest.fixture
 def mock_dotenv():
-    with patch('titan_cli.core.secrets.load_dotenv') as mock_load:
+    with patch("titan_cli.core.secrets.load_dotenv") as mock_load:
         yield mock_load
+
 
 # --- Test SecretManager initialization and project secret loading ---
 def test_secret_manager_init_loads_project_secrets(tmp_project_path, mock_dotenv):
@@ -37,16 +44,19 @@ def test_secret_manager_init_loads_project_secrets(tmp_project_path, mock_dotenv
     SecretManager(project_path=tmp_project_path)
     mock_dotenv.assert_called_once_with(secrets_file)
 
+
 def test_secret_manager_init_no_project_secrets_file(tmp_project_path, mock_dotenv):
     SecretManager(project_path=tmp_project_path)
     mock_dotenv.assert_not_called()
+
 
 # --- Test get method ---
 def test_get_from_env(mock_env, mock_keyring):
     os.environ["MY_ENV_SECRET"] = "env_value"
     sm = SecretManager()
     assert sm.get("my_env_secret") == "env_value"
-    mock_keyring[0].assert_not_called() # keyring.get_password
+    mock_keyring[0].assert_not_called()  # keyring.get_password
+
 
 def test_get_from_keyring(mock_env, mock_keyring):
     mock_keyring[0].return_value = "keyring_value"
@@ -54,10 +64,12 @@ def test_get_from_keyring(mock_env, mock_keyring):
     assert sm.get("my_keyring_secret") == "keyring_value"
     mock_keyring[0].assert_called_once_with("titan", "my_keyring_secret")
 
+
 def test_get_none_if_not_found(mock_env, mock_keyring):
     mock_keyring[0].return_value = None
     sm = SecretManager()
     assert sm.get("non_existent_secret") is None
+
 
 def test_get_priority_env_over_keyring(mock_env, mock_keyring):
     os.environ["SHARED_SECRET"] = "env_value"
@@ -66,11 +78,74 @@ def test_get_priority_env_over_keyring(mock_env, mock_keyring):
     assert sm.get("shared_secret") == "env_value"
     mock_keyring[0].assert_not_called()
 
+
+def test_get_with_scope_identifies_project_secret(
+    tmp_project_path,
+    mock_env,
+    mock_keyring,
+):
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    resolved = sm.get_with_scope("project_token")
+
+    assert resolved is not None
+    assert resolved.value == "project_value"
+    assert resolved.scope == "project"
+    mock_keyring[0].assert_not_called()
+
+
+def test_get_with_scope_keeps_real_env_over_project_secret(
+    tmp_project_path,
+    mock_env,
+):
+    os.environ["PROJECT_TOKEN"] = "env_value"
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    resolved = sm.get_with_scope("project_token")
+
+    assert resolved is not None
+    assert resolved.value == "env_value"
+    assert resolved.scope == "env"
+
+
+def test_project_scope_updates_process_env_when_it_mirrors_project(
+    tmp_project_path,
+    mock_env,
+):
+    sm = SecretManager(project_path=tmp_project_path)
+
+    sm.set("project_token", "old_value", scope="project")
+    sm.set("project_token", "new_value", scope="project")
+
+    assert os.environ["PROJECT_TOKEN"] == "new_value"
+    resolved = sm.get_with_scope("project_token")
+    assert resolved is not None
+    assert resolved.value == "new_value"
+    assert resolved.scope == "project"
+
+
+def test_project_scope_delete_clears_process_env_when_it_mirrors_project(
+    tmp_project_path,
+    mock_env,
+):
+    sm = SecretManager(project_path=tmp_project_path)
+
+    sm.set("project_token", "project_value", scope="project")
+    sm.delete("project_token", scope="project")
+
+    assert "PROJECT_TOKEN" not in os.environ
+
+
 # --- Test set method ---
 def test_set_env_scope(mock_env):
     sm = SecretManager()
     sm.set("my_temp_secret", "temp_value", scope="env")
     assert os.environ["MY_TEMP_SECRET"] == "temp_value"
+
 
 def test_set_user_scope(mock_keyring):
     sm = SecretManager()
@@ -87,34 +162,38 @@ def test_set_user_scope_raises_when_keyring_write_fails(mock_keyring, tmp_projec
 
     assert not (tmp_project_path / ".titan" / "secrets.env").exists()
 
+
 def test_set_project_scope_new_secret(tmp_project_path):
     sm = SecretManager(project_path=tmp_project_path)
     sm.set("my_project_secret", "project_value", scope="project")
-    
+
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     assert secrets_file.exists()
     with open(secrets_file, "r") as f:
         content = f.read()
     assert "MY_PROJECT_SECRET='project_value'" in content
 
+
 def test_set_project_scope_update_secret(tmp_project_path):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("EXISTING_SECRET='old_value'\nOTHER_KEY='other_value'\n")
-    
+
     sm = SecretManager(project_path=tmp_project_path)
     sm.set("existing_secret", "new_value", scope="project")
-    
+
     with open(secrets_file, "r") as f:
         content = f.read()
     assert "EXISTING_SECRET='new_value'" in content
     assert "OTHER_KEY='other_value'" in content
     assert "EXISTING_SECRET='old_value'" not in content
 
+
 def test_set_project_scope_creates_dir_if_not_exists(tmp_path):
     project_path = tmp_path / "new_project"
     sm = SecretManager(project_path=project_path)
     sm.set("new_secret", "value", scope="project")
     assert (project_path / ".titan" / "secrets.env").exists()
+
 
 # --- Test delete method ---
 def test_delete_env_scope(mock_env):
@@ -123,30 +202,33 @@ def test_delete_env_scope(mock_env):
     sm.delete("to_delete", scope="env")
     assert "TO_DELETE" not in os.environ
 
+
 def test_delete_user_scope(mock_keyring):
     sm = SecretManager()
     sm.delete("to_delete", scope="user")
     mock_keyring[2].assert_called_once_with("titan", "to_delete")
 
+
 def test_delete_project_scope(tmp_project_path):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("TO_DELETE='value'\nOTHER_KEY='other_value'\n")
-    
+
     sm = SecretManager(project_path=tmp_project_path)
     sm.delete("to_delete", scope="project")
-    
+
     with open(secrets_file, "r") as f:
         content = f.read()
     assert "TO_DELETE" not in content
     assert "OTHER_KEY='other_value'" in content
 
+
 def test_delete_project_scope_secret_not_found(tmp_project_path):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("OTHER_KEY='other_value'\n")
-    
+
     sm = SecretManager(project_path=tmp_project_path)
     sm.delete("non_existent", scope="project")
-    
+
     with open(secrets_file, "r") as f:
         content = f.read()
-    assert "OTHER_KEY='other_value'" in content # Content should be unchanged
+    assert "OTHER_KEY='other_value'" in content  # Content should be unchanged

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -112,6 +112,22 @@ def test_get_with_scope_keeps_real_env_over_project_secret(
     assert resolved.scope == "env"
 
 
+def test_get_with_scope_keeps_real_env_when_value_matches_project_secret(
+    tmp_project_path,
+    mock_env,
+):
+    os.environ["PROJECT_TOKEN"] = "same_value"
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='same_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    resolved = sm.get_with_scope("project_token")
+
+    assert resolved is not None
+    assert resolved.value == "same_value"
+    assert resolved.scope == "env"
+
+
 def test_project_scope_updates_process_env_when_it_mirrors_project(
     tmp_project_path,
     mock_env,
@@ -128,6 +144,24 @@ def test_project_scope_updates_process_env_when_it_mirrors_project(
     assert resolved.scope == "project"
 
 
+def test_project_scope_does_not_update_real_env_even_when_values_match(
+    tmp_project_path,
+    mock_env,
+):
+    os.environ["PROJECT_TOKEN"] = "same_value"
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='same_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    sm.set("project_token", "new_project_value", scope="project")
+
+    assert os.environ["PROJECT_TOKEN"] == "same_value"
+    resolved = sm.get_with_scope("project_token")
+    assert resolved is not None
+    assert resolved.value == "same_value"
+    assert resolved.scope == "env"
+
+
 def test_project_scope_delete_clears_process_env_when_it_mirrors_project(
     tmp_project_path,
     mock_env,
@@ -138,6 +172,21 @@ def test_project_scope_delete_clears_process_env_when_it_mirrors_project(
     sm.delete("project_token", scope="project")
 
     assert "PROJECT_TOKEN" not in os.environ
+
+
+def test_project_scope_delete_keeps_real_env_even_when_values_match(
+    tmp_project_path,
+    mock_env,
+):
+    os.environ["PROJECT_TOKEN"] = "same_value"
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='same_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    sm.delete("project_token", scope="project")
+
+    assert os.environ["PROJECT_TOKEN"] == "same_value"
+    assert sm.get_with_scope("project_token").scope == "env"
 
 
 # --- Test set method ---

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -207,6 +207,67 @@ def test_project_scope_updates_stay_coherent_across_instances(
     assert second_resolved.scope == "project"
 
 
+def test_project_env_injection_does_not_leak_between_projects(
+    tmp_path,
+    mock_env,
+):
+    first_project = tmp_path / "first"
+    second_project = tmp_path / "second"
+    (first_project / ".titan").mkdir(parents=True)
+    (second_project / ".titan").mkdir(parents=True)
+    (first_project / ".titan" / "secrets.env").write_text(
+        "SHARED_TOKEN='first_value'\n"
+    )
+    (second_project / ".titan" / "secrets.env").write_text(
+        "SHARED_TOKEN='second_value'\n"
+    )
+
+    first = SecretManager(project_path=first_project)
+    assert os.environ["SHARED_TOKEN"] == "first_value"
+    second = SecretManager(project_path=second_project)
+
+    first_resolved = first.get_with_scope("shared_token")
+    second_resolved = second.get_with_scope("shared_token")
+
+    assert first_resolved is not None
+    assert first_resolved.value == "first_value"
+    assert first_resolved.scope == "project"
+    assert second_resolved is not None
+    assert second_resolved.value == "second_value"
+    assert second_resolved.scope == "project"
+
+
+def test_project_scope_update_does_not_make_other_project_read_wrong_secret(
+    tmp_path,
+    mock_env,
+):
+    first_project = tmp_path / "first"
+    second_project = tmp_path / "second"
+    (first_project / ".titan").mkdir(parents=True)
+    (second_project / ".titan").mkdir(parents=True)
+    (first_project / ".titan" / "secrets.env").write_text(
+        "SHARED_TOKEN='first_value'\n"
+    )
+    (second_project / ".titan" / "secrets.env").write_text(
+        "SHARED_TOKEN='second_value'\n"
+    )
+
+    first = SecretManager(project_path=first_project)
+    second = SecretManager(project_path=second_project)
+
+    second.set("shared_token", "second_updated", scope="project")
+    first_resolved = first.get_with_scope("shared_token")
+    second_resolved = second.get_with_scope("shared_token")
+
+    assert os.environ["SHARED_TOKEN"] == "second_updated"
+    assert first_resolved is not None
+    assert first_resolved.value == "first_value"
+    assert first_resolved.scope == "project"
+    assert second_resolved is not None
+    assert second_resolved.value == "second_updated"
+    assert second_resolved.scope == "project"
+
+
 def test_project_scope_writes_are_serialized_across_instances(
     tmp_project_path,
     mock_env,

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import patch
 import os
+import threading
+import time
 
 from titan_cli.core.secrets import SecretManager
 
@@ -167,6 +169,74 @@ def test_project_scope_updates_stay_coherent_across_instances(
     assert second_resolved is not None
     assert second_resolved.value == "final_value"
     assert second_resolved.scope == "project"
+
+
+def test_project_scope_writes_are_serialized_across_instances(
+    tmp_project_path,
+    mock_env,
+    monkeypatch,
+):
+    first = SecretManager(project_path=tmp_project_path)
+    second = SecretManager(project_path=tmp_project_path)
+    first_write_entered = threading.Event()
+    release_first_write = threading.Event()
+    second_write_started = threading.Event()
+    errors: list[BaseException] = []
+    original_write = SecretManager._write_project_secret_lines_atomic
+
+    def delayed_first_write(self, secrets_file, lines):
+        if (
+            not first_write_entered.is_set()
+            and any(line.startswith("FIRST_TOKEN=") for line in lines)
+        ):
+            first_write_entered.set()
+            release_first_write.wait(timeout=2)
+        return original_write(self, secrets_file, lines)
+
+    def record_errors(action):
+        try:
+            action()
+        except BaseException as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(
+        SecretManager,
+        "_write_project_secret_lines_atomic",
+        delayed_first_write,
+    )
+
+    first_thread = threading.Thread(
+        target=lambda: record_errors(
+            lambda: first.set("first_token", "first_value", scope="project"),
+        ),
+    )
+    first_thread.start()
+    assert first_write_entered.wait(timeout=2)
+
+    def write_second_secret():
+        second_write_started.set()
+        second.set("second_token", "second_value", scope="project")
+
+    second_thread = threading.Thread(
+        target=lambda: record_errors(write_second_secret),
+    )
+    second_thread.start()
+    assert second_write_started.wait(timeout=2)
+    time.sleep(0.05)
+    assert second_thread.is_alive()
+    release_first_write.set()
+
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert errors == []
+
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    content = secrets_file.read_text()
+    assert "FIRST_TOKEN='first_value'" in content
+    assert "SECOND_TOKEN='second_value'" in content
 
 
 def test_project_scope_does_not_update_real_env_even_when_values_match(

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -130,6 +130,23 @@ def test_get_with_scope_keeps_real_env_when_value_matches_project_secret(
     assert resolved.scope == "env"
 
 
+def test_get_from_scope_reads_exact_scope(
+    tmp_project_path,
+    mock_env,
+    mock_keyring,
+):
+    os.environ["PROJECT_TOKEN"] = "env_value"
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+    mock_keyring[0].return_value = "user_value"
+
+    sm = SecretManager(project_path=tmp_project_path)
+
+    assert sm.get_from_scope("project_token", scope="env") == "env_value"
+    assert sm.get_from_scope("project_token", scope="project") == "project_value"
+    assert sm.get_from_scope("project_token", scope="user") == "user_value"
+
+
 def test_project_scope_updates_process_env_when_it_mirrors_project(
     tmp_project_path,
     mock_env,

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -130,6 +130,25 @@ def test_get_with_scope_keeps_real_env_when_value_matches_project_secret(
     assert resolved.scope == "env"
 
 
+def test_get_with_scope_keeps_runtime_env_override_after_project_injection(
+    tmp_project_path,
+    mock_env,
+):
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    assert os.environ["PROJECT_TOKEN"] == "project_value"
+
+    os.environ["PROJECT_TOKEN"] = "cli_value"
+    resolved = sm.get_with_scope("project_token")
+
+    assert os.environ["PROJECT_TOKEN"] == "cli_value"
+    assert resolved is not None
+    assert resolved.value == "cli_value"
+    assert resolved.scope == "env"
+
+
 def test_get_from_scope_reads_exact_scope(
     tmp_project_path,
     mock_env,
@@ -271,6 +290,27 @@ def test_project_scope_does_not_update_real_env_even_when_values_match(
     resolved = sm.get_with_scope("project_token")
     assert resolved is not None
     assert resolved.value == "same_value"
+    assert resolved.scope == "env"
+
+
+def test_project_scope_update_keeps_runtime_env_override_after_project_injection(
+    tmp_project_path,
+    mock_env,
+):
+    secrets_file = tmp_project_path / ".titan" / "secrets.env"
+    secrets_file.write_text("PROJECT_TOKEN='project_value'\n")
+
+    sm = SecretManager(project_path=tmp_project_path)
+    assert os.environ["PROJECT_TOKEN"] == "project_value"
+
+    os.environ["PROJECT_TOKEN"] = "cli_value"
+    sm.set("project_token", "new_project_value", scope="project")
+
+    assert os.environ["PROJECT_TOKEN"] == "cli_value"
+    assert "PROJECT_TOKEN='new_project_value'" in secrets_file.read_text()
+    resolved = sm.get_with_scope("project_token")
+    assert resolved is not None
+    assert resolved.value == "cli_value"
     assert resolved.scope == "env"
 
 

--- a/tests/core/test_secrets.py
+++ b/tests/core/test_secrets.py
@@ -425,7 +425,7 @@ def test_set_user_scope_raises_when_keyring_write_fails(mock_keyring, tmp_projec
     assert not (tmp_project_path / ".titan" / "secrets.env").exists()
 
 
-def test_set_project_scope_new_secret(tmp_project_path):
+def test_set_project_scope_new_secret(tmp_project_path, mock_env):
     sm = SecretManager(project_path=tmp_project_path)
     sm.set("my_project_secret", "project_value", scope="project")
 
@@ -436,7 +436,7 @@ def test_set_project_scope_new_secret(tmp_project_path):
     assert "MY_PROJECT_SECRET='project_value'" in content
 
 
-def test_set_project_scope_update_secret(tmp_project_path):
+def test_set_project_scope_update_secret(tmp_project_path, mock_env):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("EXISTING_SECRET='old_value'\nOTHER_KEY='other_value'\n")
 
@@ -450,7 +450,7 @@ def test_set_project_scope_update_secret(tmp_project_path):
     assert "EXISTING_SECRET='old_value'" not in content
 
 
-def test_set_project_scope_creates_dir_if_not_exists(tmp_path):
+def test_set_project_scope_creates_dir_if_not_exists(tmp_path, mock_env):
     project_path = tmp_path / "new_project"
     sm = SecretManager(project_path=project_path)
     sm.set("new_secret", "value", scope="project")
@@ -471,7 +471,7 @@ def test_delete_user_scope(mock_keyring):
     mock_keyring[2].assert_called_once_with("titan", "to_delete")
 
 
-def test_delete_project_scope(tmp_project_path):
+def test_delete_project_scope(tmp_project_path, mock_env):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("TO_DELETE='value'\nOTHER_KEY='other_value'\n")
 
@@ -484,7 +484,7 @@ def test_delete_project_scope(tmp_project_path):
     assert "OTHER_KEY='other_value'" in content
 
 
-def test_delete_project_scope_secret_not_found(tmp_project_path):
+def test_delete_project_scope_secret_not_found(tmp_project_path, mock_env):
     secrets_file = tmp_project_path / ".titan" / "secrets.env"
     secrets_file.write_text("OTHER_KEY='other_value'\n")
 

--- a/titan_cli/core/oauth/__init__.py
+++ b/titan_cli/core/oauth/__init__.py
@@ -1,0 +1,53 @@
+"""OAuth coordination primitives for Titan plugins."""
+
+from .events import (
+    CollectingOAuthEventSink,
+    NullOAuthEventSink,
+    OAuthEvent,
+    OAuthEventSink,
+    QueuedOAuthEventSink,
+)
+from .exceptions import (
+    OAuthAuthenticationRequired,
+    OAuthAuthorizationError,
+    OAuthError,
+    OAuthLockTimeout,
+    OAuthProviderNotFound,
+    OAuthStorageError,
+    OAuthTokenInvalidError,
+    OAuthTokenRefreshError,
+)
+from .locks import OAuthHeldLock, OAuthLockManager
+from .manager import OAuthManager, OAuthProvider
+from .models import (
+    OAuthCredential,
+    OAuthRequest,
+    OAuthTokenSet,
+    build_oauth_credential_key,
+)
+from .storage import OAuthTokenStore
+
+__all__ = [
+    "CollectingOAuthEventSink",
+    "NullOAuthEventSink",
+    "OAuthAuthenticationRequired",
+    "OAuthAuthorizationError",
+    "OAuthCredential",
+    "OAuthError",
+    "OAuthEvent",
+    "OAuthEventSink",
+    "OAuthHeldLock",
+    "OAuthLockManager",
+    "OAuthManager",
+    "OAuthProvider",
+    "OAuthProviderNotFound",
+    "OAuthRequest",
+    "OAuthStorageError",
+    "OAuthTokenInvalidError",
+    "OAuthTokenRefreshError",
+    "OAuthTokenSet",
+    "OAuthTokenStore",
+    "OAuthLockTimeout",
+    "QueuedOAuthEventSink",
+    "build_oauth_credential_key",
+]

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -83,6 +83,8 @@ class QueuedOAuthEventSink:
     ) -> OAuthEvent | None:
         """Return the next queued event, or None when no event is available."""
         try:
+            if not block:
+                return self.queue.get(block=False)
             return self.queue.get(block=block, timeout=timeout)
         except Empty:
             return None

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -9,6 +9,8 @@ from threading import Lock
 from types import MappingProxyType
 from typing import Any, Protocol
 
+REDACTED_METADATA_VALUE = "<redacted>"
+
 
 @dataclass(frozen=True)
 class OAuthEvent:
@@ -108,17 +110,34 @@ def _freeze_metadata(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
     """Return an immutable metadata snapshot for emitted events."""
     if not value:
         return MappingProxyType({})
-    return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    return MappingProxyType(
+        {
+            key: REDACTED_METADATA_VALUE
+            if _is_sensitive_metadata_key(key)
+            else _freeze_value(item)
+            for key, item in value.items()
+        }
+    )
 
 
 def _freeze_value(value: Any) -> Any:
     """Recursively freeze common mutable containers."""
     if isinstance(value, Mapping):
         return MappingProxyType(
-            {key: _freeze_value(item) for key, item in value.items()}
+            {
+                key: REDACTED_METADATA_VALUE
+                if _is_sensitive_metadata_key(key)
+                else _freeze_value(item)
+                for key, item in value.items()
+            }
         )
     if isinstance(value, list | tuple):
         return tuple(_freeze_value(item) for item in value)
     if isinstance(value, set | frozenset):
         return frozenset(_freeze_value(item) for item in value)
     return value
+
+
+def _is_sensitive_metadata_key(key: object) -> bool:
+    """Return whether a metadata key may carry OAuth token material."""
+    return "token" in str(key).lower()

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -1,0 +1,97 @@
+"""Provider-neutral OAuth events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from queue import Empty, Full, Queue
+from threading import Lock
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class OAuthEvent:
+    """A safe OAuth lifecycle event.
+
+    Events must never include raw access tokens or refresh tokens.
+    """
+
+    type: str
+    operation_id: str
+    credential_key: str | None = None
+    provider: str | None = None
+    connection_id: str | None = None
+    message: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class OAuthEventSink(Protocol):
+    """Receives OAuth lifecycle events."""
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Handle an OAuth event."""
+
+
+class NullOAuthEventSink:
+    """Event sink that intentionally discards every OAuth event."""
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Discard an OAuth event."""
+
+
+class CollectingOAuthEventSink:
+    """Event sink useful for tests and headless callers."""
+
+    def __init__(self) -> None:
+        self.events: list[OAuthEvent] = []
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Record an OAuth event."""
+        self.events.append(event)
+
+
+class QueuedOAuthEventSink:
+    """Thread-safe queue-backed sink for runtime event dispatchers."""
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self.queue: Queue[OAuthEvent] = Queue(maxsize=maxsize)
+        self._dropped_count = 0
+        self._dropped_count_lock = Lock()
+
+    def emit(self, event: OAuthEvent) -> None:
+        """Queue an OAuth event without allowing overflow to abort OAuth."""
+        try:
+            self.queue.put_nowait(event)
+        except Full:
+            self._record_dropped_event()
+
+    @property
+    def dropped_count(self) -> int:
+        """Return how many events were dropped because the queue was full."""
+        with self._dropped_count_lock:
+            return self._dropped_count
+
+    def get(
+        self,
+        *,
+        block: bool = True,
+        timeout: float | None = None,
+    ) -> OAuthEvent | None:
+        """Return the next queued event, or None when no event is available."""
+        try:
+            return self.queue.get(block=block, timeout=timeout)
+        except Empty:
+            return None
+
+    def drain(self) -> list[OAuthEvent]:
+        """Return all currently queued events."""
+        events = []
+        while True:
+            event = self.get(block=False)
+            if event is None:
+                return events
+            events.append(event)
+
+    def _record_dropped_event(self) -> None:
+        """Record a dropped event without blocking the OAuth flow."""
+        with self._dropped_count_lock:
+            self._dropped_count += 1

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from queue import Empty, Full, Queue
 from threading import Lock
+from types import MappingProxyType
 from typing import Any, Protocol
 
 
@@ -21,7 +23,10 @@ class OAuthEvent:
     provider: str | None = None
     connection_id: str | None = None
     message: str = ""
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
 
 
 class OAuthEventSink(Protocol):
@@ -95,3 +100,23 @@ class QueuedOAuthEventSink:
         """Record a dropped event without blocking the OAuth flow."""
         with self._dropped_count_lock:
             self._dropped_count += 1
+
+
+def _freeze_metadata(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    """Return an immutable metadata snapshot for emitted events."""
+    if not value:
+        return MappingProxyType({})
+    return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+
+
+def _freeze_value(value: Any) -> Any:
+    """Recursively freeze common mutable containers."""
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _freeze_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_freeze_value(item) for item in value)
+    return value

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -231,8 +231,10 @@ def _is_safe_source_value(value: Any) -> bool:
         return False
     if value in {"oauth-cache", "oauth-refresh", "oauth-login"}:
         return True
-    if value.startswith("keyring:"):
-        label = value.removeprefix("keyring:")
+    for prefix in ("env:", "project:", "keyring:"):
+        if not value.startswith(prefix):
+            continue
+        label = value.removeprefix(prefix)
         return _is_safe_identifier(label)
     return _is_env_var_name(value)
 

--- a/titan_cli/core/oauth/events.py
+++ b/titan_cli/core/oauth/events.py
@@ -10,6 +10,40 @@ from types import MappingProxyType
 from typing import Any, Protocol
 
 REDACTED_METADATA_VALUE = "<redacted>"
+SAFE_EVENT_MESSAGES = frozenset(
+    {
+        "",
+        "Resolving OAuth credential.",
+        "OAuth credential resolved.",
+        "OAuth refresh provider is not registered.",
+        "OAuth authorization provider is not registered.",
+        "OAuth authentication is required.",
+        "OAuth credential lock acquired.",
+        "Refreshing OAuth credential.",
+        "OAuth refresh failed.",
+        "Stale OAuth credential could not be deleted.",
+        "Deleted stale OAuth credential after refresh failure.",
+        "OAuth refreshed credential could not be saved.",
+        "Starting OAuth authorization.",
+        "OAuth authorization failed.",
+        "OAuth authorized credential could not be saved.",
+        "OAuth credential could not be saved.",
+        "OAuth credential saved.",
+    }
+)
+SAFE_METADATA_KEYS = frozenset({"source", "phase", "secret_key"})
+SENSITIVE_METADATA_KEYS = frozenset(
+    {
+        "access_token",
+        "authorization",
+        "client_secret",
+        "credential",
+        "id_token",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -28,6 +62,28 @@ class OAuthEvent:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "type", _sanitize_event_text(self.type))
+        object.__setattr__(
+            self,
+            "operation_id",
+            _sanitize_event_text(self.operation_id),
+        )
+        object.__setattr__(
+            self,
+            "credential_key",
+            _sanitize_optional_event_text(self.credential_key),
+        )
+        object.__setattr__(
+            self,
+            "provider",
+            _sanitize_optional_event_text(self.provider),
+        )
+        object.__setattr__(
+            self,
+            "connection_id",
+            _sanitize_optional_event_text(self.connection_id),
+        )
+        object.__setattr__(self, "message", _sanitize_event_message(self.message))
         object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
 
 
@@ -110,34 +166,99 @@ def _freeze_metadata(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
     """Return an immutable metadata snapshot for emitted events."""
     if not value:
         return MappingProxyType({})
-    return MappingProxyType(
-        {
-            key: REDACTED_METADATA_VALUE
-            if _is_sensitive_metadata_key(key)
-            else _freeze_value(item)
-            for key, item in value.items()
-        }
+    if not isinstance(value, Mapping):
+        raise ValueError("OAuth event metadata must be a mapping.")
+
+    safe_metadata = {}
+    for key, item in value.items():
+        key_label = str(key)
+        if key_label in SAFE_METADATA_KEYS:
+            safe_metadata[key_label] = _freeze_safe_metadata_value(key_label, item)
+            continue
+        if _is_sensitive_metadata_key(key_label):
+            safe_metadata[key_label] = REDACTED_METADATA_VALUE
+            continue
+    return MappingProxyType(safe_metadata)
+
+
+def _freeze_safe_metadata_value(key: str, value: Any) -> Any:
+    """Freeze a whitelisted metadata value after key-specific validation."""
+    if key == "source":
+        return value if _is_safe_source_value(value) else REDACTED_METADATA_VALUE
+    if key == "phase":
+        return value if value == "storage" else REDACTED_METADATA_VALUE
+    if key == "secret_key":
+        return value if _is_safe_secret_key_value(value) else REDACTED_METADATA_VALUE
+    return REDACTED_METADATA_VALUE
+
+
+def _sanitize_event_message(value: Any) -> str:
+    """Return a lifecycle-safe event message."""
+    if not isinstance(value, str):
+        raise ValueError("OAuth event message must be a string.")
+    stripped = value.strip()
+    if stripped in SAFE_EVENT_MESSAGES:
+        return stripped
+    return REDACTED_METADATA_VALUE
+
+
+def _sanitize_optional_event_text(value: Any) -> str | None:
+    """Sanitize an optional event field."""
+    if value is None:
+        return None
+    return _sanitize_event_text(value)
+
+
+def _sanitize_event_text(value: Any) -> str:
+    """Sanitize a required event field."""
+    if not isinstance(value, str):
+        raise ValueError("OAuth event fields must be strings.")
+    stripped = value.strip()
+    if _contains_sensitive_text(stripped):
+        return REDACTED_METADATA_VALUE
+    return stripped
+
+
+def _contains_sensitive_text(value: str) -> bool:
+    """Return whether text advertises token or authorization material."""
+    lowered = value.lower()
+    return any(marker in lowered for marker in SENSITIVE_METADATA_KEYS)
+
+
+def _is_safe_source_value(value: Any) -> bool:
+    """Return whether a source metadata value is a non-secret source label."""
+    if not isinstance(value, str):
+        return False
+    if value in {"oauth-cache", "oauth-refresh", "oauth-login"}:
+        return True
+    if value.startswith("keyring:"):
+        label = value.removeprefix("keyring:")
+        return _is_safe_identifier(label)
+    return _is_env_var_name(value)
+
+
+def _is_safe_secret_key_value(value: Any) -> bool:
+    """Return whether a stored secret key label is safe to expose."""
+    return isinstance(value, str) and value.startswith("oauth_") and _is_safe_identifier(
+        value
     )
 
 
-def _freeze_value(value: Any) -> Any:
-    """Recursively freeze common mutable containers."""
-    if isinstance(value, Mapping):
-        return MappingProxyType(
-            {
-                key: REDACTED_METADATA_VALUE
-                if _is_sensitive_metadata_key(key)
-                else _freeze_value(item)
-                for key, item in value.items()
-            }
-        )
-    if isinstance(value, list | tuple):
-        return tuple(_freeze_value(item) for item in value)
-    if isinstance(value, set | frozenset):
-        return frozenset(_freeze_value(item) for item in value)
-    return value
+def _is_env_var_name(value: str) -> bool:
+    """Return whether a value looks like an environment variable name."""
+    return bool(value) and all(
+        char.isupper() or char.isdigit() or char == "_" for char in value
+    )
+
+
+def _is_safe_identifier(value: str) -> bool:
+    """Return whether a label contains only non-structural identifier characters."""
+    return bool(value) and all(
+        char.isalnum() or char in {"_", "-", ".", ":"} for char in value
+    )
 
 
 def _is_sensitive_metadata_key(key: object) -> bool:
     """Return whether a metadata key may carry OAuth token material."""
-    return "token" in str(key).lower()
+    lowered = str(key).lower()
+    return any(marker in lowered for marker in SENSITIVE_METADATA_KEYS)

--- a/titan_cli/core/oauth/exceptions.py
+++ b/titan_cli/core/oauth/exceptions.py
@@ -1,0 +1,33 @@
+"""Exceptions raised by Titan's OAuth coordination layer."""
+
+
+class OAuthError(Exception):
+    """Base exception for OAuth coordination failures."""
+
+
+class OAuthAuthenticationRequired(OAuthError):
+    """Raised when no usable credential is available."""
+
+
+class OAuthAuthorizationError(OAuthError):
+    """Raised when an OAuth provider cannot authorize a new credential."""
+
+
+class OAuthProviderNotFound(OAuthError):
+    """Raised when a request needs an OAuth provider that is not registered."""
+
+
+class OAuthStorageError(OAuthError):
+    """Raised when OAuth credential storage cannot be read or written."""
+
+
+class OAuthTokenRefreshError(OAuthError):
+    """Raised when an OAuth provider cannot refresh an expired credential."""
+
+
+class OAuthTokenInvalidError(OAuthTokenRefreshError):
+    """Raised when a stored OAuth refresh token is explicitly invalid."""
+
+
+class OAuthLockTimeout(OAuthError):
+    """Raised when a credential lock cannot be acquired in time."""

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -50,6 +50,11 @@ class _FileLock:
             if cancel_event and cancel_event.is_set():
                 self._close_handle()
                 raise _OAuthLockAcquisitionCancelled
+            if self._timed_out(start):
+                self._close_handle()
+                raise OAuthLockTimeout(
+                    f"Timed out waiting for OAuth lock '{self.path.name}'."
+                )
             try:
                 self._try_acquire_once()
                 self._acquired = True
@@ -58,12 +63,7 @@ class _FileLock:
                 if not self._is_lock_contention(exc):
                     self._close_handle()
                     raise
-                if self._timed_out(start):
-                    self._close_handle()
-                    raise OAuthLockTimeout(
-                        f"Timed out waiting for OAuth lock '{self.path.name}'."
-                    )
-                time.sleep(self.poll_interval_seconds)
+                time.sleep(self._next_sleep_interval(start))
 
     def release(self) -> None:
         """Release the file lock."""
@@ -104,6 +104,14 @@ class _FileLock:
         if self.timeout_seconds is None:
             return False
         return time.monotonic() - start >= self.timeout_seconds
+
+    def _next_sleep_interval(self, start: float) -> float:
+        """Return a sleep interval bounded by the remaining timeout."""
+        if self.timeout_seconds is None:
+            return self.poll_interval_seconds
+        elapsed = time.monotonic() - start
+        remaining = max(0.0, self.timeout_seconds - elapsed)
+        return min(self.poll_interval_seconds, remaining)
 
     def _is_lock_contention(self, exc: OSError) -> bool:
         """Return whether an OS error represents a busy lock."""

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -1,0 +1,308 @@
+"""Credential-scoped locks for OAuth operations."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+import errno
+import hashlib
+import os
+from pathlib import Path
+import threading
+import time
+
+from .exceptions import OAuthLockTimeout
+
+
+class _OAuthLockAcquisitionCancelled(Exception):
+    """Raised inside the worker thread when async lock acquisition is cancelled."""
+
+
+class _FileLock:
+    """Small cross-process file lock with no third-party dependency."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        timeout_seconds: float | None,
+        poll_interval_seconds: float,
+    ) -> None:
+        self.path = path
+        self.timeout_seconds = timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self._handle = None
+        self._acquired = False
+
+    def acquire(self, cancel_event: threading.Event | None = None) -> None:
+        """Acquire the file lock, waiting up to timeout_seconds."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = open(self.path, "a+")
+        try:
+            self._ensure_windows_lock_byte()
+        except Exception:
+            self._close_handle()
+            raise
+        start = time.monotonic()
+
+        while True:
+            if cancel_event and cancel_event.is_set():
+                self._close_handle()
+                raise _OAuthLockAcquisitionCancelled
+            try:
+                self._try_acquire_once()
+                self._acquired = True
+                return
+            except OSError as exc:
+                if not self._is_lock_contention(exc):
+                    self._close_handle()
+                    raise
+                if self._timed_out(start):
+                    self._close_handle()
+                    raise OAuthLockTimeout(
+                        f"Timed out waiting for OAuth lock '{self.path.name}'."
+                    )
+                time.sleep(self.poll_interval_seconds)
+
+    def release(self) -> None:
+        """Release the file lock."""
+        if not self._handle:
+            return
+
+        try:
+            if self._acquired:
+                if os.name == "nt":
+                    import msvcrt
+
+                    self._handle.seek(0)
+                    msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._acquired = False
+            self._close_handle()
+
+    def _try_acquire_once(self) -> None:
+        if not self._handle:
+            raise RuntimeError("File lock handle is not open.")
+
+        if os.name == "nt":
+            import msvcrt
+
+            self._handle.seek(0)
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def _timed_out(self, start: float) -> bool:
+        if self.timeout_seconds is None:
+            return False
+        return time.monotonic() - start >= self.timeout_seconds
+
+    def _is_lock_contention(self, exc: OSError) -> bool:
+        """Return whether an OS error represents a busy lock."""
+        if getattr(exc, "winerror", None) in {32, 33}:
+            return True
+        lock_contention_errnos = {
+            errno.EACCES,
+            errno.EAGAIN,
+            errno.EWOULDBLOCK,
+        }
+        return exc.errno in lock_contention_errnos
+
+    def _ensure_windows_lock_byte(self) -> None:
+        """Initialize the byte Windows locks without growing the file on retries."""
+        if os.name != "nt" or not self._handle:
+            return
+        self._handle.seek(0, os.SEEK_END)
+        if self._handle.tell() > 0:
+            self._handle.seek(0)
+            return
+        self._handle.write("0")
+        self._handle.flush()
+        self._handle.seek(0)
+
+    def _close_handle(self) -> None:
+        if self._handle:
+            self._handle.close()
+            self._handle = None
+
+
+@dataclass
+class OAuthHeldLock:
+    """A held OAuth credential lock."""
+
+    key: str
+    thread_lock: threading.Lock
+    file_lock: _FileLock | None = None
+
+    def release(self) -> None:
+        """Release file and in-process locks."""
+        try:
+            if self.file_lock:
+                self.file_lock.release()
+        finally:
+            self.thread_lock.release()
+
+
+class OAuthLockManager:
+    """Coordinates refresh/login for the same OAuth credential."""
+
+    def __init__(
+        self,
+        *,
+        lock_dir: Path | None = None,
+        poll_interval_seconds: float = 0.05,
+        enable_file_locks: bool = True,
+    ) -> None:
+        self.lock_dir = lock_dir or Path.home() / ".titan" / "oauth" / "locks"
+        self.poll_interval_seconds = poll_interval_seconds
+        self.enable_file_locks = enable_file_locks
+        self._guard = threading.Lock()
+        self._locks: dict[str, threading.Lock] = {}
+
+    async def acquire(
+        self,
+        key: str,
+        *,
+        timeout_seconds: float | None = 60,
+    ) -> OAuthHeldLock:
+        """Acquire a credential lock without blocking the event loop."""
+        cancel_event = threading.Event()
+        worker = asyncio.create_task(
+            asyncio.to_thread(
+                self.acquire_blocking,
+                key,
+                timeout_seconds=timeout_seconds,
+                _cancel_event=cancel_event,
+            )
+        )
+        try:
+            return await asyncio.shield(worker)
+        except asyncio.CancelledError:
+            cancel_event.set()
+            try:
+                held_lock = await asyncio.shield(worker)
+            except _OAuthLockAcquisitionCancelled:
+                pass
+            except OAuthLockTimeout:
+                pass
+            else:
+                held_lock.release()
+            raise
+
+    def acquire_blocking(
+        self,
+        key: str,
+        *,
+        timeout_seconds: float | None = 60,
+        _cancel_event: threading.Event | None = None,
+    ) -> OAuthHeldLock:
+        """Acquire a credential lock from synchronous code."""
+        started_at = time.monotonic()
+        thread_lock = self._get_thread_lock(key)
+        self._acquire_thread_lock(
+            thread_lock,
+            key,
+            timeout_seconds=timeout_seconds,
+            started_at=started_at,
+            cancel_event=_cancel_event,
+        )
+
+        file_lock = None
+        try:
+            if self.enable_file_locks:
+                file_lock = _FileLock(
+                    self._lock_path(key),
+                    timeout_seconds=self._remaining_timeout(
+                        started_at,
+                        timeout_seconds,
+                    ),
+                    poll_interval_seconds=self.poll_interval_seconds,
+                )
+                file_lock.acquire(cancel_event=_cancel_event)
+            return OAuthHeldLock(key=key, thread_lock=thread_lock, file_lock=file_lock)
+        except Exception:
+            thread_lock.release()
+            raise
+
+    @asynccontextmanager
+    async def lock(
+        self,
+        key: str,
+        *,
+        timeout_seconds: float | None = 60,
+    ):
+        """Async context manager for a credential lock."""
+        held_lock = await self.acquire(key, timeout_seconds=timeout_seconds)
+        try:
+            yield held_lock
+        finally:
+            await asyncio.to_thread(held_lock.release)
+
+    def _acquire_thread_lock(
+        self,
+        thread_lock: threading.Lock,
+        key: str,
+        *,
+        timeout_seconds: float | None,
+        started_at: float,
+        cancel_event: threading.Event | None,
+    ) -> None:
+        """Acquire an in-process lock while observing async cancellation."""
+        while True:
+            if cancel_event and cancel_event.is_set():
+                raise _OAuthLockAcquisitionCancelled
+
+            acquired = thread_lock.acquire(
+                timeout=self._next_poll_timeout(started_at, timeout_seconds)
+            )
+            if acquired:
+                return
+
+            if self._timed_out(started_at, timeout_seconds):
+                raise OAuthLockTimeout(f"Timed out waiting for OAuth lock '{key}'.")
+
+    def _next_poll_timeout(
+        self,
+        start: float,
+        timeout_seconds: float | None,
+    ) -> float:
+        """Return the next bounded wait interval for cancellable acquisition."""
+        if timeout_seconds is None:
+            return self.poll_interval_seconds
+        remaining = timeout_seconds - (time.monotonic() - start)
+        return max(0.0, min(self.poll_interval_seconds, remaining))
+
+    def _remaining_timeout(
+        self,
+        start: float,
+        timeout_seconds: float | None,
+    ) -> float | None:
+        """Return remaining timeout budget from a shared acquisition start."""
+        if timeout_seconds is None:
+            return None
+        return max(0.0, timeout_seconds - (time.monotonic() - start))
+
+    def _timed_out(self, start: float, timeout_seconds: float | None) -> bool:
+        """Return whether a lock wait exceeded its timeout."""
+        return (
+            timeout_seconds is not None
+            and time.monotonic() - start >= timeout_seconds
+        )
+
+    def _get_thread_lock(self, key: str) -> threading.Lock:
+        with self._guard:
+            if key not in self._locks:
+                self._locks[key] = threading.Lock()
+            return self._locks[key]
+
+    def _lock_path(self, key: str) -> Path:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        return self.lock_dir / f"{digest}.lock"

--- a/titan_cli/core/oauth/locks.py
+++ b/titan_cli/core/oauth/locks.py
@@ -46,16 +46,18 @@ class _FileLock:
             raise
         start = time.monotonic()
 
+        has_attempted = False
         while True:
             if cancel_event and cancel_event.is_set():
                 self._close_handle()
                 raise _OAuthLockAcquisitionCancelled
-            if self._timed_out(start):
+            if has_attempted and self._timed_out(start):
                 self._close_handle()
                 raise OAuthLockTimeout(
                     f"Timed out waiting for OAuth lock '{self.path.name}'."
                 )
             try:
+                has_attempted = True
                 self._try_acquire_once()
                 self._acquired = True
                 return
@@ -63,6 +65,11 @@ class _FileLock:
                 if not self._is_lock_contention(exc):
                     self._close_handle()
                     raise
+                if self._timed_out(start):
+                    self._close_handle()
+                    raise OAuthLockTimeout(
+                        f"Timed out waiting for OAuth lock '{self.path.name}'."
+                    ) from exc
                 time.sleep(self._next_sleep_interval(start))
 
     def release(self) -> None:

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -167,7 +167,9 @@ class OAuthManager:
                 return credential
 
             stored_token_set = self.token_store.read_with_scope(request)
-            reauthorize_storage_scope: ScopeType = "user"
+            reauthorize_storage_scope: ScopeType = (
+                stored_token_set.scope if stored_token_set else "user"
+            )
             if stored_token_set and stored_token_set.token_set.refresh_token:
                 storage_scope = stored_token_set.scope
                 self._emit(

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -196,6 +196,14 @@ class OAuthManager:
                         "OAuth refresh failed.",
                     )
                     if not request.interactive:
+                        legacy_credential = self._legacy_after_refresh_failure(
+                            event_sink,
+                            operation_id,
+                            request,
+                            credential_key,
+                        )
+                        if legacy_credential:
+                            return legacy_credential
                         raise
                     self.token_store.delete(request, scope=storage_scope)
                     reauthorize_storage_scope = storage_scope
@@ -217,6 +225,14 @@ class OAuthManager:
                         "OAuth refresh failed.",
                     )
                     if not request.interactive:
+                        legacy_credential = self._legacy_after_refresh_failure(
+                            event_sink,
+                            operation_id,
+                            request,
+                            credential_key,
+                        )
+                        if legacy_credential:
+                            return legacy_credential
                         raise
                     reauthorize_storage_scope = storage_scope
                 except Exception as exc:
@@ -229,6 +245,14 @@ class OAuthManager:
                         "OAuth refresh failed.",
                     )
                     if not request.interactive:
+                        legacy_credential = self._legacy_after_refresh_failure(
+                            event_sink,
+                            operation_id,
+                            request,
+                            credential_key,
+                        )
+                        if legacy_credential:
+                            return legacy_credential
                         raise OAuthTokenRefreshError(str(exc)) from exc
                     reauthorize_storage_scope = storage_scope
                 else:
@@ -450,6 +474,27 @@ class OAuthManager:
                     source=f"keyring:{secret_key}",
                 )
         return None
+
+    def _legacy_after_refresh_failure(
+        self,
+        sink: OAuthEventSink,
+        operation_id: str,
+        request: OAuthRequest,
+        credential_key: str,
+    ) -> OAuthCredential | None:
+        """Return a configured legacy credential after refresh failure, if any."""
+        legacy_credential = self._credential_from_legacy_secret(
+            request,
+            credential_key,
+        )
+        if legacy_credential:
+            self._emit_resolved(
+                sink,
+                operation_id,
+                request,
+                legacy_credential,
+            )
+        return legacy_credential
 
     def _preserve_refresh_state(
         self,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -15,6 +15,7 @@ from .exceptions import (
     OAuthAuthorizationError,
     OAuthError,
     OAuthProviderNotFound,
+    OAuthStorageError,
     OAuthTokenInvalidError,
     OAuthTokenRefreshError,
 )
@@ -260,7 +261,16 @@ class OAuthManager:
                         raise OAuthTokenRefreshError(str(exc)) from exc
                     reauthorize_storage_scope = storage_scope
                 else:
-                    self.token_store.write(request, refreshed, scope=storage_scope)
+                    self._write_token_set_or_emit_failure(
+                        request,
+                        refreshed,
+                        scope=storage_scope,
+                        sink=event_sink,
+                        operation_id=operation_id,
+                        credential_key=credential_key,
+                        failure_event_type="oauth.refresh.failed",
+                        failure_message="OAuth refreshed credential could not be saved.",
+                    )
                     credential = self._credential_from_token_set(
                         request,
                         credential_key,
@@ -319,10 +329,15 @@ class OAuthManager:
                         "OAuth authorization failed.",
                     )
                     raise OAuthAuthorizationError(str(exc)) from exc
-                self.token_store.write(
+                self._write_token_set_or_emit_failure(
                     request,
                     token_set,
                     scope=reauthorize_storage_scope,
+                    sink=event_sink,
+                    operation_id=operation_id,
+                    credential_key=credential_key,
+                    failure_event_type="oauth.authorize.failed",
+                    failure_message="OAuth authorized credential could not be saved.",
                 )
                 credential = self._credential_from_token_set(
                     request,
@@ -376,7 +391,16 @@ class OAuthManager:
         credential_key = build_oauth_credential_key(request)
 
         async with self.lock_manager.lock(credential_key):
-            secret_key = self.token_store.write(request, token_set, scope=scope)
+            secret_key = self._write_token_set_or_emit_failure(
+                request,
+                token_set,
+                scope=scope,
+                sink=event_sink,
+                operation_id=operation_id,
+                credential_key=credential_key,
+                failure_event_type="oauth.storage.failed",
+                failure_message="OAuth credential could not be saved.",
+            )
 
         self._emit(
             event_sink,
@@ -500,6 +524,33 @@ class OAuthManager:
                 legacy_credential,
             )
         return legacy_credential
+
+    def _write_token_set_or_emit_failure(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType,
+        sink: OAuthEventSink,
+        operation_id: str,
+        credential_key: str,
+        failure_event_type: str,
+        failure_message: str,
+    ) -> str:
+        """Persist token data while preserving OAuth lifecycle semantics."""
+        try:
+            return self.token_store.write(request, token_set, scope=scope)
+        except OAuthStorageError:
+            self._emit(
+                sink,
+                failure_event_type,
+                operation_id,
+                request,
+                credential_key,
+                failure_message,
+                metadata={"phase": "storage"},
+            )
+            raise
 
     def _prepare_refresh_result(
         self,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -186,6 +186,10 @@ class OAuthManager:
                         stored_token_set.token_set,
                         event_sink,
                     )
+                    refreshed = self._prepare_refresh_result(
+                        stored_token_set.token_set,
+                        refreshed,
+                    )
                 except OAuthTokenInvalidError:
                     self._emit(
                         event_sink,
@@ -256,10 +260,6 @@ class OAuthManager:
                         raise OAuthTokenRefreshError(str(exc)) from exc
                     reauthorize_storage_scope = storage_scope
                 else:
-                    refreshed = self._preserve_refresh_state(
-                        stored_token_set.token_set,
-                        refreshed,
-                    )
                     self.token_store.write(request, refreshed, scope=storage_scope)
                     credential = self._credential_from_token_set(
                         request,
@@ -294,6 +294,11 @@ class OAuthManager:
                 )
                 try:
                     token_set = await provider.authorize(request, event_sink)
+                    self._validate_provider_token_set(
+                        token_set,
+                        error_cls=OAuthAuthorizationError,
+                        action="authorization",
+                    )
                 except OAuthError:
                     self._emit(
                         event_sink,
@@ -496,6 +501,25 @@ class OAuthManager:
             )
         return legacy_credential
 
+    def _prepare_refresh_result(
+        self,
+        previous: OAuthTokenSet,
+        refreshed: OAuthTokenSet,
+    ) -> OAuthTokenSet:
+        """Validate and normalize a provider refresh result before storage."""
+        self._validate_provider_token_set(
+            refreshed,
+            error_cls=OAuthTokenRefreshError,
+            action="refresh",
+        )
+        refreshed = self._preserve_refresh_state(previous, refreshed)
+        self._validate_provider_token_set(
+            refreshed,
+            error_cls=OAuthTokenRefreshError,
+            action="refresh",
+        )
+        return refreshed
+
     def _preserve_refresh_state(
         self,
         previous: OAuthTokenSet,
@@ -510,6 +534,25 @@ class OAuthManager:
             scopes=refreshed.scopes or previous.scopes,
             metadata=refreshed.metadata,
         )
+
+    def _validate_provider_token_set(
+        self,
+        token_set: OAuthTokenSet,
+        *,
+        error_cls: type[OAuthError],
+        action: str,
+    ) -> None:
+        """Validate provider token data before exposing or storing it."""
+        if not isinstance(token_set, OAuthTokenSet):
+            raise error_cls(f"OAuth {action} did not return token data.")
+        if not token_set.access_token:
+            raise error_cls(f"OAuth {action} returned an empty access token.")
+        if not token_set.is_valid(
+            refresh_margin_seconds=self.refresh_margin_seconds,
+        ):
+            raise error_cls(
+                f"OAuth {action} returned a token that expires too soon."
+            )
 
     def _credential_from_token_set(
         self,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -232,6 +232,10 @@ class OAuthManager:
                         raise OAuthTokenRefreshError(str(exc)) from exc
                     reauthorize_storage_scope = storage_scope
                 else:
+                    refreshed = self._preserve_refresh_state(
+                        stored_token_set.token_set,
+                        refreshed,
+                    )
                     self.token_store.write(request, refreshed, scope=storage_scope)
                     credential = self._credential_from_token_set(
                         request,
@@ -446,6 +450,21 @@ class OAuthManager:
                     source=f"keyring:{secret_key}",
                 )
         return None
+
+    def _preserve_refresh_state(
+        self,
+        previous: OAuthTokenSet,
+        refreshed: OAuthTokenSet,
+    ) -> OAuthTokenSet:
+        """Keep refresh metadata that providers may omit when unchanged."""
+        return OAuthTokenSet(
+            access_token=refreshed.access_token,
+            refresh_token=refreshed.refresh_token or previous.refresh_token,
+            expires_at=refreshed.expires_at,
+            token_type=refreshed.token_type,
+            scopes=refreshed.scopes or previous.scopes,
+            metadata=refreshed.metadata,
+        )
 
     def _credential_from_token_set(
         self,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -1,0 +1,514 @@
+"""Async-ready OAuth credential manager."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from typing import Protocol
+
+from titan_cli.core.secrets import ScopeType, SecretManager
+
+from .events import NullOAuthEventSink, OAuthEvent, OAuthEventSink
+from .exceptions import (
+    OAuthAuthenticationRequired,
+    OAuthAuthorizationError,
+    OAuthError,
+    OAuthProviderNotFound,
+    OAuthTokenInvalidError,
+    OAuthTokenRefreshError,
+)
+from .locks import OAuthLockManager
+from .models import (
+    OAuthCredential,
+    OAuthRequest,
+    OAuthTokenSet,
+    build_oauth_credential_key,
+)
+from .storage import OAuthTokenStore
+
+
+class OAuthProvider(Protocol):
+    """Provider adapter used by OAuthManager for refresh/login flows."""
+
+    async def refresh(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        sink: OAuthEventSink,
+    ) -> OAuthTokenSet:
+        """Refresh a stored token set."""
+
+    async def authorize(
+        self,
+        request: OAuthRequest,
+        sink: OAuthEventSink,
+    ) -> OAuthTokenSet:
+        """Run an interactive authorization flow."""
+
+
+class OAuthManager:
+    """Resolves OAuth credentials through env, storage, legacy keys, and providers."""
+
+    def __init__(
+        self,
+        secrets: SecretManager,
+        *,
+        providers: dict[str, OAuthProvider] | None = None,
+        token_store: OAuthTokenStore | None = None,
+        lock_manager: OAuthLockManager | None = None,
+        refresh_margin_seconds: int = 300,
+    ) -> None:
+        self.secrets = secrets
+        self.providers = providers or {}
+        self.token_store = token_store or OAuthTokenStore(secrets)
+        self.lock_manager = lock_manager or OAuthLockManager()
+        self.refresh_margin_seconds = refresh_margin_seconds
+
+    async def get_credential(
+        self,
+        request: OAuthRequest,
+        *,
+        sink: OAuthEventSink | None = None,
+    ) -> OAuthCredential:
+        """Resolve a credential without blocking the event loop while waiting."""
+        event_sink = sink or NullOAuthEventSink()
+        operation_id = uuid.uuid4().hex
+        credential_key = build_oauth_credential_key(request)
+
+        self._emit(
+            event_sink,
+            "oauth.resolve.started",
+            operation_id,
+            request,
+            credential_key,
+            "Resolving OAuth credential.",
+        )
+
+        credential = self._resolve_without_provider(
+            request,
+            credential_key,
+            include_legacy=False,
+        )
+        if credential:
+            self._emit_resolved(event_sink, operation_id, request, credential)
+            return credential
+
+        stored_token_set = self.token_store.read_with_scope(request)
+        provider = self.providers.get(request.provider)
+        if not provider:
+            legacy_credential = self._credential_from_legacy_secret(
+                request,
+                credential_key,
+            )
+            if legacy_credential:
+                self._emit_resolved(
+                    event_sink,
+                    operation_id,
+                    request,
+                    legacy_credential,
+                )
+                return legacy_credential
+
+            if stored_token_set and stored_token_set.token_set.refresh_token:
+                self._emit(
+                    event_sink,
+                    "oauth.provider.missing",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "OAuth refresh provider is not registered.",
+                )
+                raise OAuthProviderNotFound(
+                    f"OAuth provider '{request.provider}' is not registered."
+                )
+            if request.interactive:
+                self._emit(
+                    event_sink,
+                    "oauth.provider.missing",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "OAuth authorization provider is not registered.",
+                )
+                raise OAuthProviderNotFound(
+                    f"OAuth provider '{request.provider}' is not registered."
+                )
+
+            self._emit(
+                event_sink,
+                "oauth.resolve.auth_required",
+                operation_id,
+                request,
+                credential_key,
+                "OAuth authentication is required.",
+            )
+            raise OAuthAuthenticationRequired(
+                f"OAuth credential for '{request.connection_id}' is not available."
+            )
+
+        async with self.lock_manager.lock(credential_key):
+            self._emit(
+                event_sink,
+                "oauth.lock.acquired",
+                operation_id,
+                request,
+                credential_key,
+                "OAuth credential lock acquired.",
+            )
+
+            credential = self._resolve_without_provider(
+                request,
+                credential_key,
+                include_legacy=False,
+            )
+            if credential:
+                self._emit_resolved(event_sink, operation_id, request, credential)
+                return credential
+
+            stored_token_set = self.token_store.read_with_scope(request)
+            reauthorize_storage_scope: ScopeType = "user"
+            if stored_token_set and stored_token_set.token_set.refresh_token:
+                storage_scope = stored_token_set.scope
+                self._emit(
+                    event_sink,
+                    "oauth.refresh.started",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "Refreshing OAuth credential.",
+                )
+                try:
+                    refreshed = await provider.refresh(
+                        request,
+                        stored_token_set.token_set,
+                        event_sink,
+                    )
+                except OAuthTokenInvalidError:
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth refresh failed.",
+                    )
+                    if not request.interactive:
+                        raise
+                    self.token_store.delete(request, scope=storage_scope)
+                    reauthorize_storage_scope = storage_scope
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.stale_deleted",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "Deleted stale OAuth credential after refresh failure.",
+                    )
+                except OAuthError:
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth refresh failed.",
+                    )
+                    if not request.interactive:
+                        raise
+                    reauthorize_storage_scope = storage_scope
+                except Exception as exc:
+                    self._emit(
+                        event_sink,
+                        "oauth.refresh.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth refresh failed.",
+                    )
+                    if not request.interactive:
+                        raise OAuthTokenRefreshError(str(exc)) from exc
+                    reauthorize_storage_scope = storage_scope
+                else:
+                    self.token_store.write(request, refreshed, scope=storage_scope)
+                    credential = self._credential_from_token_set(
+                        request,
+                        credential_key,
+                        refreshed,
+                        source="oauth-refresh",
+                    )
+                    self._emit_resolved(event_sink, operation_id, request, credential)
+                    return credential
+
+            legacy_credential = self._credential_from_legacy_secret(
+                request,
+                credential_key,
+            )
+            if legacy_credential:
+                self._emit_resolved(
+                    event_sink,
+                    operation_id,
+                    request,
+                    legacy_credential,
+                )
+                return legacy_credential
+
+            if request.interactive:
+                self._emit(
+                    event_sink,
+                    "oauth.authorize.started",
+                    operation_id,
+                    request,
+                    credential_key,
+                    "Starting OAuth authorization.",
+                )
+                try:
+                    token_set = await provider.authorize(request, event_sink)
+                except OAuthError:
+                    self._emit(
+                        event_sink,
+                        "oauth.authorize.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth authorization failed.",
+                    )
+                    raise
+                except Exception as exc:
+                    self._emit(
+                        event_sink,
+                        "oauth.authorize.failed",
+                        operation_id,
+                        request,
+                        credential_key,
+                        "OAuth authorization failed.",
+                    )
+                    raise OAuthAuthorizationError(str(exc)) from exc
+                self.token_store.write(
+                    request,
+                    token_set,
+                    scope=reauthorize_storage_scope,
+                )
+                credential = self._credential_from_token_set(
+                    request,
+                    credential_key,
+                    token_set,
+                    source="oauth-login",
+                )
+                self._emit_resolved(event_sink, operation_id, request, credential)
+                return credential
+
+            self._emit(
+                event_sink,
+                "oauth.resolve.auth_required",
+                operation_id,
+                request,
+                credential_key,
+                "OAuth authentication is required.",
+            )
+            raise OAuthAuthenticationRequired(
+                f"OAuth credential for '{request.connection_id}' is not available."
+            )
+
+    def get_credential_blocking(
+        self,
+        request: OAuthRequest,
+        *,
+        sink: OAuthEventSink | None = None,
+    ) -> OAuthCredential:
+        """Resolve a credential from synchronous code."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.get_credential(request, sink=sink))
+
+        raise OAuthError(
+            "get_credential_blocking cannot run inside an active event loop. "
+            "Use await get_credential(...) instead."
+        )
+
+    async def save_token_set(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType = "user",
+        sink: OAuthEventSink | None = None,
+    ) -> str:
+        """Persist a token set under the request's credential lock."""
+        event_sink = sink or NullOAuthEventSink()
+        operation_id = uuid.uuid4().hex
+        credential_key = build_oauth_credential_key(request)
+
+        async with self.lock_manager.lock(credential_key):
+            secret_key = self.token_store.write(request, token_set, scope=scope)
+
+        self._emit(
+            event_sink,
+            "oauth.storage.saved",
+            operation_id,
+            request,
+            credential_key,
+            "OAuth credential saved.",
+            metadata={"secret_key": secret_key},
+        )
+        return secret_key
+
+    def save_token_set_blocking(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType = "user",
+        sink: OAuthEventSink | None = None,
+    ) -> str:
+        """Persist a token set from synchronous code."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(
+                self.save_token_set(
+                    request,
+                    token_set,
+                    scope=scope,
+                    sink=sink,
+                )
+            )
+
+        raise OAuthError(
+            "save_token_set_blocking cannot run inside an active event loop. "
+            "Use await save_token_set(...) instead."
+        )
+
+    def _resolve_without_provider(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+        *,
+        include_legacy: bool = True,
+    ) -> OAuthCredential | None:
+        env_credential = self._credential_from_env(request, credential_key)
+        if env_credential:
+            return env_credential
+
+        stored_token_set = self.token_store.read(request)
+        if stored_token_set and stored_token_set.is_valid(
+            refresh_margin_seconds=self.refresh_margin_seconds,
+        ):
+            return self._credential_from_token_set(
+                request,
+                credential_key,
+                stored_token_set,
+                source="oauth-cache",
+            )
+
+        if include_legacy:
+            return self._credential_from_legacy_secret(request, credential_key)
+        return None
+
+    def _credential_from_env(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+    ) -> OAuthCredential | None:
+        if not request.access_token_env_var:
+            return None
+        token = os.environ.get(request.access_token_env_var, "").strip()
+        if not token:
+            return None
+        return OAuthCredential(
+            access_token=token,
+            token_type="Bearer",
+            scopes=request.scopes,
+            provider=request.provider,
+            connection_id=request.connection_id,
+            credential_key=credential_key,
+            source=request.access_token_env_var,
+        )
+
+    def _credential_from_legacy_secret(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+    ) -> OAuthCredential | None:
+        for secret_key in request.legacy_secret_keys:
+            token = self.secrets.get(secret_key)
+            if token and token.strip():
+                return OAuthCredential(
+                    access_token=token.strip(),
+                    token_type="Bearer",
+                    scopes=request.scopes,
+                    provider=request.provider,
+                    connection_id=request.connection_id,
+                    credential_key=credential_key,
+                    source=f"keyring:{secret_key}",
+                )
+        return None
+
+    def _credential_from_token_set(
+        self,
+        request: OAuthRequest,
+        credential_key: str,
+        token_set: OAuthTokenSet,
+        *,
+        source: str,
+    ) -> OAuthCredential:
+        return OAuthCredential(
+            access_token=token_set.access_token,
+            token_type=token_set.token_type,
+            expires_at=token_set.expires_at,
+            scopes=token_set.scopes or request.scopes,
+            provider=request.provider,
+            connection_id=request.connection_id,
+            credential_key=credential_key,
+            source=source,
+        )
+
+    def _emit_resolved(
+        self,
+        sink: OAuthEventSink,
+        operation_id: str,
+        request: OAuthRequest,
+        credential: OAuthCredential,
+    ) -> None:
+        self._emit(
+            sink,
+            "oauth.resolve.succeeded",
+            operation_id,
+            request,
+            credential.credential_key,
+            "OAuth credential resolved.",
+            metadata={"source": credential.source},
+        )
+
+    def _emit(
+        self,
+        sink: OAuthEventSink,
+        event_type: str,
+        operation_id: str,
+        request: OAuthRequest,
+        credential_key: str,
+        message: str,
+        *,
+        metadata: dict | None = None,
+    ) -> None:
+        sink.emit(
+            OAuthEvent(
+                type=event_type,
+                operation_id=operation_id,
+                credential_key=credential_key,
+                provider=request.provider,
+                connection_id=request.connection_id,
+                message=message,
+                metadata=self._safe_metadata(metadata or {}),
+            )
+        )
+
+    def _safe_metadata(self, metadata: dict) -> dict:
+        safe_metadata = {}
+        for key, value in metadata.items():
+            if "token" in str(key).lower():
+                safe_metadata[key] = "<redacted>"
+            else:
+                safe_metadata[key] = value
+        return safe_metadata

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -545,7 +545,10 @@ class OAuthManager:
         """Validate provider token data before exposing or storing it."""
         if not isinstance(token_set, OAuthTokenSet):
             raise error_cls(f"OAuth {action} did not return token data.")
-        if not token_set.access_token:
+        if (
+            not isinstance(token_set.access_token, str)
+            or not token_set.access_token.strip()
+        ):
             raise error_cls(f"OAuth {action} returned an empty access token.")
         if not token_set.is_valid(
             refresh_margin_seconds=self.refresh_margin_seconds,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -60,6 +60,15 @@ def _validate_refresh_margin_seconds(refresh_margin_seconds: object) -> int:
     return refresh_margin_seconds
 
 
+def _legacy_secret_source(secret_key: str, scope: ScopeType) -> str:
+    """Build a non-secret source label for a resolved legacy credential."""
+    if scope == "env":
+        return f"env:{secret_key.upper()}"
+    if scope == "project":
+        return f"project:{secret_key}"
+    return f"keyring:{secret_key}"
+
+
 class OAuthManager:
     """Resolves OAuth credentials through env, storage, legacy keys, and providers."""
 
@@ -513,16 +522,16 @@ class OAuthManager:
         credential_key: str,
     ) -> OAuthCredential | None:
         for secret_key in request.legacy_secret_keys:
-            token = self.secrets.get(secret_key)
-            if token and token.strip():
+            resolved_secret = self.secrets.get_with_scope(secret_key)
+            if resolved_secret and resolved_secret.value.strip():
                 return OAuthCredential(
-                    access_token=token.strip(),
+                    access_token=resolved_secret.value.strip(),
                     token_type="Bearer",
                     scopes=request.scopes,
                     provider=request.provider,
                     connection_id=request.connection_id,
                     credential_key=credential_key,
-                    source=f"keyring:{secret_key}",
+                    source=_legacy_secret_source(secret_key, resolved_secret.scope),
                 )
         return None
 

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -200,16 +200,6 @@ class OAuthManager:
                         credential_key,
                         "OAuth refresh failed.",
                     )
-                    if not request.interactive:
-                        legacy_credential = self._legacy_after_refresh_failure(
-                            event_sink,
-                            operation_id,
-                            request,
-                            credential_key,
-                        )
-                        if legacy_credential:
-                            return legacy_credential
-                        raise
                     self.token_store.delete(request, scope=storage_scope)
                     reauthorize_storage_scope = storage_scope
                     self._emit(
@@ -220,6 +210,16 @@ class OAuthManager:
                         credential_key,
                         "Deleted stale OAuth credential after refresh failure.",
                     )
+                    if not request.interactive:
+                        legacy_credential = self._legacy_after_refresh_failure(
+                            event_sink,
+                            operation_id,
+                            request,
+                            credential_key,
+                        )
+                        if legacy_credential:
+                            return legacy_credential
+                        raise
                 except OAuthError:
                     self._emit(
                         event_sink,
@@ -583,7 +583,7 @@ class OAuthManager:
             expires_at=refreshed.expires_at,
             token_type=refreshed.token_type,
             scopes=refreshed.scopes or previous.scopes,
-            metadata=refreshed.metadata,
+            metadata={**previous.metadata, **refreshed.metadata},
         )
 
     def _validate_provider_token_set(

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -48,6 +48,18 @@ class OAuthProvider(Protocol):
         """Run an interactive authorization flow."""
 
 
+def _validate_refresh_margin_seconds(refresh_margin_seconds: object) -> int:
+    """Validate token refresh margin configuration."""
+    if not isinstance(refresh_margin_seconds, int) or isinstance(
+        refresh_margin_seconds,
+        bool,
+    ):
+        raise ValueError("OAuth refresh_margin_seconds must be a non-negative integer.")
+    if refresh_margin_seconds < 0:
+        raise ValueError("OAuth refresh_margin_seconds must be a non-negative integer.")
+    return refresh_margin_seconds
+
+
 class OAuthManager:
     """Resolves OAuth credentials through env, storage, legacy keys, and providers."""
 
@@ -64,7 +76,9 @@ class OAuthManager:
         self.providers = providers or {}
         self.token_store = token_store or OAuthTokenStore(secrets)
         self.lock_manager = lock_manager or OAuthLockManager()
-        self.refresh_margin_seconds = refresh_margin_seconds
+        self.refresh_margin_seconds = _validate_refresh_margin_seconds(
+            refresh_margin_seconds,
+        )
 
     async def get_credential(
         self,

--- a/titan_cli/core/oauth/manager.py
+++ b/titan_cli/core/oauth/manager.py
@@ -214,7 +214,15 @@ class OAuthManager:
                         credential_key,
                         "OAuth refresh failed.",
                     )
-                    self.token_store.delete(request, scope=storage_scope)
+                    self._delete_token_set_or_emit_failure(
+                        request,
+                        scope=storage_scope,
+                        sink=event_sink,
+                        operation_id=operation_id,
+                        credential_key=credential_key,
+                        failure_event_type="oauth.refresh.failed",
+                        failure_message="Stale OAuth credential could not be deleted.",
+                    )
                     reauthorize_storage_scope = storage_scope
                     self._emit(
                         event_sink,
@@ -554,6 +562,32 @@ class OAuthManager:
         """Persist token data while preserving OAuth lifecycle semantics."""
         try:
             return self.token_store.write(request, token_set, scope=scope)
+        except OAuthStorageError:
+            self._emit(
+                sink,
+                failure_event_type,
+                operation_id,
+                request,
+                credential_key,
+                failure_message,
+                metadata={"phase": "storage"},
+            )
+            raise
+
+    def _delete_token_set_or_emit_failure(
+        self,
+        request: OAuthRequest,
+        *,
+        scope: ScopeType,
+        sink: OAuthEventSink,
+        operation_id: str,
+        credential_key: str,
+        failure_event_type: str,
+        failure_message: str,
+    ) -> None:
+        """Delete token data while preserving OAuth lifecycle semantics."""
+        try:
+            self.token_store.delete(request, scope=scope)
         except OAuthStorageError:
             self._emit(
                 sink,

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -1,0 +1,213 @@
+"""Provider-neutral OAuth data models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import hashlib
+import json
+import time
+from typing import Any
+
+
+def _normalize_optional(value: Any, *, field_name: str = "value") -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string when present.")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_values(
+    values: Sequence[str] | str | None,
+    *,
+    field_name: str = "values",
+) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, str):
+        values = (values,)
+    elif not isinstance(values, Sequence):
+        raise ValueError(f"{field_name} must be a string or sequence of strings.")
+
+    normalized_values = []
+    for index, value in enumerate(values):
+        if not isinstance(value, str):
+            raise ValueError(f"{field_name}[{index}] must be a string.")
+        stripped = value.strip()
+        if stripped:
+            normalized_values.append(stripped)
+    return tuple(sorted(set(normalized_values)))
+
+
+@dataclass(frozen=True)
+class OAuthRequest:
+    """A provider-neutral request for an OAuth credential."""
+
+    provider: str
+    connection_id: str
+    scopes: Sequence[str] = field(default_factory=tuple)
+    interactive: bool = False
+    access_token_env_var: str | None = None
+    legacy_secret_keys: Sequence[str] = field(default_factory=tuple)
+    subject: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provider", self.provider.strip().lower())
+        object.__setattr__(self, "connection_id", self.connection_id.strip())
+        object.__setattr__(
+            self,
+            "scopes",
+            _normalize_values(self.scopes, field_name="scopes"),
+        )
+        object.__setattr__(
+            self,
+            "legacy_secret_keys",
+            _normalize_values(
+                self.legacy_secret_keys,
+                field_name="legacy_secret_keys",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "access_token_env_var",
+            _normalize_optional(
+                self.access_token_env_var,
+                field_name="access_token_env_var",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "subject",
+            _normalize_optional(self.subject, field_name="subject"),
+        )
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+        if not self.provider:
+            raise ValueError("OAuth provider is required.")
+        if not self.connection_id:
+            raise ValueError("OAuth connection_id is required.")
+
+
+@dataclass(frozen=True)
+class OAuthTokenSet:
+    """Stored OAuth token data."""
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: int | None = None
+    token_type: str = "Bearer"
+    scopes: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "access_token", self.access_token.strip())
+        object.__setattr__(
+            self,
+            "refresh_token",
+            _normalize_optional(self.refresh_token, field_name="refresh_token"),
+        )
+        object.__setattr__(self, "token_type", self.token_type.strip() or "Bearer")
+        object.__setattr__(
+            self,
+            "scopes",
+            _normalize_values(self.scopes, field_name="scopes"),
+        )
+        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+
+    def is_valid(
+        self,
+        *,
+        now: int | None = None,
+        refresh_margin_seconds: int = 300,
+    ) -> bool:
+        """Return whether the access token can be used without refresh."""
+        if not self.access_token:
+            return False
+        if self.expires_at is None:
+            return True
+        current_time = int(time.time()) if now is None else now
+        return self.expires_at > current_time + refresh_margin_seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize token data for SecretManager storage."""
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at,
+            "token_type": self.token_type,
+            "scopes": list(self.scopes),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "OAuthTokenSet":
+        """Build a token set from SecretManager storage."""
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise ValueError("Stored OAuth token set is missing access_token.")
+
+        expires_at_raw = payload.get("expires_at")
+        expires_at = int(expires_at_raw) if expires_at_raw is not None else None
+
+        refresh_token = _normalize_optional(
+            payload.get("refresh_token"),
+            field_name="Stored OAuth token set refresh_token",
+        )
+
+        try:
+            scopes = _normalize_values(
+                payload.get("scopes"),
+                field_name="Stored OAuth token set scopes",
+            )
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+
+        metadata_raw = payload.get("metadata")
+        metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
+
+        return cls(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            token_type=str(payload.get("token_type") or "Bearer"),
+            scopes=scopes,
+            metadata=metadata,
+        )
+
+
+@dataclass(frozen=True)
+class OAuthCredential:
+    """Resolved credential returned to callers."""
+
+    access_token: str
+    provider: str
+    connection_id: str
+    credential_key: str
+    source: str
+    token_type: str = "Bearer"
+    expires_at: int | None = None
+    scopes: Sequence[str] = field(default_factory=tuple)
+
+
+def build_oauth_credential_key(request: OAuthRequest) -> str:
+    """Build a stable, non-secret credential key for an OAuth request."""
+    provider_label = "".join(
+        char if char.isalnum() else "_"
+        for char in request.provider.lower()
+    ).strip("_") or "oauth"
+    material = {
+        "provider": request.provider,
+        "connection_id": request.connection_id,
+        "scopes": list(request.scopes),
+        "subject": request.subject,
+    }
+    encoded = json.dumps(
+        material,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()[:32]
+    return f"{provider_label}_{digest}"

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -103,7 +103,12 @@ class OAuthTokenSet:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "access_token", self.access_token.strip())
+        if not isinstance(self.access_token, str):
+            raise ValueError("OAuth access_token must be a string.")
+        access_token = self.access_token.strip()
+        if not access_token:
+            raise ValueError("OAuth access_token is required.")
+        object.__setattr__(self, "access_token", access_token)
         object.__setattr__(
             self,
             "refresh_token",

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -19,6 +19,12 @@ def _normalize_optional(value: Any, *, field_name: str = "value") -> str | None:
     return stripped or None
 
 
+def _normalize_token_type(value: Any, *, field_name: str = "token_type") -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string.")
+    return value.strip() or "Bearer"
+
+
 def _normalize_optional_int(value: Any, *, field_name: str = "value") -> int | None:
     if value is None:
         return None
@@ -65,6 +71,19 @@ def _normalize_values(
     if sort:
         return tuple(sorted(deduplicated_values))
     return deduplicated_values
+
+
+def _normalize_mapping(
+    value: Any,
+    *,
+    field_name: str = "metadata",
+    allow_none: bool = True,
+) -> dict[str, Any]:
+    if value is None and allow_none:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be a mapping when present.")
+    return dict(value)
 
 
 @dataclass(frozen=True)
@@ -155,13 +174,21 @@ class OAuthTokenSet:
             "expires_at",
             _normalize_optional_int(self.expires_at, field_name="expires_at"),
         )
-        object.__setattr__(self, "token_type", self.token_type.strip() or "Bearer")
+        object.__setattr__(
+            self,
+            "token_type",
+            _normalize_token_type(self.token_type, field_name="token_type"),
+        )
         object.__setattr__(
             self,
             "scopes",
             _normalize_values(self.scopes, field_name="scopes"),
         )
-        object.__setattr__(self, "metadata", dict(self.metadata or {}))
+        object.__setattr__(
+            self,
+            "metadata",
+            _normalize_mapping(self.metadata, field_name="metadata"),
+        )
 
     def is_valid(
         self,
@@ -213,14 +240,26 @@ class OAuthTokenSet:
         except ValueError as exc:
             raise ValueError(str(exc)) from exc
 
-        metadata_raw = payload.get("metadata")
-        metadata = metadata_raw if isinstance(metadata_raw, dict) else {}
+        metadata = {}
+        if "metadata" in payload:
+            metadata = _normalize_mapping(
+                payload["metadata"],
+                field_name="Stored OAuth token set metadata",
+                allow_none=False,
+            )
+
+        token_type = "Bearer"
+        if "token_type" in payload:
+            token_type = _normalize_token_type(
+                payload["token_type"],
+                field_name="Stored OAuth token set token_type",
+            )
 
         return cls(
             access_token=access_token,
             refresh_token=refresh_token,
             expires_at=expires_at,
-            token_type=str(payload.get("token_type") or "Bearer"),
+            token_type=token_type,
             scopes=scopes,
             metadata=metadata,
         )

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -19,6 +19,28 @@ def _normalize_optional(value: Any, *, field_name: str = "value") -> str | None:
     return stripped or None
 
 
+def _normalize_optional_int(value: Any, *, field_name: str = "value") -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a non-boolean integer when present.")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError(
+                f"{field_name} must be a non-boolean integer when present."
+            )
+        try:
+            return int(stripped, 10)
+        except ValueError as exc:
+            raise ValueError(
+                f"{field_name} must be a non-boolean integer when present."
+            ) from exc
+    raise ValueError(f"{field_name} must be a non-boolean integer when present.")
+
+
 def _normalize_values(
     values: Sequence[str] | str | None,
     *,
@@ -128,6 +150,11 @@ class OAuthTokenSet:
             "refresh_token",
             _normalize_optional(self.refresh_token, field_name="refresh_token"),
         )
+        object.__setattr__(
+            self,
+            "expires_at",
+            _normalize_optional_int(self.expires_at, field_name="expires_at"),
+        )
         object.__setattr__(self, "token_type", self.token_type.strip() or "Bearer")
         object.__setattr__(
             self,
@@ -168,8 +195,10 @@ class OAuthTokenSet:
         if not isinstance(access_token, str) or not access_token.strip():
             raise ValueError("Stored OAuth token set is missing access_token.")
 
-        expires_at_raw = payload.get("expires_at")
-        expires_at = int(expires_at_raw) if expires_at_raw is not None else None
+        expires_at = _normalize_optional_int(
+            payload.get("expires_at"),
+            field_name="Stored OAuth token set expires_at",
+        )
 
         refresh_token = _normalize_optional(
             payload.get("refresh_token"),

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -52,6 +52,7 @@ class OAuthRequest:
     access_token_env_var: str | None = None
     legacy_secret_keys: Sequence[str] = field(default_factory=tuple)
     subject: str | None = None
+    storage_context: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -82,6 +83,14 @@ class OAuthRequest:
             self,
             "subject",
             _normalize_optional(self.subject, field_name="subject"),
+        )
+        object.__setattr__(
+            self,
+            "storage_context",
+            _normalize_optional(
+                self.storage_context,
+                field_name="storage_context",
+            ),
         )
         object.__setattr__(self, "metadata", dict(self.metadata or {}))
 
@@ -208,6 +217,7 @@ def build_oauth_credential_key(request: OAuthRequest) -> str:
         "connection_id": request.connection_id,
         "scopes": list(request.scopes),
         "subject": request.subject,
+        "storage_context": request.storage_context,
     }
     encoded = json.dumps(
         material,

--- a/titan_cli/core/oauth/models.py
+++ b/titan_cli/core/oauth/models.py
@@ -23,6 +23,7 @@ def _normalize_values(
     values: Sequence[str] | str | None,
     *,
     field_name: str = "values",
+    sort: bool = True,
 ) -> tuple[str, ...]:
     if values is None:
         return ()
@@ -38,7 +39,10 @@ def _normalize_values(
         stripped = value.strip()
         if stripped:
             normalized_values.append(stripped)
-    return tuple(sorted(set(normalized_values)))
+    deduplicated_values = tuple(dict.fromkeys(normalized_values))
+    if sort:
+        return tuple(sorted(deduplicated_values))
+    return deduplicated_values
 
 
 @dataclass(frozen=True)
@@ -69,6 +73,7 @@ class OAuthRequest:
             _normalize_values(
                 self.legacy_secret_keys,
                 field_name="legacy_secret_keys",
+                sort=False,
             ),
         )
         object.__setattr__(

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -1,0 +1,126 @@
+"""SecretManager-backed OAuth token storage."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from titan_cli.core.secrets import ResolvedSecret, ScopeType, SecretManager
+
+from .exceptions import OAuthStorageError
+from .models import OAuthRequest, OAuthTokenSet, build_oauth_credential_key
+
+
+@dataclass(frozen=True)
+class StoredOAuthTokenSet:
+    """Stored OAuth token set with its SecretManager scope."""
+
+    token_set: OAuthTokenSet
+    scope: ScopeType
+
+
+class OAuthTokenStore:
+    """Stores one JSON token-set blob per OAuth credential."""
+
+    def __init__(
+        self,
+        secrets: SecretManager,
+        *,
+        namespace: str = "titan",
+        secret_prefix: str = "oauth",
+    ) -> None:
+        self.secrets = secrets
+        self.namespace = namespace
+        self.secret_prefix = secret_prefix
+
+    def build_secret_key(self, request: OAuthRequest) -> str:
+        """Return the SecretManager key for an OAuth request."""
+        return f"{self.secret_prefix}_{build_oauth_credential_key(request)}"
+
+    def read(self, request: OAuthRequest) -> OAuthTokenSet | None:
+        """Read a stored token set, if present."""
+        stored_token_set = self.read_with_scope(request)
+        return stored_token_set.token_set if stored_token_set else None
+
+    def read_with_scope(self, request: OAuthRequest) -> StoredOAuthTokenSet | None:
+        """Read a stored token set with the scope that supplied it."""
+        secret_key = self.build_secret_key(request)
+        resolved_secret = self._get_secret_with_scope(secret_key)
+        if not resolved_secret or not resolved_secret.value:
+            return None
+
+        try:
+            payload = json.loads(resolved_secret.value)
+            if not isinstance(payload, dict):
+                raise ValueError("OAuth token payload is not an object.")
+            return StoredOAuthTokenSet(
+                token_set=OAuthTokenSet.from_dict(payload),
+                scope=resolved_secret.scope,
+            )
+        except Exception as exc:
+            raise OAuthStorageError(
+                f"Stored OAuth credential '{secret_key}' is not valid."
+            ) from exc
+
+    def write(
+        self,
+        request: OAuthRequest,
+        token_set: OAuthTokenSet,
+        *,
+        scope: ScopeType = "user",
+    ) -> str:
+        """Write a token set and return the SecretManager key used."""
+        secret_key = self.build_secret_key(request)
+        payload = json.dumps(
+            token_set.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        self._set_secret(secret_key, payload, scope=scope)
+        return secret_key
+
+    def delete(self, request: OAuthRequest, *, scope: ScopeType = "user") -> None:
+        """Delete a stored token set."""
+        self._delete_secret(self.build_secret_key(request), scope=scope)
+
+    def _get_secret_with_scope(self, key: str) -> ResolvedSecret | None:
+        get_with_scope = getattr(self.secrets, "get_with_scope", None)
+        if get_with_scope:
+            if self.namespace == "titan":
+                resolved_secret = get_with_scope(key)
+            else:
+                resolved_secret = get_with_scope(key, namespace=self.namespace)
+            normalized_secret = _normalize_resolved_secret(resolved_secret)
+            if normalized_secret:
+                return normalized_secret
+
+        raw_value = self._get_secret_legacy(key)
+        return ResolvedSecret(raw_value, "user") if raw_value else None
+
+    def _get_secret_legacy(self, key: str) -> str | None:
+        if self.namespace == "titan":
+            return self.secrets.get(key)
+        return self.secrets.get(key, namespace=self.namespace)
+
+    def _set_secret(self, key: str, value: str, *, scope: ScopeType) -> None:
+        if self.namespace == "titan":
+            self.secrets.set(key, value, scope=scope)
+            return
+        self.secrets.set(key, value, namespace=self.namespace, scope=scope)
+
+    def _delete_secret(self, key: str, *, scope: ScopeType) -> None:
+        if self.namespace == "titan":
+            self.secrets.delete(key, scope=scope)
+            return
+        self.secrets.delete(key, namespace=self.namespace, scope=scope)
+
+
+def _normalize_resolved_secret(value: object) -> ResolvedSecret | None:
+    """Normalize SecretManager-compatible scoped secret results."""
+    if value is None:
+        return None
+    secret_value = getattr(value, "value", None)
+    secret_scope = getattr(value, "scope", None)
+    if isinstance(secret_value, str) and secret_scope in {"env", "project", "user"}:
+        return ResolvedSecret(secret_value, secret_scope)
+    return None

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -71,12 +71,17 @@ class OAuthTokenStore:
     ) -> str:
         """Write a token set and return the SecretManager key used."""
         secret_key = self.build_secret_key(request)
-        payload = json.dumps(
-            token_set.to_dict(),
-            sort_keys=True,
-            separators=(",", ":"),
-        )
-        self._set_secret(secret_key, payload, scope=scope)
+        try:
+            payload = json.dumps(
+                token_set.to_dict(),
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            self._set_secret(secret_key, payload, scope=scope)
+        except Exception as exc:
+            raise OAuthStorageError(
+                f"OAuth credential '{secret_key}' could not be written."
+            ) from exc
         return secret_key
 
     def delete(self, request: OAuthRequest, *, scope: ScopeType = "user") -> None:

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -90,8 +90,14 @@ class OAuthTokenStore:
 
     def delete(self, request: OAuthRequest, *, scope: ScopeType = "user") -> None:
         """Delete a stored token set."""
-        scope = _validate_scope(scope)
-        self._delete_secret(self.build_secret_key(request), scope=scope)
+        secret_key = self.build_secret_key(request)
+        try:
+            scope = _validate_scope(scope)
+            self._delete_secret(secret_key, scope=scope)
+        except Exception as exc:
+            raise OAuthStorageError(
+                f"OAuth credential '{secret_key}' could not be deleted."
+            ) from exc
 
     def _get_secret_with_scope(self, key: str) -> ResolvedSecret | None:
         get_with_scope = getattr(self.secrets, "get_with_scope", None)

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from typing import Final, cast
 
 from titan_cli.core.secrets import ResolvedSecret, ScopeType, SecretManager
 
 from .exceptions import OAuthStorageError
 from .models import OAuthRequest, OAuthTokenSet, build_oauth_credential_key
+
+_VALID_STORAGE_SCOPES: Final[frozenset[str]] = frozenset({"env", "project", "user"})
 
 
 @dataclass(frozen=True)
@@ -72,6 +75,7 @@ class OAuthTokenStore:
         """Write a token set and return the SecretManager key used."""
         secret_key = self.build_secret_key(request)
         try:
+            scope = _validate_scope(scope)
             payload = json.dumps(
                 token_set.to_dict(),
                 sort_keys=True,
@@ -86,6 +90,7 @@ class OAuthTokenStore:
 
     def delete(self, request: OAuthRequest, *, scope: ScopeType = "user") -> None:
         """Delete a stored token set."""
+        scope = _validate_scope(scope)
         self._delete_secret(self.build_secret_key(request), scope=scope)
 
     def _get_secret_with_scope(self, key: str) -> ResolvedSecret | None:
@@ -129,3 +134,11 @@ def _normalize_resolved_secret(value: object) -> ResolvedSecret | None:
     if isinstance(secret_value, str) and secret_scope in {"env", "project", "user"}:
         return ResolvedSecret(secret_value, secret_scope)
     return None
+
+
+def _validate_scope(scope: object) -> ScopeType:
+    """Validate runtime storage scopes before delegating to SecretManager."""
+    if scope not in _VALID_STORAGE_SCOPES:
+        allowed = ", ".join(sorted(_VALID_STORAGE_SCOPES))
+        raise ValueError(f"OAuth storage scope must be one of: {allowed}.")
+    return cast(ScopeType, scope)

--- a/titan_cli/core/oauth/storage.py
+++ b/titan_cli/core/oauth/storage.py
@@ -94,6 +94,9 @@ class OAuthTokenStore:
         try:
             scope = _validate_scope(scope)
             self._delete_secret(secret_key, scope=scope)
+            self._verify_secret_deleted(secret_key, scope=scope)
+        except OAuthStorageError:
+            raise
         except Exception as exc:
             raise OAuthStorageError(
                 f"OAuth credential '{secret_key}' could not be deleted."
@@ -129,6 +132,26 @@ class OAuthTokenStore:
             self.secrets.delete(key, scope=scope)
             return
         self.secrets.delete(key, namespace=self.namespace, scope=scope)
+
+    def _verify_secret_deleted(self, key: str, *, scope: ScopeType) -> None:
+        """Verify that a scoped credential is gone after deletion."""
+        scoped_value = self._get_secret_from_scope(key, scope=scope)
+        if scoped_value is not None:
+            raise OAuthStorageError(
+                f"OAuth credential '{key}' was not deleted from {scope} storage."
+            )
+
+    def _get_secret_from_scope(self, key: str, *, scope: ScopeType) -> str | None:
+        get_from_scope = getattr(self.secrets, "get_from_scope", None)
+        if get_from_scope:
+            if self.namespace == "titan":
+                return get_from_scope(key, scope=scope)
+            return get_from_scope(key, namespace=self.namespace, scope=scope)
+
+        resolved_secret = self._get_secret_with_scope(key)
+        if resolved_secret and resolved_secret.scope == scope:
+            return resolved_secret.value
+        return None
 
 
 def _normalize_resolved_secret(value: object) -> ResolvedSecret | None:

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -30,6 +30,7 @@ class SecretManager:
     def __init__(self, project_path: Optional[Path] = None):
         self.project_path = project_path or Path.cwd()
         self._project_secret_values: dict[str, str] = {}
+        self._project_env_keys: set[str] = set()
         self._load_project_secrets()
 
     def _load_project_secrets(self):
@@ -37,6 +38,9 @@ class SecretManager:
         secrets_file = self.project_path / ".titan" / "secrets.env"
         if secrets_file.exists():
             self._project_secret_values = self._read_project_secrets_file()
+            self._project_env_keys = {
+                key for key in self._project_secret_values if key not in os.environ
+            }
             load_dotenv(secrets_file)
 
     def get(self, key: str, namespace: str = "titan") -> Optional[str]:
@@ -65,7 +69,7 @@ class SecretManager:
         project_value = self._project_secret_values.get(env_key)
 
         if env_value is not None:
-            if project_value is not None and env_value == project_value:
+            if env_key in self._project_env_keys:
                 return ResolvedSecret(env_value, "project")
             return ResolvedSecret(env_value, "env")
 
@@ -98,7 +102,9 @@ class SecretManager:
         """
         if scope == "env":
             # Set in current environment only
-            os.environ[key.upper()] = value
+            env_key = key.upper()
+            os.environ[env_key] = value
+            self._project_env_keys.discard(env_key)
 
         elif scope == "user":
             # Store in system keyring (most secure)
@@ -109,7 +115,9 @@ class SecretManager:
             secrets_file = self.project_path / ".titan" / "secrets.env"
             secrets_file.parent.mkdir(parents=True, exist_ok=True)
             key_upper = key.upper()
-            old_project_value = self._project_secret_values.get(key_upper)
+            should_update_env = (
+                key_upper in self._project_env_keys or key_upper not in os.environ
+            )
 
             # Read existing content
             existing_lines = []
@@ -132,14 +140,16 @@ class SecretManager:
             with open(secrets_file, "w") as f:
                 f.writelines(existing_lines)
             self._project_secret_values[key_upper] = value
-            if _env_key_should_follow_project(key_upper, old_project_value):
+            if should_update_env:
                 os.environ[key_upper] = value
+                self._project_env_keys.add(key_upper)
 
     def delete(self, key: str, namespace: str = "titan", scope: ScopeType = "user"):
         """Delete secret from specified scope"""
         if scope == "env":
             env_key = key.upper()
             os.environ.pop(env_key, None)
+            self._project_env_keys.discard(env_key)
 
         elif scope == "user":
             try:
@@ -152,7 +162,7 @@ class SecretManager:
             if not secrets_file.exists():
                 return
             key_upper = key.upper()
-            old_project_value = self._project_secret_values.pop(key_upper, None)
+            self._project_secret_values.pop(key_upper, None)
 
             # Read and filter
             with open(secrets_file, "r") as f:
@@ -163,11 +173,9 @@ class SecretManager:
             # Write back
             with open(secrets_file, "w") as f:
                 f.writelines(filtered)
-            if (
-                old_project_value is not None
-                and os.environ.get(key_upper) == old_project_value
-            ):
+            if key_upper in self._project_env_keys:
                 os.environ.pop(key_upper, None)
+                self._project_env_keys.discard(key_upper)
 
     def _read_project_secrets_file(self) -> dict[str, str]:
         """Read project secrets without consulting process environment."""
@@ -178,15 +186,3 @@ class SecretManager:
         return {
             key.upper(): value for key, value in values.items() if value is not None
         }
-
-
-def _env_key_should_follow_project(
-    key_upper: str,
-    old_project_value: Optional[str],
-) -> bool:
-    """Return whether process env mirrors project storage for a secret key."""
-    if key_upper not in os.environ:
-        return True
-    return (
-        old_project_value is not None and os.environ.get(key_upper) == old_project_value
-    )

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
 # titan_cli/core/secrets.py
+from collections.abc import Iterable
 import os
 from dataclasses import dataclass
 import keyring
 from pathlib import Path
+import threading
 from typing import Literal, Optional
 
 from dotenv import dotenv_values, load_dotenv
 
 ScopeType = Literal["env", "project", "user"]
+
+_PROJECT_ENV_KEYS_LOCK = threading.Lock()
+_PROJECT_ENV_KEYS_BY_PATH: dict[Path, set[str]] = {}
 
 
 @dataclass(frozen=True)
@@ -28,9 +35,11 @@ class SecretManager:
     """
 
     def __init__(self, project_path: Optional[Path] = None):
-        self.project_path = project_path or Path.cwd()
+        self.project_path = (project_path or Path.cwd()).expanduser().resolve(
+            strict=False
+        )
         self._project_secret_values: dict[str, str] = {}
-        self._project_env_keys: set[str] = set()
+        self._project_env_keys = self._shared_project_env_keys(self.project_path)
         self._load_project_secrets()
 
     def _load_project_secrets(self):
@@ -38,9 +47,9 @@ class SecretManager:
         secrets_file = self.project_path / ".titan" / "secrets.env"
         if secrets_file.exists():
             self._project_secret_values = self._read_project_secrets_file()
-            self._project_env_keys = {
+            self._mark_project_env_keys(
                 key for key in self._project_secret_values if key not in os.environ
-            }
+            )
             load_dotenv(secrets_file)
 
     def get(self, key: str, namespace: str = "titan") -> Optional[str]:
@@ -65,12 +74,15 @@ class SecretManager:
     ) -> Optional[ResolvedSecret]:
         """Get a secret with the scope that supplied the winning value."""
         env_key = key.upper()
+        self._refresh_project_secret_values()
         env_value = os.environ.get(env_key)
         project_value = self._project_secret_values.get(env_key)
 
         if env_value is not None:
-            if env_key in self._project_env_keys:
-                return ResolvedSecret(env_value, "project")
+            if self._is_project_env_key(env_key) and project_value is not None:
+                if env_value != project_value:
+                    os.environ[env_key] = project_value
+                return ResolvedSecret(project_value, "project")
             return ResolvedSecret(env_value, "env")
 
         if project_value is not None:
@@ -104,7 +116,7 @@ class SecretManager:
             # Set in current environment only
             env_key = key.upper()
             os.environ[env_key] = value
-            self._project_env_keys.discard(env_key)
+            self._discard_project_env_key(env_key)
 
         elif scope == "user":
             # Store in system keyring (most secure)
@@ -115,8 +127,9 @@ class SecretManager:
             secrets_file = self.project_path / ".titan" / "secrets.env"
             secrets_file.parent.mkdir(parents=True, exist_ok=True)
             key_upper = key.upper()
+            self._refresh_project_secret_values()
             should_update_env = (
-                key_upper in self._project_env_keys or key_upper not in os.environ
+                self._is_project_env_key(key_upper) or key_upper not in os.environ
             )
 
             # Read existing content
@@ -142,14 +155,14 @@ class SecretManager:
             self._project_secret_values[key_upper] = value
             if should_update_env:
                 os.environ[key_upper] = value
-                self._project_env_keys.add(key_upper)
+                self._mark_project_env_key(key_upper)
 
     def delete(self, key: str, namespace: str = "titan", scope: ScopeType = "user"):
         """Delete secret from specified scope"""
         if scope == "env":
             env_key = key.upper()
             os.environ.pop(env_key, None)
-            self._project_env_keys.discard(env_key)
+            self._discard_project_env_key(env_key)
 
         elif scope == "user":
             try:
@@ -173,9 +186,9 @@ class SecretManager:
             # Write back
             with open(secrets_file, "w") as f:
                 f.writelines(filtered)
-            if key_upper in self._project_env_keys:
+            if self._is_project_env_key(key_upper):
                 os.environ.pop(key_upper, None)
-                self._project_env_keys.discard(key_upper)
+                self._discard_project_env_key(key_upper)
 
     def _read_project_secrets_file(self) -> dict[str, str]:
         """Read project secrets without consulting process environment."""
@@ -186,3 +199,29 @@ class SecretManager:
         return {
             key.upper(): value for key, value in values.items() if value is not None
         }
+
+    @staticmethod
+    def _shared_project_env_keys(project_path: Path) -> set[str]:
+        """Return the process-wide project-injected env key set for a project."""
+        with _PROJECT_ENV_KEYS_LOCK:
+            return _PROJECT_ENV_KEYS_BY_PATH.setdefault(project_path, set())
+
+    def _refresh_project_secret_values(self) -> None:
+        """Refresh project secret values from disk without mutating env."""
+        self._project_secret_values = self._read_project_secrets_file()
+
+    def _is_project_env_key(self, key: str) -> bool:
+        with _PROJECT_ENV_KEYS_LOCK:
+            return key in self._project_env_keys
+
+    def _mark_project_env_key(self, key: str) -> None:
+        with _PROJECT_ENV_KEYS_LOCK:
+            self._project_env_keys.add(key)
+
+    def _mark_project_env_keys(self, keys: Iterable[str]) -> None:
+        with _PROJECT_ENV_KEYS_LOCK:
+            self._project_env_keys.update(keys)
+
+    def _discard_project_env_key(self, key: str) -> None:
+        with _PROJECT_ENV_KEYS_LOCK:
+            self._project_env_keys.discard(key)

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -1,11 +1,22 @@
 # titan_cli/core/secrets.py
 import os
+from dataclasses import dataclass
 import keyring
 from pathlib import Path
-from typing import Optional, Literal
-from dotenv import load_dotenv
+from typing import Literal, Optional
+
+from dotenv import dotenv_values, load_dotenv
 
 ScopeType = Literal["env", "project", "user"]
+
+
+@dataclass(frozen=True)
+class ResolvedSecret:
+    """Secret value plus the scope that supplied it."""
+
+    value: str
+    scope: ScopeType
+
 
 class SecretManager:
     """
@@ -18,12 +29,14 @@ class SecretManager:
 
     def __init__(self, project_path: Optional[Path] = None):
         self.project_path = project_path or Path.cwd()
+        self._project_secret_values: dict[str, str] = {}
         self._load_project_secrets()
 
     def _load_project_secrets(self):
         """Load secrets from .titan/secrets.env"""
         secrets_file = self.project_path / ".titan" / "secrets.env"
         if secrets_file.exists():
+            self._project_secret_values = self._read_project_secrets_file()
             load_dotenv(secrets_file)
 
     def get(self, key: str, namespace: str = "titan") -> Optional[str]:
@@ -38,27 +51,38 @@ class SecretManager:
         Note: Project secrets (.titan/secrets.env) are loaded
         into environment on init, so they are checked in step 1.
         """
-        # 1. Environment variable (includes project secrets)
-        env_key = key.upper()
-        if env_key in os.environ:
-            return os.environ[env_key]
+        resolved = self.get_with_scope(key, namespace=namespace)
+        return resolved.value if resolved else None
 
-        # 2. System keyring
+    def get_with_scope(
+        self,
+        key: str,
+        namespace: str = "titan",
+    ) -> Optional[ResolvedSecret]:
+        """Get a secret with the scope that supplied the winning value."""
+        env_key = key.upper()
+        env_value = os.environ.get(env_key)
+        project_value = self._project_secret_values.get(env_key)
+
+        if env_value is not None:
+            if project_value is not None and env_value == project_value:
+                return ResolvedSecret(env_value, "project")
+            return ResolvedSecret(env_value, "env")
+
+        if project_value is not None:
+            return ResolvedSecret(project_value, "project")
+
         try:
             value = keyring.get_password(namespace, key)
             if value:
-                return value
+                return ResolvedSecret(value, "user")
         except Exception:
             pass  # Keyring might not be available
 
         return None
 
     def set(
-        self,
-        key: str,
-        value: str,
-        namespace: str = "titan",
-        scope: ScopeType = "user"
+        self, key: str, value: str, namespace: str = "titan", scope: ScopeType = "user"
     ):
         """
         Set secret
@@ -84,6 +108,8 @@ class SecretManager:
             # Store in .titan/secrets.env
             secrets_file = self.project_path / ".titan" / "secrets.env"
             secrets_file.parent.mkdir(parents=True, exist_ok=True)
+            key_upper = key.upper()
+            old_project_value = self._project_secret_values.get(key_upper)
 
             # Read existing content
             existing_lines = []
@@ -92,7 +118,6 @@ class SecretManager:
                     existing_lines = f.readlines()
 
             # Update or append
-            key_upper = key.upper()
             updated = False
             for i, line in enumerate(existing_lines):
                 if line.startswith(f"{key_upper}="):
@@ -106,6 +131,9 @@ class SecretManager:
             # Write back
             with open(secrets_file, "w") as f:
                 f.writelines(existing_lines)
+            self._project_secret_values[key_upper] = value
+            if _env_key_should_follow_project(key_upper, old_project_value):
+                os.environ[key_upper] = value
 
     def delete(self, key: str, namespace: str = "titan", scope: ScopeType = "user"):
         """Delete secret from specified scope"""
@@ -117,20 +145,48 @@ class SecretManager:
             try:
                 keyring.delete_password(namespace, key)
             except Exception:
-                pass # Keyring might not be available
+                pass  # Keyring might not be available
 
         elif scope == "project":
             secrets_file = self.project_path / ".titan" / "secrets.env"
             if not secrets_file.exists():
                 return
+            key_upper = key.upper()
+            old_project_value = self._project_secret_values.pop(key_upper, None)
 
             # Read and filter
             with open(secrets_file, "r") as f:
                 lines = f.readlines()
 
-            key_upper = key.upper()
             filtered = [line for line in lines if not line.startswith(f"{key_upper}=")]
 
             # Write back
             with open(secrets_file, "w") as f:
                 f.writelines(filtered)
+            if (
+                old_project_value is not None
+                and os.environ.get(key_upper) == old_project_value
+            ):
+                os.environ.pop(key_upper, None)
+
+    def _read_project_secrets_file(self) -> dict[str, str]:
+        """Read project secrets without consulting process environment."""
+        secrets_file = self.project_path / ".titan" / "secrets.env"
+        if not secrets_file.exists():
+            return {}
+        values = dotenv_values(secrets_file)
+        return {
+            key.upper(): value for key, value in values.items() if value is not None
+        }
+
+
+def _env_key_should_follow_project(
+    key_upper: str,
+    old_project_value: Optional[str],
+) -> bool:
+    """Return whether process env mirrors project storage for a secret key."""
+    if key_upper not in os.environ:
+        return True
+    return (
+        old_project_value is not None and os.environ.get(key_upper) == old_project_value
+    )

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import dataclass
 import keyring
 from pathlib import Path
+import tempfile
 import threading
 from typing import Literal, Optional
 
@@ -15,6 +16,8 @@ ScopeType = Literal["env", "project", "user"]
 
 _PROJECT_ENV_KEYS_LOCK = threading.Lock()
 _PROJECT_ENV_KEYS_BY_PATH: dict[Path, set[str]] = {}
+_PROJECT_SECRET_FILE_LOCKS_GUARD = threading.Lock()
+_PROJECT_SECRET_FILE_LOCKS_BY_PATH: dict[Path, threading.Lock] = {}
 
 
 @dataclass(frozen=True)
@@ -23,6 +26,93 @@ class ResolvedSecret:
 
     value: str
     scope: ScopeType
+
+
+class _ProjectSecretsFileLock:
+    """Cross-process lock for one project's shared secrets file."""
+
+    def __init__(self, lock_path: Path) -> None:
+        self.lock_path = lock_path
+        self._thread_lock: threading.Lock | None = None
+        self._handle = None
+
+    def __enter__(self) -> "_ProjectSecretsFileLock":
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._thread_lock = _shared_project_secret_file_lock(self.lock_path)
+        self._thread_lock.acquire()
+        try:
+            self._handle = self.lock_path.open("a+", encoding="utf-8")
+            self._ensure_windows_lock_byte()
+            self._lock_file()
+        except Exception:
+            self._close_handle()
+            self._thread_lock.release()
+            self._thread_lock = None
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        try:
+            self._unlock_file()
+        finally:
+            self._close_handle()
+            if self._thread_lock:
+                self._thread_lock.release()
+                self._thread_lock = None
+        return False
+
+    def _lock_file(self) -> None:
+        if not self._handle:
+            raise RuntimeError("Project secrets lock handle is not open.")
+        if os.name == "nt":
+            import msvcrt
+
+            self._handle.seek(0)
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_LOCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX)
+
+    def _unlock_file(self) -> None:
+        if not self._handle:
+            return
+        if os.name == "nt":
+            import msvcrt
+
+            self._handle.seek(0)
+            msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+
+    def _ensure_windows_lock_byte(self) -> None:
+        if os.name != "nt" or not self._handle:
+            return
+        self._handle.seek(0, os.SEEK_END)
+        if self._handle.tell() > 0:
+            self._handle.seek(0)
+            return
+        self._handle.write("0")
+        self._handle.flush()
+        self._handle.seek(0)
+
+    def _close_handle(self) -> None:
+        if self._handle:
+            self._handle.close()
+            self._handle = None
+
+
+def _shared_project_secret_file_lock(lock_path: Path) -> threading.Lock:
+    """Return the process-wide thread lock for a project secrets lock file."""
+    with _PROJECT_SECRET_FILE_LOCKS_GUARD:
+        return _PROJECT_SECRET_FILE_LOCKS_BY_PATH.setdefault(
+            lock_path,
+            threading.Lock(),
+        )
 
 
 class SecretManager:
@@ -124,38 +214,36 @@ class SecretManager:
 
         elif scope == "project":
             # Store in .titan/secrets.env
-            secrets_file = self.project_path / ".titan" / "secrets.env"
-            secrets_file.parent.mkdir(parents=True, exist_ok=True)
-            key_upper = key.upper()
-            self._refresh_project_secret_values()
-            should_update_env = (
-                self._is_project_env_key(key_upper) or key_upper not in os.environ
-            )
+            secrets_file = self._project_secrets_file()
+            with self._lock_project_secrets_file():
+                secrets_file.parent.mkdir(parents=True, exist_ok=True)
+                key_upper = key.upper()
+                self._refresh_project_secret_values()
+                should_update_env = (
+                    self._is_project_env_key(key_upper)
+                    or key_upper not in os.environ
+                )
 
-            # Read existing content
-            existing_lines = []
-            if secrets_file.exists():
-                with open(secrets_file, "r") as f:
-                    existing_lines = f.readlines()
+                existing_lines = self._read_project_secret_lines(secrets_file)
 
-            # Update or append
-            updated = False
-            for i, line in enumerate(existing_lines):
-                if line.startswith(f"{key_upper}="):
-                    existing_lines[i] = f"{key_upper}='{value}'\n"
-                    updated = True
-                    break
+                updated = False
+                for i, line in enumerate(existing_lines):
+                    if line.startswith(f"{key_upper}="):
+                        existing_lines[i] = f"{key_upper}='{value}'\n"
+                        updated = True
+                        break
 
-            if not updated:
-                existing_lines.append(f"{key_upper}='{value}'\n")
+                if not updated:
+                    existing_lines.append(f"{key_upper}='{value}'\n")
 
-            # Write back
-            with open(secrets_file, "w") as f:
-                f.writelines(existing_lines)
-            self._project_secret_values[key_upper] = value
-            if should_update_env:
-                os.environ[key_upper] = value
-                self._mark_project_env_key(key_upper)
+                self._write_project_secret_lines_atomic(
+                    secrets_file,
+                    existing_lines,
+                )
+                self._refresh_project_secret_values()
+                if should_update_env:
+                    os.environ[key_upper] = value
+                    self._mark_project_env_key(key_upper)
 
     def delete(self, key: str, namespace: str = "titan", scope: ScopeType = "user"):
         """Delete secret from specified scope"""
@@ -171,34 +259,75 @@ class SecretManager:
                 pass  # Keyring might not be available
 
         elif scope == "project":
-            secrets_file = self.project_path / ".titan" / "secrets.env"
-            if not secrets_file.exists():
-                return
-            key_upper = key.upper()
-            self._project_secret_values.pop(key_upper, None)
+            secrets_file = self._project_secrets_file()
+            with self._lock_project_secrets_file():
+                if not secrets_file.exists():
+                    return
+                key_upper = key.upper()
 
-            # Read and filter
-            with open(secrets_file, "r") as f:
-                lines = f.readlines()
+                lines = self._read_project_secret_lines(secrets_file)
+                filtered = [
+                    line for line in lines if not line.startswith(f"{key_upper}=")
+                ]
 
-            filtered = [line for line in lines if not line.startswith(f"{key_upper}=")]
-
-            # Write back
-            with open(secrets_file, "w") as f:
-                f.writelines(filtered)
-            if self._is_project_env_key(key_upper):
-                os.environ.pop(key_upper, None)
-                self._discard_project_env_key(key_upper)
+                self._write_project_secret_lines_atomic(secrets_file, filtered)
+                self._refresh_project_secret_values()
+                if self._is_project_env_key(key_upper):
+                    os.environ.pop(key_upper, None)
+                    self._discard_project_env_key(key_upper)
 
     def _read_project_secrets_file(self) -> dict[str, str]:
         """Read project secrets without consulting process environment."""
-        secrets_file = self.project_path / ".titan" / "secrets.env"
+        secrets_file = self._project_secrets_file()
         if not secrets_file.exists():
             return {}
         values = dotenv_values(secrets_file)
         return {
             key.upper(): value for key, value in values.items() if value is not None
         }
+
+    def _project_secrets_file(self) -> Path:
+        """Return the project-scoped secrets file path."""
+        return self.project_path / ".titan" / "secrets.env"
+
+    def _lock_project_secrets_file(self) -> _ProjectSecretsFileLock:
+        """Return a cross-process lock for project-scoped secrets writes."""
+        secrets_file = self._project_secrets_file()
+        return _ProjectSecretsFileLock(
+            secrets_file.with_name(f"{secrets_file.name}.lock"),
+        )
+
+    def _read_project_secret_lines(self, secrets_file: Path) -> list[str]:
+        """Read the project secrets file as raw lines."""
+        if not secrets_file.exists():
+            return []
+        with secrets_file.open("r", encoding="utf-8") as f:
+            return f.readlines()
+
+    def _write_project_secret_lines_atomic(
+        self,
+        secrets_file: Path,
+        lines: list[str],
+    ) -> None:
+        """Atomically replace the project secrets file with raw lines."""
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=secrets_file.parent,
+                prefix=f".{secrets_file.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as f:
+                temp_path = Path(f.name)
+                f.writelines(lines)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_path, secrets_file)
+        finally:
+            if temp_path and temp_path.exists():
+                temp_path.unlink()
 
     @staticmethod
     def _shared_project_env_keys(project_path: Path) -> set[str]:

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 # titan_cli/core/secrets.py
-from collections.abc import Iterable
-import os
+from collections.abc import Mapping
 from dataclasses import dataclass
+import os
 import keyring
 from pathlib import Path
 import tempfile
@@ -15,7 +15,7 @@ from dotenv import dotenv_values, load_dotenv
 ScopeType = Literal["env", "project", "user"]
 
 _PROJECT_ENV_KEYS_LOCK = threading.Lock()
-_PROJECT_ENV_KEYS_BY_PATH: dict[Path, set[str]] = {}
+_PROJECT_ENV_VALUES_BY_PATH: dict[Path, dict[str, str]] = {}
 _PROJECT_SECRET_FILE_LOCKS_GUARD = threading.Lock()
 _PROJECT_SECRET_FILE_LOCKS_BY_PATH: dict[Path, threading.Lock] = {}
 
@@ -129,7 +129,7 @@ class SecretManager:
             strict=False
         )
         self._project_secret_values: dict[str, str] = {}
-        self._project_env_keys = self._shared_project_env_keys(self.project_path)
+        self._project_env_values = self._shared_project_env_values(self.project_path)
         self._load_project_secrets()
 
     def _load_project_secrets(self):
@@ -137,8 +137,12 @@ class SecretManager:
         secrets_file = self.project_path / ".titan" / "secrets.env"
         if secrets_file.exists():
             self._project_secret_values = self._read_project_secrets_file()
-            self._mark_project_env_keys(
-                key for key in self._project_secret_values if key not in os.environ
+            self._mark_project_env_values(
+                {
+                    key: value
+                    for key, value in self._project_secret_values.items()
+                    if key not in os.environ
+                }
             )
             load_dotenv(secrets_file)
 
@@ -169,10 +173,16 @@ class SecretManager:
         project_value = self._project_secret_values.get(env_key)
 
         if env_value is not None:
-            if self._is_project_env_key(env_key) and project_value is not None:
-                if env_value != project_value:
+            injected_project_value = self._project_env_value(env_key)
+            if injected_project_value is not None and project_value is not None:
+                if env_value == injected_project_value:
                     os.environ[env_key] = project_value
-                return ResolvedSecret(project_value, "project")
+                    self._mark_project_env_key(env_key, project_value)
+                    return ResolvedSecret(project_value, "project")
+                self._discard_project_env_key(env_key)
+                return ResolvedSecret(env_value, "env")
+            if injected_project_value is not None:
+                self._discard_project_env_key(env_key)
             return ResolvedSecret(env_value, "env")
 
         if project_value is not None:
@@ -236,9 +246,11 @@ class SecretManager:
                 key_upper = key.upper()
                 self._refresh_project_secret_values()
                 should_update_env = (
-                    self._is_project_env_key(key_upper)
+                    self._is_project_env_key_current(key_upper)
                     or key_upper not in os.environ
                 )
+                if key_upper in os.environ and not should_update_env:
+                    self._discard_project_env_key(key_upper)
 
                 existing_lines = self._read_project_secret_lines(secrets_file)
 
@@ -259,7 +271,7 @@ class SecretManager:
                 self._refresh_project_secret_values()
                 if should_update_env:
                     os.environ[key_upper] = value
-                    self._mark_project_env_key(key_upper)
+                    self._mark_project_env_key(key_upper, value)
 
     def delete(self, key: str, namespace: str = "titan", scope: ScopeType = "user"):
         """Delete secret from specified scope"""
@@ -288,9 +300,9 @@ class SecretManager:
 
                 self._write_project_secret_lines_atomic(secrets_file, filtered)
                 self._refresh_project_secret_values()
-                if self._is_project_env_key(key_upper):
+                if self._is_project_env_key_current(key_upper):
                     os.environ.pop(key_upper, None)
-                    self._discard_project_env_key(key_upper)
+                self._discard_project_env_key(key_upper)
 
     def _read_project_secrets_file(self) -> dict[str, str]:
         """Read project secrets without consulting process environment."""
@@ -346,27 +358,32 @@ class SecretManager:
                 temp_path.unlink()
 
     @staticmethod
-    def _shared_project_env_keys(project_path: Path) -> set[str]:
-        """Return the process-wide project-injected env key set for a project."""
+    def _shared_project_env_values(project_path: Path) -> dict[str, str]:
+        """Return project-injected env values shared by process/project."""
         with _PROJECT_ENV_KEYS_LOCK:
-            return _PROJECT_ENV_KEYS_BY_PATH.setdefault(project_path, set())
+            return _PROJECT_ENV_VALUES_BY_PATH.setdefault(project_path, {})
 
     def _refresh_project_secret_values(self) -> None:
         """Refresh project secret values from disk without mutating env."""
         self._project_secret_values = self._read_project_secrets_file()
 
-    def _is_project_env_key(self, key: str) -> bool:
+    def _is_project_env_key_current(self, key: str) -> bool:
         with _PROJECT_ENV_KEYS_LOCK:
-            return key in self._project_env_keys
+            project_value = self._project_env_values.get(key)
+        return project_value is not None and os.environ.get(key) == project_value
 
-    def _mark_project_env_key(self, key: str) -> None:
+    def _project_env_value(self, key: str) -> str | None:
         with _PROJECT_ENV_KEYS_LOCK:
-            self._project_env_keys.add(key)
+            return self._project_env_values.get(key)
 
-    def _mark_project_env_keys(self, keys: Iterable[str]) -> None:
+    def _mark_project_env_key(self, key: str, value: str) -> None:
         with _PROJECT_ENV_KEYS_LOCK:
-            self._project_env_keys.update(keys)
+            self._project_env_values[key] = value
+
+    def _mark_project_env_values(self, values: Mapping[str, str]) -> None:
+        with _PROJECT_ENV_KEYS_LOCK:
+            self._project_env_values.update(values)
 
     def _discard_project_env_key(self, key: str) -> None:
         with _PROJECT_ENV_KEYS_LOCK:
-            self._project_env_keys.discard(key)
+            self._project_env_values.pop(key, None)

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -187,6 +187,22 @@ class SecretManager:
 
         return None
 
+    def get_from_scope(
+        self,
+        key: str,
+        namespace: str = "titan",
+        scope: ScopeType = "user",
+    ) -> Optional[str]:
+        """Get a secret only from one storage scope."""
+        if scope == "env":
+            return os.environ.get(key.upper())
+        if scope == "project":
+            self._refresh_project_secret_values()
+            return self._project_secret_values.get(key.upper())
+        if scope == "user":
+            return keyring.get_password(namespace, key)
+        raise ValueError(f"Unknown secret scope: {scope}")
+
     def set(
         self, key: str, value: str, namespace: str = "titan", scope: ScopeType = "user"
     ):

--- a/titan_cli/core/secrets.py
+++ b/titan_cli/core/secrets.py
@@ -14,8 +14,8 @@ from dotenv import dotenv_values, load_dotenv
 
 ScopeType = Literal["env", "project", "user"]
 
-_PROJECT_ENV_KEYS_LOCK = threading.Lock()
-_PROJECT_ENV_VALUES_BY_PATH: dict[Path, dict[str, str]] = {}
+_PROJECT_ENV_INJECTIONS_LOCK = threading.Lock()
+_PROJECT_ENV_INJECTIONS: dict[str, "_ProjectEnvInjection"] = {}
 _PROJECT_SECRET_FILE_LOCKS_GUARD = threading.Lock()
 _PROJECT_SECRET_FILE_LOCKS_BY_PATH: dict[Path, threading.Lock] = {}
 
@@ -26,6 +26,14 @@ class ResolvedSecret:
 
     value: str
     scope: ScopeType
+
+
+@dataclass(frozen=True)
+class _ProjectEnvInjection:
+    """Process-wide ownership for a project secret injected into os.environ."""
+
+    project_path: Path
+    value: str
 
 
 class _ProjectSecretsFileLock:
@@ -129,7 +137,6 @@ class SecretManager:
             strict=False
         )
         self._project_secret_values: dict[str, str] = {}
-        self._project_env_values = self._shared_project_env_values(self.project_path)
         self._load_project_secrets()
 
     def _load_project_secrets(self):
@@ -173,17 +180,19 @@ class SecretManager:
         project_value = self._project_secret_values.get(env_key)
 
         if env_value is not None:
-            injected_project_value = self._project_env_value(env_key)
-            if injected_project_value is not None and project_value is not None:
-                if env_value == injected_project_value:
+            project_injection = self._current_project_env_injection(env_key)
+            if project_injection is None:
+                return ResolvedSecret(env_value, "env")
+
+            if project_value is not None:
+                if project_injection.project_path == self.project_path:
                     os.environ[env_key] = project_value
                     self._mark_project_env_key(env_key, project_value)
-                    return ResolvedSecret(project_value, "project")
-                self._discard_project_env_key(env_key)
-                return ResolvedSecret(env_value, "env")
-            if injected_project_value is not None:
-                self._discard_project_env_key(env_key)
-            return ResolvedSecret(env_value, "env")
+                return ResolvedSecret(project_value, "project")
+
+            if project_injection.project_path == self.project_path:
+                os.environ.pop(env_key, None)
+                self._discard_project_env_key(env_key, project_path=self.project_path)
 
         if project_value is not None:
             return ResolvedSecret(project_value, "project")
@@ -245,12 +254,16 @@ class SecretManager:
                 secrets_file.parent.mkdir(parents=True, exist_ok=True)
                 key_upper = key.upper()
                 self._refresh_project_secret_values()
+                project_injection = self._current_project_env_injection(key_upper)
                 should_update_env = (
-                    self._is_project_env_key_current(key_upper)
+                    project_injection is not None
                     or key_upper not in os.environ
                 )
                 if key_upper in os.environ and not should_update_env:
-                    self._discard_project_env_key(key_upper)
+                    self._discard_project_env_key(
+                        key_upper,
+                        project_path=self.project_path,
+                    )
 
                 existing_lines = self._read_project_secret_lines(secrets_file)
 
@@ -300,9 +313,16 @@ class SecretManager:
 
                 self._write_project_secret_lines_atomic(secrets_file, filtered)
                 self._refresh_project_secret_values()
-                if self._is_project_env_key_current(key_upper):
+                project_injection = self._current_project_env_injection(key_upper)
+                if (
+                    project_injection
+                    and project_injection.project_path == self.project_path
+                ):
                     os.environ.pop(key_upper, None)
-                self._discard_project_env_key(key_upper)
+                    self._discard_project_env_key(
+                        key_upper,
+                        project_path=self.project_path,
+                    )
 
     def _read_project_secrets_file(self) -> dict[str, str]:
         """Read project secrets without consulting process environment."""
@@ -357,33 +377,52 @@ class SecretManager:
             if temp_path and temp_path.exists():
                 temp_path.unlink()
 
-    @staticmethod
-    def _shared_project_env_values(project_path: Path) -> dict[str, str]:
-        """Return project-injected env values shared by process/project."""
-        with _PROJECT_ENV_KEYS_LOCK:
-            return _PROJECT_ENV_VALUES_BY_PATH.setdefault(project_path, {})
-
     def _refresh_project_secret_values(self) -> None:
         """Refresh project secret values from disk without mutating env."""
         self._project_secret_values = self._read_project_secrets_file()
 
-    def _is_project_env_key_current(self, key: str) -> bool:
-        with _PROJECT_ENV_KEYS_LOCK:
-            project_value = self._project_env_values.get(key)
-        return project_value is not None and os.environ.get(key) == project_value
-
-    def _project_env_value(self, key: str) -> str | None:
-        with _PROJECT_ENV_KEYS_LOCK:
-            return self._project_env_values.get(key)
+    def _current_project_env_injection(
+        self,
+        key: str,
+    ) -> _ProjectEnvInjection | None:
+        """Return current Titan-owned env injection, discarding stale entries."""
+        with _PROJECT_ENV_INJECTIONS_LOCK:
+            injection = _PROJECT_ENV_INJECTIONS.get(key)
+        if injection is None:
+            return None
+        if os.environ.get(key) == injection.value:
+            return injection
+        self._discard_project_env_key(key, injection=injection)
+        return None
 
     def _mark_project_env_key(self, key: str, value: str) -> None:
-        with _PROJECT_ENV_KEYS_LOCK:
-            self._project_env_values[key] = value
+        with _PROJECT_ENV_INJECTIONS_LOCK:
+            _PROJECT_ENV_INJECTIONS[key] = _ProjectEnvInjection(
+                project_path=self.project_path,
+                value=value,
+            )
 
     def _mark_project_env_values(self, values: Mapping[str, str]) -> None:
-        with _PROJECT_ENV_KEYS_LOCK:
-            self._project_env_values.update(values)
+        with _PROJECT_ENV_INJECTIONS_LOCK:
+            for key, value in values.items():
+                _PROJECT_ENV_INJECTIONS[key] = _ProjectEnvInjection(
+                    project_path=self.project_path,
+                    value=value,
+                )
 
-    def _discard_project_env_key(self, key: str) -> None:
-        with _PROJECT_ENV_KEYS_LOCK:
-            self._project_env_values.pop(key, None)
+    def _discard_project_env_key(
+        self,
+        key: str,
+        *,
+        project_path: Path | None = None,
+        injection: _ProjectEnvInjection | None = None,
+    ) -> None:
+        with _PROJECT_ENV_INJECTIONS_LOCK:
+            current = _PROJECT_ENV_INJECTIONS.get(key)
+            if current is None:
+                return
+            if project_path is not None and current.project_path != project_path:
+                return
+            if injection is not None and current != injection:
+                return
+            _PROJECT_ENV_INJECTIONS.pop(key, None)


### PR DESCRIPTION
# Pull Request

## 📝 Summary
Introduces a centralized OAuth manager in `titan_cli.core.oauth` that provides provider-neutral credential resolution for plugins. The manager handles token storage, refresh coordination with credential-scoped locks, and lifecycle events through an event sink abstraction, enabling plugins to request OAuth credentials without coupling to specific OAuth providers.

## 🔧 Changes Made
- Add `OAuthManager` with async API for credential resolution from environment variables, token store, legacy secrets, or registered providers
- Implement `OAuthTokenStore` for persisting token sets as JSON blobs via SecretManager
- Add `OAuthLockManager` with file-based and in-memory locks for refresh/login coordination across workers
- Create `OAuthRequest` and `OAuthTokenSet` dataclasses with scope normalization and validation
- Implement `OAuthCredential` as the resolved credential returned to plugins
- Add `OAuthEventSink` abstraction with `CollectingOAuthEventSink` and `QueuedOAuthEventSink` implementations
- Define OAuth exceptions: `OAuthAuthenticationRequired`, `OAuthAuthorizationError`, `OAuthTokenInvalidError`
- Implement automatic token refresh with configurable expiry margin (default 300s)
- Add blocking wrappers (`get_credential_sync`, `invalidate_sync`) for synchronous workflow executor
- Add comprehensive documentation in `docs/concepts/oauth-manager.md`

## 🧪 Testing
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

Comprehensive test coverage including:
- Environment variable token resolution with priority over other sources
- Stored OAuth blob retrieval and validation
- Automatic token refresh when inside expiry margin with lock coordination
- Concurrent refresh deduplication (multiple workers don't duplicate refresh calls)
- Provider-based authentication flow with browser/device login
- Legacy secret key fallback resolution
- Token invalidation and deletion
- Lock acquisition/release for credential-scoped operations
- Event emission for all OAuth lifecycle stages
- Error handling for authorization failures and invalid tokens
- File lock timeout and cleanup scenarios

## 📊 Logs
- `oauth.resolve.started` (DEBUG) — Emitted when credential resolution begins; includes connection_id
- `oauth.resolve.succeeded` (DEBUG) — Emitted on successful resolution; includes source (env var, cache, legacy, provider)
- `oauth.resolve.failed` (DEBUG) — Emitted on resolution failure; includes error details
- `oauth.refresh.started` (DEBUG) — Emitted when token refresh begins
- `oauth.refresh.succeeded` (DEBUG) — Emitted on successful refresh
- `oauth.refresh.failed` (DEBUG) — Emitted on refresh failure
- `oauth.auth.required` (DEBUG) — Emitted when user authentication is needed
- `oauth.invalidate.started` (DEBUG) — Emitted when token invalidation begins
- `oauth.invalidate.succeeded` (DEBUG) — Emitted on successful invalidation

## ✅ Checklist
- [x] Self-review done
- [x] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [ ] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)