### PR TITLE
feat: Add file excerpt support and review quality improvements

### DIFF
--- a/docs/plugins/git/client-api.md
+++ b/docs/plugins/git/client-api.md
@@ -789,6 +789,26 @@ client.remove_worktree(path="../repo-search-worktree", force=False)
 - `path`: Required. Worktree path.
 - `force`: Optional. Force removal.
 
+### Prune stale worktree metadata
+
+Clears Git's records for worktrees whose directories no longer exist.
+
+Git keeps administrative data under `.git/worktrees` for every registered worktree. If
+the directory is deleted by hand, or a removal is interrupted, that record survives and
+blocks the path: `create_worktree` reports it as already registered, while
+`remove_worktree` reports it as "not a working tree". Pruning is the only way to clear
+it, so call this before recreating a worktree at a path a previous run may have used.
+
+**Call:**
+
+```python
+client.prune_worktrees()
+```
+
+**Parameters:**
+
+- No parameters.
+
 ### List worktrees
 
 Returns all worktrees for the repository.

--- a/docs/plugins/github/client-api.md
+++ b/docs/plugins/github/client-api.md
@@ -433,7 +433,11 @@ client.reply_to_comment(
 
 ### Get general PR comments
 
-Returns PR comments that are not attached to a code line.
+Returns PR comments that are not attached to a code line: top-level conversation
+comments plus the summary bodies of submitted reviews (where findings without an
+inline anchor end up). Pending reviews and empty review bodies (plain approvals)
+are skipped. Each entry is wrapped as a pseudo-thread whose `thread_id` starts
+with `general_`.
 
 **Call:**
 

--- a/plugins/titan-plugin-git/tests/services/test_worktree_service.py
+++ b/plugins/titan-plugin-git/tests/services/test_worktree_service.py
@@ -58,6 +58,29 @@ class TestWorktreeServiceCheckoutBranch:
 
 
 @pytest.mark.unit
+class TestWorktreeServicePrune:
+    """Test WorktreeService.prune_worktrees()"""
+
+    def test_prune_runs_git_worktree_prune(self, mock_git_network):
+        mock_git_network.run_command.return_value = ""
+
+        service = WorktreeService(mock_git_network)
+        result = service.prune_worktrees()
+
+        assert isinstance(result, ClientSuccess)
+        mock_git_network.run_command.assert_called_once_with(["git", "worktree", "prune"])
+
+    def test_prune_error_returns_client_error(self, mock_git_network):
+        mock_git_network.run_command.side_effect = GitError("not a git repository")
+
+        service = WorktreeService(mock_git_network)
+        result = service.prune_worktrees()
+
+        assert isinstance(result, ClientError)
+        assert result.error_code == "WORKTREE_PRUNE_ERROR"
+
+
+@pytest.mark.unit
 class TestWorktreeServiceCommit:
     """Test WorktreeService.commit_in_worktree()"""
 

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/git_client.py
@@ -444,6 +444,10 @@ class GitClient:
         """Remove a worktree."""
         return self.worktree_service.remove_worktree(path, force)
 
+    def prune_worktrees(self) -> ClientResult[None]:
+        """Prune stale worktree metadata for directories that no longer exist."""
+        return self.worktree_service.prune_worktrees()
+
     def list_worktrees(self) -> ClientResult[List[UIGitWorktree]]:
         """List all worktrees."""
         return self.worktree_service.list_worktrees()

--- a/plugins/titan-plugin-git/titan_plugin_git/clients/services/worktree_service.py
+++ b/plugins/titan-plugin-git/titan_plugin_git/clients/services/worktree_service.py
@@ -98,6 +98,27 @@ class WorktreeService:
             return ClientError(error_message=str(e), error_code="WORKTREE_REMOVE_ERROR")
 
     @log_client_operation()
+    def prune_worktrees(self) -> ClientResult[None]:
+        """
+        Prune worktree administrative metadata for directories that no longer exist.
+
+        Git keeps a record under ``.git/worktrees`` for every registered worktree. When
+        the directory is deleted by hand (or a removal is interrupted), that record is
+        left behind and ``git worktree add`` on the same path fails as "already
+        registered", while ``git worktree remove`` fails as "not a working tree".
+        Pruning clears those stale records so the path becomes reusable.
+
+        Returns:
+            ClientResult[None]
+        """
+        try:
+            self.git.run_command(["git", "worktree", "prune"])
+            return ClientSuccess(data=None, message="Pruned stale worktree metadata")
+
+        except GitError as e:
+            return ClientError(error_message=str(e), error_code="WORKTREE_PRUNE_ERROR")
+
+    @log_client_operation()
     def list_worktrees(self) -> ClientResult[List[UIGitWorktree]]:
         """
         List all worktrees.

--- a/plugins/titan-plugin-github/tests/conftest.py
+++ b/plugins/titan-plugin-github/tests/conftest.py
@@ -190,6 +190,7 @@ def mock_git_client():
 
     client.create_worktree = Mock(return_value=ClientSuccess(data=None, message="Created"))
     client.remove_worktree = Mock(return_value=ClientSuccess(data=None, message="Removed"))
+    client.prune_worktrees = Mock(return_value=ClientSuccess(data=None, message="Pruned"))
     client.commit_in_worktree = Mock(return_value=ClientSuccess(
         data="abc123def456789abc123def456789abc1234567", message="Committed"
     ))

--- a/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
@@ -291,6 +291,15 @@ class TestResolveFileReadAccess:
         assert access.allowed is False
         assert "uncommitted" in access.reason
 
+    def test_unverifiable_dirty_state_at_head_is_rejected(self):
+        access = resolve_file_read_access(
+            None, head_sha=HEAD_SHA, checkout_sha=HEAD_SHA, checkout_dirty=None
+        )
+
+        assert access.allowed is False
+        assert access.source == "none"
+        assert "could not be verified" in access.reason
+
     def test_unknown_checkout_sha_is_rejected(self):
         access = resolve_file_read_access(None, head_sha=HEAD_SHA, checkout_sha=None)
 

--- a/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_context_resolution_operations.py
@@ -6,17 +6,29 @@ extraction). Guards against silently reverting to the old inline
 """
 
 from titan_plugin_github.managers.prompt_budget_manager import get_prompt_budget_manager
-from titan_plugin_github.models.review_enums import ChecklistCategory, FileChangeStatus, FileReadMode, FileReviewPriority, PRSizeClass, ReviewStrategyType
+from titan_plugin_github.models.review_enums import (
+    ChecklistCategory,
+    ContextRequestType,
+    FileChangeStatus,
+    FileReadMode,
+    FileReviewPriority,
+    PRSizeClass,
+    ReviewStrategyType,
+)
 from titan_plugin_github.models.review_models import (
     ChangeManifest,
     ChangedFileEntry,
+    ContextRequest,
     FileReviewPlan,
     PullRequestManifest,
     ReviewChecklistItem,
     ReviewPlan,
     ReviewStrategy,
 )
-from titan_plugin_github.operations.context_resolution_operations import build_review_context_package
+from titan_plugin_github.operations.context_resolution_operations import (
+    build_review_context_package,
+    resolve_file_read_access,
+)
 
 
 def make_diff(path: str, added_line: str) -> str:
@@ -226,3 +238,196 @@ def test_mixed_batch_closes_before_a_second_worktree_reference_file():
     assert len(package.batches) == 2
     assert list(package.batches[0].files_context.keys()) == ["inline.py", "a.py"]
     assert list(package.batches[1].files_context.keys()) == ["b.py"]
+
+
+# ---------------------------------------------------------------------------
+# File-read access: never pair the PR's diff with another revision's file content
+# ---------------------------------------------------------------------------
+
+HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OTHER_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+class TestResolveFileReadAccess:
+    def test_worktree_is_always_trusted(self):
+        access = resolve_file_read_access("/tmp/titan-review-1")
+
+        assert access.allowed is True
+        assert access.source == "worktree"
+
+    def test_worktree_does_not_need_sha_verification(self):
+        """The worktree is checked out at the PR ref, so a mismatching local
+        checkout is irrelevant."""
+        access = resolve_file_read_access(
+            "/tmp/titan-review-1", head_sha=HEAD_SHA, checkout_sha=OTHER_SHA, checkout_dirty=True
+        )
+
+        assert access.allowed is True
+
+    def test_clean_checkout_at_head_is_trusted(self):
+        access = resolve_file_read_access(
+            None, head_sha=HEAD_SHA, checkout_sha=HEAD_SHA, checkout_dirty=False
+        )
+
+        assert access.allowed is True
+        assert access.source == "checkout"
+
+    def test_checkout_on_another_revision_is_rejected(self):
+        """The bug this guards: worktree creation failed, the user is on another
+        branch, and full-file reads would review code that is not in the PR."""
+        access = resolve_file_read_access(
+            None, head_sha=HEAD_SHA, checkout_sha=OTHER_SHA, checkout_dirty=False
+        )
+
+        assert access.allowed is False
+        assert access.source == "none"
+        assert "aaaaaaaa" in access.reason and "bbbbbbbb" in access.reason
+
+    def test_dirty_checkout_at_head_is_rejected(self):
+        access = resolve_file_read_access(
+            None, head_sha=HEAD_SHA, checkout_sha=HEAD_SHA, checkout_dirty=True
+        )
+
+        assert access.allowed is False
+        assert "uncommitted" in access.reason
+
+    def test_unknown_checkout_sha_is_rejected(self):
+        access = resolve_file_read_access(None, head_sha=HEAD_SHA, checkout_sha=None)
+
+        assert access.allowed is False
+
+    def test_unknown_head_sha_is_rejected(self):
+        access = resolve_file_read_access(None, head_sha=None, checkout_sha=HEAD_SHA)
+
+        assert access.allowed is False
+
+    def test_no_information_at_all_is_rejected(self):
+        assert resolve_file_read_access(None).allowed is False
+
+
+def _single_file_setup(read_mode, path="a.py"):
+    diff = make_diff(path, "added_line = 1")
+    plan = ReviewPlan(
+        focus_files=[
+            FileReviewPlan(path=path, priority=FileReviewPriority.HIGH, read_mode=read_mode)
+        ],
+        review_axes=[ChecklistCategory.FUNCTIONAL_CORRECTNESS],
+    )
+    checklist = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            name="Functional correctness",
+            description="Does it work",
+        )
+    ]
+    strategy = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=100_000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    return diff, plan, make_manifest([path]), checklist, strategy
+
+
+class TestBuildPackageWithoutFileReads:
+    def test_full_file_degrades_to_hunks_only(self, tmp_path):
+        """A real file exists at cwd, but it is the wrong revision — it must be ignored."""
+        (tmp_path / "a.py").write_text("content from the wrong branch\n" * 5)
+        diff, plan, manifest, checklist, strategy = _single_file_setup(FileReadMode.FULL_FILE)
+
+        package = build_review_context_package(
+            plan, diff, manifest, checklist,
+            comment_context=[], strategy=strategy,
+            cwd=str(tmp_path), allow_file_reads=False,
+        )
+
+        entry = package.batches[0].files_context["a.py"]
+        assert entry.read_mode == FileReadMode.HUNKS_ONLY
+        assert entry.full_content is None
+        assert "wrong branch" not in "".join(entry.hunks)
+
+    def test_expanded_hunks_degrades_to_hunks_only(self, tmp_path):
+        (tmp_path / "a.py").write_text("content from the wrong branch\n" * 5)
+        diff, plan, manifest, checklist, strategy = _single_file_setup(FileReadMode.EXPANDED_HUNKS)
+
+        package = build_review_context_package(
+            plan, diff, manifest, checklist,
+            comment_context=[], strategy=strategy,
+            cwd=str(tmp_path), allow_file_reads=False,
+        )
+
+        entry = package.batches[0].files_context["a.py"]
+        assert entry.read_mode == FileReadMode.HUNKS_ONLY
+        assert entry.expanded_hunks == []
+
+    def test_full_file_is_used_when_reads_are_allowed(self, tmp_path):
+        (tmp_path / "a.py").write_text("verified content\n")
+        diff, plan, manifest, checklist, strategy = _single_file_setup(FileReadMode.FULL_FILE)
+
+        package = build_review_context_package(
+            plan, diff, manifest, checklist,
+            comment_context=[], strategy=strategy,
+            cwd=str(tmp_path), allow_file_reads=True,
+        )
+
+        entry = package.batches[0].files_context["a.py"]
+        assert entry.read_mode == FileReadMode.FULL_FILE
+        assert entry.full_content == "verified content\n"
+
+    def test_never_falls_back_to_worktree_reference(self):
+        """worktree_reference has the CLI read the file itself — the same
+        wrong-revision read, just delegated."""
+        path = "big.py"
+        diff, plan, manifest, checklist, strategy = _single_file_setup(
+            FileReadMode.FULL_FILE, path=path
+        )
+        # Oversized hunk: normally this ends up as a worktree_reference entry.
+        diff = make_diff(path, "x" * 40_000)
+
+        package = build_review_context_package(
+            plan, diff, manifest, checklist,
+            comment_context=[], strategy=strategy,
+            allow_file_reads=False,
+        )
+
+        entry = package.batches[0].files_context[path]
+        assert entry.worktree_reference is False
+        assert entry.read_mode == FileReadMode.HUNKS_ONLY
+
+    def test_file_absent_from_diff_gets_headers_only_with_a_hint(self):
+        diff, plan, manifest, checklist, strategy = _single_file_setup(
+            FileReadMode.FULL_FILE, path="in_plan.py"
+        )
+        diff = make_diff("something_else.py", "y = 2")
+
+        package = build_review_context_package(
+            plan, diff, manifest, checklist,
+            comment_context=[], strategy=strategy,
+            allow_file_reads=False,
+        )
+
+        entry = package.batches[0].files_context["in_plan.py"]
+        assert entry.worktree_reference is False
+        assert entry.hunks == []
+        assert "not at this PR's head commit" in entry.review_hint
+
+    def test_related_context_requests_are_skipped(self, tmp_path):
+        (tmp_path / "test_a.py").write_text("def test_something(): pass\n")
+        diff, plan, manifest, checklist, strategy = _single_file_setup(FileReadMode.HUNKS_ONLY)
+        plan = ReviewPlan(
+            focus_files=plan.focus_files,
+            review_axes=plan.review_axes,
+            extra_context_requests=[
+                ContextRequest(type=ContextRequestType.RELATED_TESTS, for_path="a.py")
+            ],
+        )
+
+        package = build_review_context_package(
+            plan, diff, manifest, checklist,
+            comment_context=[], strategy=strategy,
+            cwd=str(tmp_path), allow_file_reads=False,
+        )
+
+        assert package.batches[0].related_files == {}

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -56,7 +56,10 @@ def test_build_findings_prompt_parts_compacts_axes_and_pr_context():
     parts = build_findings_prompt_parts(batch)
 
     assert '"functional_correctness"' in parts["review_axes"]
-    assert "Long description" not in parts["review_axes"]
+    # review-quality-001 (D-002 approved): applicable checklist items now include
+    # name + description (capped) so the findings model knows what each axis means.
+    assert "Long description that should not appear" in parts["review_axes"]
+    assert '"name": "Functional"' in parts["review_axes"]
     assert "Base" not in parts["pr_context"]
     assert "Batch: batch_1" in parts["pr_context"]
     assert "observable meaning of data, events, labels, classifications, or results" in parts["instructions"]
@@ -217,3 +220,110 @@ def test_parse_findings_response_structured_falls_back_to_error_on_prose():
     result = parse_findings_response("I refuse to call that tool.", structured=True)
 
     assert isinstance(result, ClientError)
+
+
+# ---------------------------------------------------------------------------
+# review-quality-001/002: checklist content cap + PR intent (D-002 token mandate)
+# ---------------------------------------------------------------------------
+
+def test_checklist_descriptions_are_hard_capped():
+    from titan_plugin_github.operations.findings_operations import _checklist_to_json
+
+    items = [
+        ReviewChecklistItem(
+            id=ChecklistCategory.SECURITY,
+            name="Security",
+            description="x" * 500,
+        )
+    ]
+
+    rendered = _checklist_to_json(items)
+
+    assert "x" * 200 in rendered
+    assert "x" * 201 not in rendered
+
+
+def test_pr_context_includes_one_line_intent():
+    batch = FocusContextBatch(
+        batch_id="batch_1",
+        files_context={"src/foo.py": FileContextEntry(path="src/foo.py", hunks=["@@ -1 +1 @@\n+x"])},
+        checklist_applicable=[],
+        pr_manifest=PullRequestManifest(
+            number=3597,
+            title="Marketplace token retry",
+            base="develop",
+            head="feat/marketplace-token-retry",
+            author="alex",
+            # Real-world shape (PR #3597): meme image first, then the actual intent.
+            description=(
+                "\n![Token Refresh Meme](https://media.giphy.com/media/abc/giphy.gif)\n\n"
+                "### PR's key points\n"
+                "This PR implements a robust token retry mechanism for Marketplace API calls "
+                "to handle scenarios where the local token expiration check is out of sync."
+            ),
+        ),
+    )
+
+    parts = build_findings_prompt_parts(batch)
+
+    # The short section heading ("PR's key points") is skipped in favor of the
+    # first substantive sentence.
+    assert "Intent: This PR implements a robust token retry mechanism" in parts["pr_context"]
+    assert "giphy" not in parts["pr_context"]
+    # single line, capped
+    intent_line = next(line for line in parts["pr_context"].splitlines() if line.startswith("Intent:"))
+    assert len(intent_line) <= 210
+
+
+def test_pr_context_omits_intent_when_description_is_only_noise():
+    batch = FocusContextBatch(
+        batch_id="batch_1",
+        files_context={"src/foo.py": FileContextEntry(path="src/foo.py", hunks=["@@ -1 +1 @@\n+x"])},
+        checklist_applicable=[],
+        pr_manifest=PullRequestManifest(
+            number=1,
+            title="T",
+            base="main",
+            head="f",
+            author="a",
+            description="<!-- template -->\n![img](https://x.com/i.png)\n- [ ] checkbox\n",
+        ),
+    )
+
+    parts = build_findings_prompt_parts(batch)
+
+    assert "Intent:" not in parts["pr_context"]
+
+
+def test_extract_pr_intent_strips_noise_and_caps():
+    from titan_plugin_github.operations.prompt_formatting_operations import extract_pr_intent
+
+    description = (
+        "<!-- PR template: fill everything -->\n"
+        "![badge](https://img.shields.io/badge.svg)\n"
+        "## Summary\n"
+        "Adds retry logic to the token refresh flow.\n"
+        "- [x] Tests added\n"
+        "- [ ] Docs updated\n"
+        "https://jira.example.com/TICKET-123\n"
+        "More prose here.\n"
+    )
+
+    result = extract_pr_intent(description, max_chars=800)
+
+    assert "Summary" in result
+    assert "Adds retry logic" in result
+    assert "More prose here." in result
+    assert "badge" not in result
+    assert "Tests added" not in result
+    assert "jira.example.com" not in result
+    assert "template" not in result
+
+
+def test_extract_pr_intent_line_returns_first_meaningful_line_capped():
+    from titan_plugin_github.operations.prompt_formatting_operations import extract_pr_intent_line
+
+    assert extract_pr_intent_line("") == ""
+    assert extract_pr_intent_line("A" * 500).startswith("A")
+    assert len(extract_pr_intent_line("A" * 500)) == 200
+    assert extract_pr_intent_line("![m](http://x.gif)\nReal intent sentence.") == "Real intent sentence."

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -327,3 +327,19 @@ def test_extract_pr_intent_line_returns_first_meaningful_line_capped():
     assert extract_pr_intent_line("A" * 500).startswith("A")
     assert len(extract_pr_intent_line("A" * 500)) == 200
     assert extract_pr_intent_line("![m](http://x.gif)\nReal intent sentence.") == "Real intent sentence."
+
+
+def test_default_titan_checklist_renders_with_descriptions_too():
+    """The checklist content fix must work without a project override: Titan's
+    built-in DEFAULT_REVIEW_CHECKLIST (served by ChecklistManager when no
+    .titan/review/checklist.yaml exists) must reach the findings prompt with
+    name + description, same as any project checklist."""
+    from titan_plugin_github.checklists.defaults import DEFAULT_REVIEW_CHECKLIST
+    from titan_plugin_github.operations.findings_operations import _checklist_to_json
+
+    assert all(item.name and item.description for item in DEFAULT_REVIEW_CHECKLIST)
+
+    rendered = _checklist_to_json(list(DEFAULT_REVIEW_CHECKLIST)[:4])
+
+    assert '"name": "Functional Correctness"' in rendered
+    assert "Logic bugs" in rendered

--- a/plugins/titan-plugin-github/tests/operations/test_pr_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_pr_operations.py
@@ -1,0 +1,131 @@
+from titan_plugin_github.models.view import UIComment, UICommentThread
+from titan_plugin_github.operations.pr_operations import (
+    build_quote_reply,
+    split_titan_review_body,
+)
+
+
+def _general_thread(body: str, comment_id: int = 555) -> UICommentThread:
+    comment = UIComment(
+        id=comment_id,
+        body=body,
+        author_login="reviewer",
+        author_name="Reviewer",
+        formatted_date="31/07/2026 06:11:38",
+    )
+    return UICommentThread(
+        thread_id=f"general_{comment_id}",
+        main_comment=comment,
+        replies=[],
+        is_resolved=False,
+        is_outdated=False,
+    )
+
+
+TITAN_BODY = (
+    "**src/foo.py** (line 866):\n"
+    "The marker points at the wrong line.\n\n"
+    "Second paragraph of the same finding.\n\n"
+    "---\n\n"
+    "**src/bar.py** (line 265):\n"
+    "This gate checks the wrong field.\n\n"
+    "---\n\n"
+    "General:\n"
+    "A finding without a path."
+)
+
+
+class TestSplitTitanReviewBody:
+    def test_titan_body_splits_into_one_thread_per_finding(self):
+        parts = split_titan_review_body(_general_thread(TITAN_BODY))
+
+        assert len(parts) == 3
+        assert parts[0].main_comment.path == "src/foo.py"
+        assert parts[0].main_comment.line == 866
+        assert parts[0].main_comment.body.startswith("The marker points")
+        # multi-paragraph finding bodies stay whole
+        assert "Second paragraph" in parts[0].main_comment.body
+        assert parts[1].main_comment.path == "src/bar.py"
+        assert parts[1].main_comment.line == 265
+        assert parts[2].main_comment.path is None
+        assert parts[2].main_comment.line is None
+
+    def test_split_parts_are_general_comments_with_unique_ids(self):
+        parts = split_titan_review_body(_general_thread(TITAN_BODY))
+
+        assert all(p.is_general_comment for p in parts)
+        ids = [p.main_comment.id for p in parts]
+        assert len(set(ids)) == 3
+        # Synthetic ids are negative so they can never collide with real
+        # (positive) GitHub comment ids in the reply/commit maps.
+        assert all(i < 0 for i in ids)
+
+    def test_split_parts_keep_author_and_date(self):
+        parts = split_titan_review_body(_general_thread(TITAN_BODY))
+
+        assert parts[0].main_comment.author_login == "reviewer"
+        assert parts[0].main_comment.formatted_date == "31/07/2026 06:11:38"
+
+    def test_human_general_comment_is_returned_unchanged(self):
+        thread = _general_thread("Nice PR! Just one question about the approach.")
+
+        assert split_titan_review_body(thread) == [thread]
+
+    def test_body_with_separator_but_non_titan_sections_is_not_split(self):
+        thread = _general_thread("Intro text\n\n---\n\nSome unrelated footer")
+
+        assert split_titan_review_body(thread) == [thread]
+
+    def test_mixed_body_with_one_non_matching_section_is_not_split(self):
+        body = TITAN_BODY + "\n\n---\n\nTrailing human note"
+        thread = _general_thread(body)
+
+        assert split_titan_review_body(thread) == [thread]
+
+    def test_inline_thread_is_never_split(self):
+        comment = UIComment(
+            id=1,
+            body=TITAN_BODY,
+            author_login="reviewer",
+            author_name="Reviewer",
+            formatted_date="",
+        )
+        thread = UICommentThread(
+            thread_id="RT_abc123",
+            main_comment=comment,
+            replies=[],
+            is_resolved=False,
+            is_outdated=False,
+        )
+
+        assert split_titan_review_body(thread) == [thread]
+
+    def test_single_section_titan_body_splits(self):
+        thread = _general_thread("**src/foo.py** (line 12):\nOne single finding.")
+
+        parts = split_titan_review_body(thread)
+
+        assert len(parts) == 1
+        assert parts[0].main_comment.path == "src/foo.py"
+        assert parts[0].main_comment.line == 12
+        assert parts[0].main_comment.body == "One single finding."
+
+
+class TestBuildQuoteReply:
+    def test_quotes_original_before_reply(self):
+        result = build_quote_reply("Original comment", "My answer")
+
+        assert result == "> Original comment\n\nMy answer"
+
+    def test_quotes_every_line_of_a_short_original(self):
+        result = build_quote_reply("line one\nline two", "ok")
+
+        assert result == "> line one\n> line two\n\nok"
+
+    def test_long_original_is_truncated_with_ellipsis(self):
+        original = "\n".join(f"line {i}" for i in range(1, 11))
+
+        result = build_quote_reply(original, "ok", max_quote_lines=3)
+
+        assert result.startswith("> line 1\n> line 2\n> line 3\n> […]\n\nok")
+        assert "> line 4" not in result

--- a/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
@@ -471,3 +471,60 @@ def test_comment_view_renders_the_excerpt_for_an_unanchored_finding():
     # explains what the finding is about.
     assert view.line is None
     assert view.line_label == "⚠ outside this PR's diff (AI said 10)"
+
+
+# ---------------------------------------------------------------------------
+# PR #253 review feedback: gates that dropped valid context or anchors
+# ---------------------------------------------------------------------------
+
+
+def test_extract_diff_hunk_for_snippet_anchored_action_without_ai_line():
+    """A finding the AI reported with line=null can still be snippet-anchored
+    (resolved_line set) — it must get its hunk like any other resolved action."""
+    action = ReviewActionProposal(
+        action_type=ReviewActionType.NEW_COMMENT,
+        source=ReviewActionSource.NEW_FINDING,
+        path="src/foo.py",
+        line=None,
+        resolved_line=12,
+        resolution_source="snippet",
+        title="Test",
+        body="Comment body",
+        reasoning="Why",
+    )
+
+    hunk = extract_diff_hunk_for_action(action, DIFF)
+
+    assert hunk is not None
+    assert 'print("world")' in hunk
+
+
+def test_resolve_action_anchors_uses_supplied_manager_when_diff_string_is_empty():
+    """An explicitly supplied manager must anchor even with an empty diff string —
+    bailing on `not diff` alone silently unresolved every action."""
+    from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+
+    manager = DiffContextManager.from_diff(DIFF)
+    action = ReviewActionProposal(
+        action_type=ReviewActionType.NEW_COMMENT,
+        source=ReviewActionSource.NEW_FINDING,
+        path="src/foo.py",
+        line=12,
+        title="Test",
+        body="Comment body",
+        reasoning="Why",
+    )
+
+    resolved = resolve_action_anchors([action], diff="", diff_manager=manager)
+
+    assert resolved[0].resolved_line == 12
+
+
+def test_severity_badge_is_skipped_for_thread_severity_none():
+    """ThreadSeverity.NONE is truthy (StrEnum "none") but has no badge label —
+    the widget must skip the badge instead of raising KeyError in compose()."""
+    from titan_plugin_github.models.review_enums import ThreadSeverity
+
+    view = CommentView(body="x", severity=ThreadSeverity.NONE)
+
+    assert view._severity_badge() is None

--- a/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
@@ -14,7 +14,7 @@ diff --git a/src/foo.py b/src/foo.py
 index abc..def 100644
 --- a/src/foo.py
 +++ b/src/foo.py
-@@ -10,6 +10,7 @@
+@@ -10,3 +10,4 @@
  def hello():
      print(\"hello\")
 +    print(\"world\")

--- a/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
@@ -5,6 +5,7 @@ from titan_plugin_github.operations.review_action_operations import (
     build_review_action_payload,
     detect_head_sha_drift,
     extract_diff_hunk_for_action,
+    extract_file_excerpt_for_action,
     resolve_action_anchors,
 )
 from titan_plugin_github.widgets.comment_view import CommentView
@@ -402,3 +403,71 @@ def test_force_general_body_defaults_to_inline_placement():
     payload = build_review_action_payload([_make_action(12)], commit_sha="abc123", diff=DIFF)
 
     assert payload["comments"][0]["line"] == 12
+
+
+# ---------------------------------------------------------------------------
+# Real code for findings the diff cannot anchor
+# ---------------------------------------------------------------------------
+
+_PREEXISTING_FILE = "\n".join(f"code line {n}" for n in range(1, 16))
+
+
+def _manager_with_content(content=_PREEXISTING_FILE):
+    from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+
+    manager = DiffContextManager.from_diff(DIFF)
+    manager.attach_content_provider(lambda path: content)
+    return manager
+
+
+class TestExtractFileExcerptForAction:
+    def test_unanchored_action_gets_an_excerpt_from_the_real_file(self):
+        """The finding is about pre-existing code, so the diff has nothing to show —
+        without this the comment appeared with no code at all."""
+        manager = _manager_with_content()
+
+        excerpt = extract_file_excerpt_for_action(_unresolved_action(line=10), manager)
+
+        assert excerpt is not None
+        assert "code line 10 ◄" in excerpt
+
+    def test_anchored_action_gets_no_excerpt(self):
+        """An anchored action already shows its diff hunk."""
+        manager = _manager_with_content()
+
+        assert extract_file_excerpt_for_action(_make_action(12), manager) is None
+
+    def test_no_manager_means_no_excerpt(self):
+        assert extract_file_excerpt_for_action(_unresolved_action(), None) is None
+
+    def test_no_content_provider_means_no_excerpt(self):
+        from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+
+        manager = DiffContextManager.from_diff(DIFF)
+
+        assert extract_file_excerpt_for_action(_unresolved_action(), manager) is None
+
+    def test_action_without_a_line_gets_no_excerpt(self):
+        manager = _manager_with_content()
+
+        assert extract_file_excerpt_for_action(_unresolved_action(line=None), manager) is None
+
+    def test_line_past_the_end_of_the_file_gets_no_excerpt(self):
+        manager = _manager_with_content()
+
+        assert extract_file_excerpt_for_action(_unresolved_action(line=999), manager) is None
+
+
+def test_comment_view_renders_the_excerpt_for_an_unanchored_finding():
+    manager = _manager_with_content()
+    action = _unresolved_action(line=10)
+    excerpt = extract_file_excerpt_for_action(action, manager)
+
+    view = CommentView.from_action(action, file_excerpt=excerpt)
+
+    assert view.file_excerpt is not None
+    assert view.file_excerpt_line == 10
+    # Still no line: the finding remains unpublishable inline, the excerpt only
+    # explains what the finding is about.
+    assert view.line is None
+    assert view.line_label == "⚠ outside this PR's diff (AI said 10)"

--- a/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
@@ -161,3 +161,119 @@ def test_comment_view_from_action_prefers_resolved_line_label():
 
     assert view.line == 12
     assert view.line_label == "Line 12 (AI 999 via snippet)"
+
+
+# ---------------------------------------------------------------------------
+# D-008: publish gate validates against GitHub's diff, not the -U20 context diff
+# ---------------------------------------------------------------------------
+
+WIDE_CONTEXT_DIFF = """\
+diff --git a/src/foo.py b/src/foo.py
+index abc..def 100644
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -10,20 +10,21 @@
+ line10
+ line11
+ line12
+ line13
+ line14
+ line15
+ line16
+ line17
+ line18
+ line19
++line20_added
+ line21
+ line22
+ line23
+ line24
+ line25
+ line26
+ line27
+ line28
+ line29
+ line30
+"""
+
+GITHUB_U3_DIFF = """\
+diff --git a/src/foo.py b/src/foo.py
+index abc..def 100644
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -17,6 +17,7 @@
+ line17
+ line18
+ line19
++line20_added
+ line21
+ line22
+ line23
+"""
+
+
+def _make_action(resolved_line):
+    return ReviewActionProposal(
+        action_type=ReviewActionType.NEW_COMMENT,
+        source=ReviewActionSource.NEW_FINDING,
+        path="src/foo.py",
+        line=resolved_line,
+        resolved_line=resolved_line,
+        resolution_source="validated_line",
+        title="Test",
+        body="Comment body",
+        reasoning="Why",
+    )
+
+
+def test_payload_rejects_wide_context_only_line_with_github_diff_attached():
+    """The D-004 422 case: line 10 is valid in the -U20 diff but absent from GitHub's."""
+    from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+
+    manager = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+    manager.attach_github_diff(GITHUB_U3_DIFF)
+
+    payload = build_review_action_payload(
+        [_make_action(10), _make_action(20)],
+        commit_sha="abc123",
+        diff=WIDE_CONTEXT_DIFF,
+        diff_manager=manager,
+    )
+
+    # line 20 (added, in GitHub's hunk) goes inline; line 10 degrades to the body
+    assert [c["line"] for c in payload["comments"]] == [20]
+    assert "line 10" in payload["body"]
+
+
+def test_payload_without_github_diff_falls_back_to_added_lines_only():
+    from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+
+    manager = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+
+    payload = build_review_action_payload(
+        [_make_action(18), _make_action(20)],
+        commit_sha="abc123",
+        diff=WIDE_CONTEXT_DIFF,
+        diff_manager=manager,
+    )
+
+    # only the added line survives inline; the context line (18) degrades safely
+    assert [c["line"] for c in payload["comments"]] == [20]
+    assert "line 18" in payload["body"]
+
+
+def test_resolve_action_anchors_marks_inline_safety_from_publishable_lines():
+    from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+
+    manager = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+    manager.attach_github_diff(GITHUB_U3_DIFF)
+
+    actions = resolve_action_anchors(
+        [_make_action(10), _make_action(20)],
+        diff=WIDE_CONTEXT_DIFF,
+        diff_manager=manager,
+    )
+
+    by_line = {a.resolved_line: a for a in actions}
+    assert by_line[20].is_inline_safe_for_github is True
+    assert by_line[10].is_inline_safe_for_github is False

--- a/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
@@ -3,6 +3,7 @@ from titan_plugin_github.models.review_models import Finding, ReviewActionPropos
 from titan_plugin_github.operations.review_action_operations import (
     build_new_comment_actions,
     build_review_action_payload,
+    detect_head_sha_drift,
     extract_diff_hunk_for_action,
     resolve_action_anchors,
 )
@@ -277,3 +278,127 @@ def test_resolve_action_anchors_marks_inline_safety_from_publishable_lines():
     by_line = {a.resolved_line: a for a in actions}
     assert by_line[20].is_inline_safe_for_github is True
     assert by_line[10].is_inline_safe_for_github is False
+
+
+# ---------------------------------------------------------------------------
+# Unresolved anchors must not be displayed as if they were verified
+# ---------------------------------------------------------------------------
+
+
+def _unresolved_action(action_type=ReviewActionType.NEW_COMMENT, line=102):
+    return ReviewActionProposal(
+        action_type=action_type,
+        source=ReviewActionSource.NEW_FINDING,
+        path="src/findings_operations.py",
+        line=line,
+        original_line=line,
+        resolved_line=None,
+        title="Test",
+        body="Comment body",
+        reasoning="Why",
+        thread_id="t1" if action_type != ReviewActionType.NEW_COMMENT else None,
+    )
+
+
+def test_unresolved_new_comment_is_labelled_as_outside_the_diff():
+    """The finding is real but about pre-existing code the PR never touched, so the AI's
+    line number was never validated — showing it bare claimed precision nothing backs."""
+    view = CommentView.from_action(_unresolved_action())
+
+    assert view.line_label == "⚠ outside this PR's diff (AI said 102)"
+
+
+def test_unresolved_new_comment_carries_no_line():
+    """With no line there is no code block, which matches
+    extract_diff_hunk_for_action returning no hunk for an unresolved anchor."""
+    view = CommentView.from_action(_unresolved_action())
+
+    assert view.line is None
+
+
+def test_unresolved_new_comment_without_any_line_still_says_outside_diff():
+    view = CommentView.from_action(_unresolved_action(line=None))
+
+    assert view.line_label == "⚠ outside this PR's diff"
+
+
+def test_thread_reply_keeps_its_line_when_unresolved():
+    """A reply inherits the existing thread's position, which GitHub already accepted —
+    it is not an anchoring failure and must not be labelled as one."""
+    view = CommentView.from_action(_unresolved_action(ReviewActionType.REPLY_TO_THREAD, line=541))
+
+    assert view.line_label == "Line 541"
+    assert view.line == 541
+
+
+def test_resolved_new_comment_is_unaffected():
+    action = ReviewActionProposal(
+        action_type=ReviewActionType.NEW_COMMENT,
+        source=ReviewActionSource.NEW_FINDING,
+        path="src/foo.py",
+        line=12,
+        original_line=12,
+        resolved_line=12,
+        resolution_source="validated_line",
+        title="Test",
+        body="Comment body",
+        reasoning="Why",
+    )
+
+    view = CommentView.from_action(action)
+
+    assert view.line == 12
+    assert view.line_label == "Line 12"
+
+
+# ---------------------------------------------------------------------------
+# Head SHA drift: resolved lines describe one specific commit's diff
+# ---------------------------------------------------------------------------
+
+_SHA_A = "a1b2c3d4" + "0" * 32
+_SHA_B = "e5f6a7b8" + "0" * 32
+
+
+class TestDetectHeadShaDrift:
+    def test_same_sha_is_not_drift(self):
+        drift = detect_head_sha_drift(_SHA_A, _SHA_A)
+
+        assert drift.drifted is False
+        assert drift.message == ""
+
+    def test_different_sha_is_drift_with_both_shas_in_the_message(self):
+        drift = detect_head_sha_drift(_SHA_A, _SHA_B)
+
+        assert drift.drifted is True
+        assert "a1b2c3d4" in drift.message
+        assert "e5f6a7b8" in drift.message
+
+    def test_unknown_current_sha_is_not_reported_as_drift(self):
+        """An unverifiable comparison is not evidence of a change, and the publish
+        gate still validates every line against the diff."""
+        assert detect_head_sha_drift(_SHA_A, None).drifted is False
+        assert detect_head_sha_drift(_SHA_A, "").drifted is False
+
+    def test_unknown_reviewed_sha_is_not_reported_as_drift(self):
+        assert detect_head_sha_drift(None, _SHA_B).drifted is False
+
+    def test_whitespace_is_ignored(self):
+        assert detect_head_sha_drift(f"  {_SHA_A}\n", _SHA_A).drifted is False
+
+
+def test_force_general_body_sends_publishable_lines_to_the_body():
+    """The drift response: line 12 is perfectly publishable, but it describes the
+    old commit's diff, so it must not be published inline."""
+    payload = build_review_action_payload(
+        [_make_action(12)], commit_sha="abc123", diff=DIFF, force_general_body=True
+    )
+
+    assert payload["comments"] == []
+    assert "src/foo.py" in payload["body"]
+    assert "(line 12)" in payload["body"]
+
+
+def test_force_general_body_defaults_to_inline_placement():
+    payload = build_review_action_payload([_make_action(12)], commit_sha="abc123", diff=DIFF)
+
+    assert payload["comments"][0]["line"] == 12

--- a/plugins/titan-plugin-github/tests/services/test_review_service.py
+++ b/plugins/titan-plugin-github/tests/services/test_review_service.py
@@ -314,3 +314,101 @@ def test_submit_review_pending_review_exists(review_service, mock_gh_network):
     assert result.error_code == "PENDING_REVIEW_EXISTS"
     assert "review in progress" in result.error_message.lower()
     assert result.log_level == "warning"
+
+
+# ---------------------------------------------------------------------------
+# get_pr_general_comments: issue comments + submitted review bodies
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_general_comments_graphql_response():
+    """Issue comments plus reviews: one with findings, one pending, one empty approval."""
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "comments": {
+                        "nodes": [
+                            {
+                                "databaseId": 2001,
+                                "body": "General question about the approach",
+                                "author": {"login": "human", "name": "Human"},
+                                "createdAt": "2026-07-31T06:00:00Z",
+                                "updatedAt": "2026-07-31T06:00:00Z",
+                            }
+                        ]
+                    },
+                    "reviews": {
+                        "nodes": [
+                            {
+                                "databaseId": 3001,
+                                "body": "**src/foo.py** (line 866):\nFinding text",
+                                "state": "COMMENTED",
+                                "author": {"login": "titan", "name": "Titan"},
+                                "createdAt": "2026-07-31T06:11:00Z",
+                                "updatedAt": "2026-07-31T06:11:00Z",
+                            },
+                            {
+                                "databaseId": 3002,
+                                "body": "",
+                                "state": "APPROVED",
+                                "author": {"login": "human", "name": "Human"},
+                                "createdAt": "2026-07-31T07:00:00Z",
+                                "updatedAt": "2026-07-31T07:00:00Z",
+                            },
+                            {
+                                "databaseId": 3003,
+                                "body": "draft notes",
+                                "state": "PENDING",
+                                "author": {"login": "human", "name": "Human"},
+                                "createdAt": None,
+                                "updatedAt": None,
+                            },
+                        ]
+                    },
+                }
+            }
+        }
+    }
+
+
+def test_get_pr_general_comments_includes_submitted_review_bodies(
+    review_service, mock_graphql_network, sample_general_comments_graphql_response
+):
+    """Review bodies are where unanchorable findings end up — the respond
+    workflow must see them, not just issue comments."""
+    mock_graphql_network.run_query.return_value = sample_general_comments_graphql_response
+
+    result = review_service.get_pr_general_comments(42)
+
+    assert isinstance(result, ClientSuccess)
+    bodies = [t.main_comment.body for t in result.data]
+    assert "General question about the approach" in bodies
+    assert "**src/foo.py** (line 866):\nFinding text" in bodies
+
+
+def test_get_pr_general_comments_skips_pending_and_empty_reviews(
+    review_service, mock_graphql_network, sample_general_comments_graphql_response
+):
+    mock_graphql_network.run_query.return_value = sample_general_comments_graphql_response
+
+    result = review_service.get_pr_general_comments(42)
+
+    assert isinstance(result, ClientSuccess)
+    assert len(result.data) == 2  # 1 issue comment + 1 submitted review with body
+    assert all(t.is_general_comment for t in result.data)
+
+
+def test_get_pr_general_comments_without_reviews_key_still_works(
+    review_service, mock_graphql_network
+):
+    """Defensive: a response missing the reviews connection must not break."""
+    mock_graphql_network.run_query.return_value = {
+        "data": {"repository": {"pullRequest": {"comments": {"nodes": []}}}}
+    }
+
+    result = review_service.get_pr_general_comments(42)
+
+    assert isinstance(result, ClientSuccess)
+    assert result.data == []

--- a/plugins/titan-plugin-github/tests/services/test_review_service.py
+++ b/plugins/titan-plugin-github/tests/services/test_review_service.py
@@ -412,3 +412,21 @@ def test_get_pr_general_comments_without_reviews_key_still_works(
 
     assert isinstance(result, ClientSuccess)
     assert result.data == []
+
+
+# ---------------------------------------------------------------------------
+# add_issue_comment: body must travel via stdin, not as a literal "-"
+# ---------------------------------------------------------------------------
+
+
+def test_add_issue_comment_reads_body_from_stdin(review_service, mock_gh_network):
+    """gh api needs "body=@-" to read the field from stdin — a bare "body=-" is
+    taken literally and every general reply gets posted as a one-dash comment
+    (live-observed on PR #253, 2026-07-31)."""
+    result = review_service.add_issue_comment(42, "Actual reply text")
+
+    assert isinstance(result, ClientSuccess)
+    args, kwargs = mock_gh_network.run_command.call_args
+    assert "body=@-" in args[0]
+    assert "body=-" not in args[0]
+    assert kwargs.get("stdin_input") == "Actual reply text"

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -965,3 +965,137 @@ def test_ai_thread_resolution_falls_back_to_empty_decisions_on_parse_failure(mon
 
     assert isinstance(result, Success)
     assert ctx.data["raw_thread_decisions"] == []
+
+
+# ---------------------------------------------------------------------------
+# File-read access guard: the fallback root is the user's own checkout, which is
+# usually on a different branch than the PR head.
+# ---------------------------------------------------------------------------
+
+_HEAD_SHA = "a" * 40
+_OTHER_SHA = "b" * 40
+
+
+def _read_access_ctx(*, head_sha=_HEAD_SHA, checkout_sha=_HEAD_SHA, dirty=False, with_git=True):
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_commit_sha"] = head_sha
+    if with_git:
+        ctx.git = Mock()
+        ctx.git.get_current_commit.return_value = ClientSuccess(data=checkout_sha, message="ok")
+        ctx.git.has_uncommitted_changes.return_value = ClientSuccess(data=dirty, message="ok")
+    else:
+        ctx.git = None
+    return ctx
+
+
+def test_file_read_access_trusts_worktree_without_querying_git():
+    ctx = _read_access_ctx(checkout_sha=_OTHER_SHA)
+
+    access = code_review_steps._resolve_file_read_access(ctx, "/tmp/titan-review-1")
+
+    assert access.allowed is True
+    assert access.source == "worktree"
+    ctx.git.get_current_commit.assert_not_called()
+
+
+def test_file_read_access_allows_clean_checkout_at_pr_head():
+    ctx = _read_access_ctx()
+
+    access = code_review_steps._resolve_file_read_access(ctx, None)
+
+    assert access.allowed is True
+    assert access.source == "checkout"
+
+
+def test_file_read_access_blocks_checkout_on_another_branch():
+    """The failure mode: create_worktree failed (on_error: continue) and the user is
+    sitting on an unrelated branch."""
+    ctx = _read_access_ctx(checkout_sha=_OTHER_SHA)
+
+    access = code_review_steps._resolve_file_read_access(ctx, None)
+
+    assert access.allowed is False
+
+
+def test_file_read_access_blocks_dirty_checkout():
+    ctx = _read_access_ctx(dirty=True)
+
+    access = code_review_steps._resolve_file_read_access(ctx, None)
+
+    assert access.allowed is False
+
+
+def test_file_read_access_blocks_when_git_queries_fail():
+    ctx = _read_access_ctx()
+    ctx.git.get_current_commit.return_value = ClientError(
+        error_message="not a repo", error_code="GIT_ERROR"
+    )
+
+    access = code_review_steps._resolve_file_read_access(ctx, None)
+
+    assert access.allowed is False
+
+
+def test_file_read_access_blocks_without_git_client():
+    ctx = _read_access_ctx(with_git=False)
+
+    access = code_review_steps._resolve_file_read_access(ctx, None)
+
+    assert access.allowed is False
+
+
+def test_file_read_access_blocks_when_head_sha_unknown():
+    ctx = _read_access_ctx(head_sha="")
+
+    access = code_review_steps._resolve_file_read_access(ctx, None)
+
+    assert access.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Submit-time head SHA re-check: the bundle SHA is minutes old by then
+# ---------------------------------------------------------------------------
+
+
+def _drift_ctx(current_sha_result):
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.github = Mock()
+    ctx.github.get_pr_commit_sha.return_value = current_sha_result
+    return ctx
+
+
+def test_submit_sha_drift_detected_when_pr_was_pushed_to():
+    ctx = _drift_ctx(ClientSuccess(data="b" * 40, message="ok"))
+
+    drift = code_review_steps._detect_submit_time_sha_drift(ctx, 123, "a" * 40)
+
+    assert drift.drifted is True
+    assert drift.current_sha == "b" * 40
+
+
+def test_submit_sha_no_drift_when_head_is_unchanged():
+    ctx = _drift_ctx(ClientSuccess(data="a" * 40, message="ok"))
+
+    drift = code_review_steps._detect_submit_time_sha_drift(ctx, 123, "a" * 40)
+
+    assert drift.drifted is False
+
+
+def test_submit_sha_recheck_failure_does_not_block_the_submission():
+    """The publish gate already validates lines against the diff, so a failed
+    re-check must not degrade or cancel an otherwise valid review."""
+    ctx = _drift_ctx(ClientError(error_message="api down", error_code="GH_ERROR"))
+
+    drift = code_review_steps._detect_submit_time_sha_drift(ctx, 123, "a" * 40)
+
+    assert drift.drifted is False
+
+
+def test_submit_sha_drift_ignores_surrounding_whitespace():
+    ctx = _drift_ctx(ClientSuccess(data=f"  {'a' * 40}\n", message="ok"))
+
+    drift = code_review_steps._detect_submit_time_sha_drift(ctx, 123, "a" * 40)
+
+    assert drift.drifted is False

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -474,3 +474,81 @@ class TestPublishableLines:
 
         all_lines = mgr.get_all_publishable_lines()
         assert all_lines == {"src/foo.py": frozenset({17, 18, 19, 20, 21, 22, 23})}
+
+
+# ---------------------------------------------------------------------------
+# Resolver v2 (line-anchoring-003: D-002/D-005 reproduced false positive)
+# ---------------------------------------------------------------------------
+
+# The generic line `return None` is ADDED in two different hunks:
+# hunk 1 -> new-file line 5, hunk 2 -> new-file line 53.
+DUPLICATE_SNIPPET_DIFF = """\
+diff --git a/src/svc.py b/src/svc.py
+index 111..222 100644
+--- a/src/svc.py
++++ b/src/svc.py
+@@ -3,5 +3,6 @@
+ def early_helper(x):
+     if not x:
++        return None
+     return x
+
+@@ -48,6 +50,7 @@
+ def late_handler(y):
+     value = compute(y)
+     if value is None:
++        return None
+     return value
+"""
+
+
+class TestResolverV2:
+    def _mgr(self):
+        return DiffContextManager.from_diff(DUPLICATE_SNIPPET_DIFF)
+
+    def test_repro_duplicate_snippet_no_longer_relocates_valid_ai_line(self):
+        """The reproduced false positive: the AI reported line 53 with snippet
+        'return None' (also added at line 5, an earlier hunk). The old resolver
+        returned 5 — first global occurrence — silently relocating a correct
+        comment to the wrong hunk."""
+        resolved = self._mgr().resolve_line_anchor("src/svc.py", line=53, snippet="return None")
+
+        assert resolved == 53
+
+    def test_ambiguous_snippet_with_ai_line_among_matches_keeps_it(self):
+        resolved = self._mgr().resolve_line_anchor("src/svc.py", line=5, snippet="return None")
+
+        assert resolved == 5
+
+    def test_unique_snippet_match_still_corrects_offset_ai_line(self):
+        # snippet unique in the file; AI line slightly off (52) — snippet wins
+        resolved = self._mgr().resolve_line_anchor(
+            "src/svc.py", line=52, snippet="value = compute(y)"
+        )
+
+        assert resolved == 51
+
+    def test_ambiguous_snippet_without_usable_ai_line_prefers_publishable_then_first(self):
+        resolved = self._mgr().resolve_line_anchor("src/svc.py", line=None, snippet="return None")
+
+        assert resolved == 5
+
+    def test_ambiguous_snippet_without_usable_ai_line_prefers_nearest_publishable(self):
+        # AI line 999 (not valid, not a match) — nearest publishable match wins
+        resolved = self._mgr().resolve_line_anchor("src/svc.py", line=999, snippet="return None")
+
+        assert resolved == 53
+
+    def test_find_lines_by_snippet_returns_all_matches_in_order(self):
+        assert self._mgr().find_lines_by_snippet("src/svc.py", "return None") == [5, 53]
+
+    def test_polluted_snippets_are_sanitized_before_matching(self):
+        """Models copy prompt-annotation prefixes ('NN | ', 'NN [ADDED] ', '+')
+        into the snippet — the old matcher lost the anchor entirely."""
+        mgr = self._mgr()
+
+        for polluted in ("53 [ADDED] return None", "53 | return None", "+return None"):
+            assert mgr.find_lines_by_snippet("src/svc.py", polluted) == [5, 53], polluted
+
+    def test_find_line_by_snippet_compat_returns_first_match(self):
+        assert self._mgr().find_line_by_snippet("src/svc.py", "return None") == 5

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -6,7 +6,10 @@ outdated comments, suggestions multiline, snippet match,
 líneas válidas para inline comment, y fallbacks.
 """
 
-from titan_plugin_github.managers.diff_context_manager import DiffContextManager
+from titan_plugin_github.managers.diff_context_manager import (
+    DiffContextManager,
+    get_or_create_diff_manager,
+)
 from titan_plugin_github.managers.diff_context_manager import _extract_best_anchor_from_text
 
 
@@ -709,3 +712,58 @@ class TestCrlfDiffs:
 
         assert mgr.get_file("src/win.py").hunks_consistent is True
         assert mgr.get_publishable_lines("src/win.py") == frozenset({2})
+
+
+# ---------------------------------------------------------------------------
+# Manager cache: a refetched diff must not keep serving the previous parse
+# ---------------------------------------------------------------------------
+
+class TestGetOrCreateDiffManager:
+    def test_parses_and_caches_on_first_call(self):
+        cache = {}
+
+        mgr = get_or_create_diff_manager(SIMPLE_DIFF, cache)
+
+        assert mgr.get_file("src/foo.py") is not None
+        assert get_or_create_diff_manager(SIMPLE_DIFF, cache) is mgr
+
+    def test_same_diff_reuses_the_cached_manager(self):
+        cache = {}
+        first = get_or_create_diff_manager(SIMPLE_DIFF, cache)
+
+        assert get_or_create_diff_manager(SIMPLE_DIFF, cache) is first
+
+    def test_changed_diff_reparses_instead_of_serving_stale_lines(self):
+        """The bug: a diff refetched after a push kept returning the old manager, so
+        every anchor resolved against line numbers from the previous revision."""
+        cache = {}
+        get_or_create_diff_manager(SIMPLE_DIFF, cache)
+
+        refreshed = get_or_create_diff_manager(MULTI_HUNK_DIFF, cache)
+
+        assert refreshed.get_file("src/bar.py") is not None
+        assert refreshed.get_file("src/foo.py") is None
+
+    def test_reverting_to_the_previous_diff_reparses_too(self):
+        cache = {}
+        first = get_or_create_diff_manager(SIMPLE_DIFF, cache)
+        get_or_create_diff_manager(MULTI_HUNK_DIFF, cache)
+
+        back = get_or_create_diff_manager(SIMPLE_DIFF, cache)
+
+        assert back is not first
+        assert back.get_file("src/foo.py") is not None
+
+    def test_distinct_cache_keys_stay_independent(self):
+        cache = {}
+
+        review = get_or_create_diff_manager(SIMPLE_DIFF, cache, cache_key="review")
+        thread = get_or_create_diff_manager(MULTI_HUNK_DIFF, cache, cache_key="thread")
+
+        assert get_or_create_diff_manager(SIMPLE_DIFF, cache, cache_key="review") is review
+        assert get_or_create_diff_manager(MULTI_HUNK_DIFF, cache, cache_key="thread") is thread
+
+    def test_works_without_a_cache(self):
+        mgr = get_or_create_diff_manager(SIMPLE_DIFF)
+
+        assert mgr.get_file("src/foo.py") is not None

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -474,11 +474,13 @@ class TestPublishableLines:
         assert not mgr.has_github_diff
         assert mgr.get_publishable_lines("src/foo.py") == frozenset({20})
 
-    def test_file_missing_from_github_diff_has_no_publishable_lines(self):
+    def test_file_missing_from_github_diff_falls_back_to_added_lines(self):
+        # GitHub omits `patch` for large files, so a missing entry doesn't mean
+        # the file is un-commentable — added lines remain publishable.
         mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
         mgr.attach_github_diff(GITHUB_U3_DIFF.replace("src/foo.py", "src/other.py"))
 
-        assert mgr.get_publishable_lines("src/foo.py") == frozenset()
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset({20})
 
     def test_get_all_publishable_lines_covers_union_of_paths(self):
         mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -767,3 +767,117 @@ class TestGetOrCreateDiffManager:
         mgr = get_or_create_diff_manager(SIMPLE_DIFF)
 
         assert mgr.get_file("src/foo.py") is not None
+
+
+# ---------------------------------------------------------------------------
+# File-content provider: code the diff does not contain at all
+# ---------------------------------------------------------------------------
+
+FILE_CONTENT = "\n".join(f"line {n}" for n in range(1, 21))
+
+
+class TestContentProvider:
+    def test_no_provider_means_no_content(self):
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+
+        assert mgr.has_content_provider is False
+        assert mgr.get_file_content("src/foo.py") is None
+        assert mgr.build_file_excerpt("src/foo.py", 10) is None
+
+    def test_provider_supplies_content(self):
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+        mgr.attach_content_provider(lambda path: FILE_CONTENT)
+
+        assert mgr.has_content_provider is True
+        assert mgr.get_file_content("src/foo.py") == FILE_CONTENT
+
+    def test_content_is_cached_per_path(self):
+        calls = []
+
+        def provider(path):
+            calls.append(path)
+            return FILE_CONTENT
+
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+        mgr.attach_content_provider(provider)
+
+        mgr.get_file_content("src/foo.py")
+        mgr.get_file_content("src/foo.py")
+
+        assert calls == ["src/foo.py"]
+
+    def test_missing_file_is_cached_too(self):
+        calls = []
+
+        def provider(path):
+            calls.append(path)
+            return None
+
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+        mgr.attach_content_provider(provider)
+
+        assert mgr.get_file_content("gone.py") is None
+        assert mgr.get_file_content("gone.py") is None
+        assert calls == ["gone.py"]
+
+    def test_provider_exception_never_breaks_rendering(self):
+        def provider(path):
+            raise OSError("worktree vanished")
+
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+        mgr.attach_content_provider(provider)
+
+        assert mgr.get_file_content("src/foo.py") is None
+        assert mgr.build_file_excerpt("src/foo.py", 5) is None
+
+    def test_reattaching_a_provider_clears_the_cache(self):
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+        mgr.attach_content_provider(lambda path: "old content")
+        mgr.get_file_content("src/foo.py")
+
+        mgr.attach_content_provider(lambda path: "new content")
+
+        assert mgr.get_file_content("src/foo.py") == "new content"
+
+
+class TestBuildFileExcerpt:
+    def _mgr(self, content=FILE_CONTENT):
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+        mgr.attach_content_provider(lambda path: content)
+        return mgr
+
+    def test_centres_the_window_on_the_target_line(self):
+        excerpt = self._mgr().build_file_excerpt("src/foo.py", 10, before=2, after=2)
+
+        assert excerpt.splitlines() == [
+            " 8 | line 8",
+            " 9 | line 9",
+            "10 | line 10 ◄",
+            "11 | line 11",
+            "12 | line 12",
+        ]
+
+    def test_marks_only_the_target_line(self):
+        excerpt = self._mgr().build_file_excerpt("src/foo.py", 10, before=2, after=2)
+
+        assert excerpt.count("◄") == 1
+
+    def test_window_is_clamped_at_the_start_of_the_file(self):
+        excerpt = self._mgr().build_file_excerpt("src/foo.py", 2, before=6, after=1)
+
+        assert excerpt.splitlines()[0] == "1 | line 1"
+
+    def test_window_is_clamped_at_the_end_of_the_file(self):
+        excerpt = self._mgr().build_file_excerpt("src/foo.py", 20, before=1, after=6)
+
+        assert excerpt.splitlines()[-1] == "20 | line 20 ◄"
+
+    def test_line_beyond_the_file_returns_none(self):
+        """The AI's line was never validated — it can point past the file's end."""
+        assert self._mgr().build_file_excerpt("src/foo.py", 999) is None
+
+    def test_non_positive_line_returns_none(self):
+        assert self._mgr().build_file_excerpt("src/foo.py", 0) is None
+
+    def test_empty_content_returns_none(self):
+        assert self._mgr(content="").build_file_excerpt("src/foo.py", 1) is None

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -258,6 +258,15 @@ class TestBuildFocusedDiff:
         result = mgr.build_focused_diff("src/foo.py", 10, is_outdated=True)
         assert "◄" not in result
 
+    def test_outdated_large_hunk_does_not_mark_a_coincidental_new_line(self):
+        """In the outdated path target_line is an old-file number. SIMPLE_DIFF is
+        small enough to return unchanged, but a large hunk goes through
+        _rebuild_diff, where a new-file line sharing the number used to get the ◄
+        marker — pointing the reader at the wrong line."""
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+        result = mgr.build_focused_diff("src/foo.py", 25, is_outdated=True)
+        assert "◄" not in result
+
     def test_unknown_file_returns_empty(self):
         """Should return empty string for a file not in the diff."""
         mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
@@ -505,6 +514,22 @@ index 111..222 100644
 """
 
 
+# One snippet occurrence on a context line (1) and one on an added line (3): with
+# no GitHub diff attached only added lines are publishable, so the resolver must
+# prefer 3 — anchoring to the context line would be rejected by GitHub.
+PUBLISHABLE_PREFERENCE_DIFF = """\
+diff --git a/src/pref.py b/src/pref.py
+index 111..222 100644
+--- a/src/pref.py
++++ b/src/pref.py
+@@ -1,3 +1,4 @@
+ log.debug("retry")
+ def handler(x):
++    log.debug("retry")
+ return x
+"""
+
+
 class TestResolverV2:
     def _mgr(self):
         return DiffContextManager.from_diff(DUPLICATE_SNIPPET_DIFF)
@@ -522,6 +547,13 @@ class TestResolverV2:
         resolved = self._mgr().resolve_line_anchor("src/svc.py", line=5, snippet="return None")
 
         assert resolved == 5
+
+    def test_ambiguous_snippet_with_ai_line_valid_elsewhere_keeps_the_ai_line(self):
+        """Line 51 is a valid review line but NOT among the snippet matches [5, 53]:
+        a validated AI line must win over an ambiguous guess, not be relocated."""
+        resolved = self._mgr().resolve_line_anchor("src/svc.py", line=51, snippet="return None")
+
+        assert resolved == 51
 
     def test_unique_snippet_match_still_corrects_offset_ai_line(self):
         # snippet unique in the file; AI line slightly off (52) — snippet wins
@@ -544,6 +576,17 @@ class TestResolverV2:
 
     def test_find_lines_by_snippet_returns_all_matches_in_order(self):
         assert self._mgr().find_lines_by_snippet("src/svc.py", "return None") == [5, 53]
+
+    def test_ambiguous_snippet_prefers_the_publishable_match_over_the_first(self):
+        """In DUPLICATE_SNIPPET_DIFF both matches are added lines, so the
+        publishable-preference sort key never discriminates there. Here the snippet
+        matches a context line (1) and an added line (3); with no GitHub diff
+        attached only the added line is publishable — anchoring to 1 would 422."""
+        mgr = DiffContextManager.from_diff(PUBLISHABLE_PREFERENCE_DIFF)
+
+        resolved = mgr.resolve_line_anchor("src/pref.py", line=None, snippet='log.debug("retry")')
+
+        assert resolved == 3
 
     def test_polluted_snippets_are_sanitized_before_matching(self):
         """Models copy prompt-annotation prefixes ('NN | ', 'NN [ADDED] ', '+')
@@ -589,6 +632,31 @@ DESYNCED_DIFF = (
     "@@ -1,3 +1,4 @@\n"
     " import os\n"
     "+import sys\n"
+)
+
+# A file that embeds diff text as string literals: its added lines include
+# "+++ b/..." (rendered "++++ b/...") and "@@ ..." (rendered "+@@ ..."), which a
+# naive not-startswith("+++") guard skips, desyncing every counter after them.
+EMBEDDED_DIFF_TEXT_DIFF = (
+    "diff --git a/tests/fixture_diffs.py b/tests/fixture_diffs.py\n"
+    "index 111..222 100644\n"
+    "--- a/tests/fixture_diffs.py\n"
+    "+++ b/tests/fixture_diffs.py\n"
+    "@@ -1,2 +1,14 @@\n"
+    " import textwrap\n"
+    " EMBEDDED = textwrap.dedent(\n"
+    "+    '''\n"
+    "+diff --git a/src/foo.py b/src/foo.py\n"
+    "+index abc..def 100644\n"
+    "+--- a/src/foo.py\n"
+    "++++ b/src/foo.py\n"
+    "+@@ -10,2 +10,3 @@\n"
+    "+ line10\n"
+    "++line11_added\n"
+    "+ line12\n"
+    "+    '''\n"
+    "+)\n"
+    '+MARKER = "end"\n'
 )
 
 QUOTED_PATH_DIFF = (
@@ -677,6 +745,33 @@ class TestHunkHeaderSelfCheck:
 
         assert mgr.get_publishable_lines("src/foo.py") == frozenset()
         assert mgr.get_publishable_lines("src/ok.py") == frozenset({20})
+
+
+class TestEmbeddedDiffTextCounting:
+    """Files that contain diff text as string literals (e.g. test fixtures) must
+    still count against the @@ header — the live PR #253 run degraded a correctly
+    anchorable inline comment to the general body because of this."""
+
+    def test_added_file_header_lines_keep_the_hunk_consistent(self):
+        mgr = DiffContextManager.from_diff(EMBEDDED_DIFF_TEXT_DIFF)
+
+        hunk = mgr.get_hunks("tests/fixture_diffs.py")[0]
+        assert hunk.header_consistent is True
+        assert mgr.get_file("tests/fixture_diffs.py").hunks_consistent is True
+
+    def test_lines_after_embedded_headers_are_not_shifted(self):
+        """Pre-fix, the '++++ b/...' added line was skipped, so every later line
+        resolved one short (MARKER landed on 13 instead of 14)."""
+        mgr = DiffContextManager.from_diff(EMBEDDED_DIFF_TEXT_DIFF)
+
+        assert mgr.find_line_by_snippet("tests/fixture_diffs.py", 'MARKER = "end"') == 14
+
+    def test_embedded_header_lines_are_valid_added_lines(self):
+        mgr = DiffContextManager.from_diff(EMBEDDED_DIFF_TEXT_DIFF)
+
+        publishable = mgr.get_publishable_lines("tests/fixture_diffs.py")
+        # 6/7/8 are the embedded '--- a/', '+++ b/' and '@@' lines — all added here
+        assert {6, 7, 8, 14} <= set(publishable)
 
 
 class TestQuotedPathHeaders:

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -369,3 +369,108 @@ return route.toPath()
         result = _extract_best_anchor_from_text(text)
 
         assert result == "return route.toPath()"
+
+
+# ---------------------------------------------------------------------------
+# Publishable lines (D-008: GitHub diff as placement truth)
+# ---------------------------------------------------------------------------
+
+# Same change as WIDE_CONTEXT_DIFF below, but with GitHub's 3-line context:
+# only lines 17-23 exist in GitHub's hunk.
+GITHUB_U3_DIFF = """\
+diff --git a/src/foo.py b/src/foo.py
+index abc..def 100644
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -17,6 +17,7 @@
+ line17
+ line18
+ line19
++line20_added
+ line21
+ line22
+ line23
+"""
+
+# The same change generated with extended context (-U20 style): the hunk covers
+# many more context lines (10-30) that GitHub does NOT accept for inline comments.
+WIDE_CONTEXT_DIFF = """\
+diff --git a/src/foo.py b/src/foo.py
+index abc..def 100644
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -10,20 +10,21 @@
+ line10
+ line11
+ line12
+ line13
+ line14
+ line15
+ line16
+ line17
+ line18
+ line19
++line20_added
+ line21
+ line22
+ line23
+ line24
+ line25
+ line26
+ line27
+ line28
+ line29
+ line30
+"""
+
+
+class TestPublishableLines:
+    def test_added_lines_tracked_separately_from_context(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+
+        hunks = mgr.get_hunks("src/foo.py")
+        assert len(hunks) == 1
+        assert hunks[0].added_lines == frozenset({20})
+        # valid_review_lines keeps its historical added+context semantics
+        assert 20 in hunks[0].valid_review_lines
+        assert 10 in hunks[0].valid_review_lines
+
+    def test_fallback_without_github_diff_is_added_lines_only(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+
+        assert not mgr.has_github_diff
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset({20})
+
+    def test_github_diff_widens_fallback_to_its_own_hunk_lines(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+        mgr.attach_github_diff(GITHUB_U3_DIFF)
+
+        publishable = mgr.get_publishable_lines("src/foo.py")
+        assert mgr.has_github_diff
+        # GitHub's hunk lines (17-23) are publishable...
+        assert publishable == frozenset({17, 18, 19, 20, 21, 22, 23})
+        # ...but the -U20-only context lines are not (the D-004 422 case: line 10)
+        assert 10 not in publishable
+        # while the context diff still considers them valid for anchoring/display
+        assert 10 in mgr.get_valid_review_lines("src/foo.py")
+
+    def test_attach_empty_github_diff_keeps_fallback(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+        mgr.attach_github_diff("")
+        mgr.attach_github_diff("   \n")
+
+        assert not mgr.has_github_diff
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset({20})
+
+    def test_file_missing_from_github_diff_has_no_publishable_lines(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+        mgr.attach_github_diff(GITHUB_U3_DIFF.replace("src/foo.py", "src/other.py"))
+
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset()
+
+    def test_get_all_publishable_lines_covers_union_of_paths(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+        mgr.attach_github_diff(GITHUB_U3_DIFF)
+
+        all_lines = mgr.get_all_publishable_lines()
+        assert all_lines == {"src/foo.py": frozenset({17, 18, 19, 20, 21, 22, 23})}

--- a/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
+++ b/plugins/titan-plugin-github/tests/unit/test_diff_context_manager.py
@@ -19,7 +19,7 @@ diff --git a/src/foo.py b/src/foo.py
 index abc..def 100644
 --- a/src/foo.py
 +++ b/src/foo.py
-@@ -10,6 +10,7 @@
+@@ -10,5 +10,6 @@
  def hello():
      print("hello")
 +    print("world")
@@ -33,13 +33,13 @@ diff --git a/src/bar.py b/src/bar.py
 index 111..222 100644
 --- a/src/bar.py
 +++ b/src/bar.py
-@@ -1,5 +1,6 @@
+@@ -1,4 +1,5 @@
  import os
 +import sys
  import re
 
  def first():
-@@ -20,4 +21,5 @@
+@@ -20,2 +21,3 @@
  def second():
      pass
 +    # new comment
@@ -51,7 +51,7 @@ diff --git a/src/baz.py b/src/baz.py
 index aaa..bbb 100644
 --- a/src/baz.py
 +++ b/src/baz.py
-@@ -5,7 +5,6 @@
+@@ -5,4 +5,3 @@
  def foo():
 -    old_line_1 = True
 -    old_line_2 = False
@@ -487,13 +487,13 @@ diff --git a/src/svc.py b/src/svc.py
 index 111..222 100644
 --- a/src/svc.py
 +++ b/src/svc.py
-@@ -3,5 +3,6 @@
+@@ -3,3 +3,4 @@
  def early_helper(x):
      if not x:
 +        return None
      return x
 
-@@ -48,6 +50,7 @@
+@@ -48,4 +50,5 @@
  def late_handler(y):
      value = compute(y)
      if value is None:
@@ -552,3 +552,160 @@ class TestResolverV2:
 
     def test_find_line_by_snippet_compat_returns_first_match(self):
         assert self._mgr().find_line_by_snippet("src/svc.py", "return None") == 5
+
+
+# ---------------------------------------------------------------------------
+# Parser hardening: empty context lines, @@ self-check, quoted paths, CRLF
+# ---------------------------------------------------------------------------
+
+# An empty context line that lost its leading space ("" instead of " ") — e.g.
+# a trailing-whitespace-stripping transport. Not counting it shifts every
+# subsequent line of the hunk by one (the classic "comment lands N lines off").
+STRIPPED_EMPTY_CONTEXT_DIFF = (
+    "diff --git a/src/pkg.py b/src/pkg.py\n"
+    "index 111..222 100644\n"
+    "--- a/src/pkg.py\n"
+    "+++ b/src/pkg.py\n"
+    "@@ -1,6 +1,6 @@\n"
+    " import os\n"
+    "\n"  # empty context line whose leading space was stripped
+    " def run():\n"
+    "-    pass\n"
+    "+    return os.name\n"
+    " \n"
+    " # end\n"
+)
+
+# Hunk header declares 4 new-file lines but the body only has 2 — a desync the
+# self-check must flag so the file degrades to general-body placement.
+DESYNCED_DIFF = (
+    "diff --git a/src/foo.py b/src/foo.py\n"
+    "index 111..222 100644\n"
+    "--- a/src/foo.py\n"
+    "+++ b/src/foo.py\n"
+    "@@ -1,3 +1,4 @@\n"
+    " import os\n"
+    "+import sys\n"
+)
+
+QUOTED_PATH_DIFF = (
+    'diff --git "a/src/my file.py" "b/src/my file.py"\n'
+    "index 111..222 100644\n"
+    '--- "a/src/my file.py"\n'
+    '+++ "b/src/my file.py"\n'
+    "@@ -1,2 +1,3 @@\n"
+    " x = 1\n"
+    "+y = 2\n"
+    " z = 3\n"
+)
+
+CRLF_DIFF = (
+    "diff --git a/src/win.py b/src/win.py\r\n"
+    "index 111..222 100644\r\n"
+    "--- a/src/win.py\r\n"
+    "+++ b/src/win.py\r\n"
+    "@@ -1,2 +1,3 @@\r\n"
+    " x = 1\r\n"
+    "+y = 2\r\n"
+    " z = 3\r\n"
+)
+
+
+class TestEmptyContextLineCounting:
+    def test_lines_after_stripped_empty_line_are_not_shifted(self):
+        """Without counting "" as context, '# end' would resolve to line 5 instead of 6."""
+        mgr = DiffContextManager.from_diff(STRIPPED_EMPTY_CONTEXT_DIFF)
+
+        assert mgr.find_line_by_snippet("src/pkg.py", "# end") == 6
+        assert mgr.find_line_by_snippet("src/pkg.py", "return os.name") == 4
+
+    def test_hunk_with_stripped_empty_line_passes_self_check(self):
+        mgr = DiffContextManager.from_diff(STRIPPED_EMPTY_CONTEXT_DIFF)
+
+        hunk = mgr.get_hunks("src/pkg.py")[0]
+        assert hunk.header_consistent is True
+        assert mgr.get_file("src/pkg.py").hunks_consistent is True
+
+    def test_stripped_empty_line_is_a_valid_review_line(self):
+        mgr = DiffContextManager.from_diff(STRIPPED_EMPTY_CONTEXT_DIFF)
+
+        assert 2 in mgr.get_valid_review_lines("src/pkg.py")
+
+
+class TestHunkHeaderSelfCheck:
+    def test_consistent_hunk_is_flagged_consistent(self):
+        mgr = DiffContextManager.from_diff(SIMPLE_DIFF)
+
+        assert mgr.get_hunks("src/foo.py")[0].header_consistent is True
+
+    def test_desynced_hunk_is_flagged_inconsistent(self):
+        mgr = DiffContextManager.from_diff(DESYNCED_DIFF)
+
+        hunk = mgr.get_hunks("src/foo.py")[0]
+        assert hunk.header_consistent is False
+        assert mgr.get_file("src/foo.py").hunks_consistent is False
+
+    def test_desynced_file_has_no_publishable_lines(self):
+        """The load-bearing degradation: a desynced parse must never publish
+        potentially-shifted lines inline — not even its added lines."""
+        mgr = DiffContextManager.from_diff(DESYNCED_DIFF)
+
+        assert 2 in mgr.get_file("src/foo.py").added_lines  # parsed, but untrusted
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset()
+
+    def test_desynced_context_diff_wins_over_attached_github_diff(self):
+        """Anchors resolve against the context diff; if that parse desynced, an
+        intact GitHub diff cannot make its lines trustworthy."""
+        mgr = DiffContextManager.from_diff(DESYNCED_DIFF)
+        mgr.attach_github_diff(GITHUB_U3_DIFF)
+
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset()
+
+    def test_desynced_github_diff_falls_back_to_added_lines(self):
+        mgr = DiffContextManager.from_diff(WIDE_CONTEXT_DIFF)
+        mgr.attach_github_diff(DESYNCED_DIFF)
+
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset({20})
+
+    def test_desync_does_not_affect_other_files(self):
+        mgr = DiffContextManager.from_diff(
+            DESYNCED_DIFF + WIDE_CONTEXT_DIFF.replace("src/foo.py", "src/ok.py")
+        )
+
+        assert mgr.get_publishable_lines("src/foo.py") == frozenset()
+        assert mgr.get_publishable_lines("src/ok.py") == frozenset({20})
+
+
+class TestQuotedPathHeaders:
+    def test_quoted_path_with_spaces_is_indexed(self):
+        mgr = DiffContextManager.from_diff(QUOTED_PATH_DIFF)
+
+        assert mgr.get_file("src/my file.py") is not None
+        assert mgr.find_line_by_snippet("src/my file.py", "y = 2") == 2
+
+    def test_quoted_path_hunk_is_consistent(self):
+        mgr = DiffContextManager.from_diff(QUOTED_PATH_DIFF)
+
+        assert mgr.get_file("src/my file.py").hunks_consistent is True
+        assert mgr.get_publishable_lines("src/my file.py") == frozenset({2})
+
+
+class TestCrlfDiffs:
+    def test_crlf_path_is_indexed_without_carriage_return(self):
+        mgr = DiffContextManager.from_diff(CRLF_DIFF)
+
+        assert mgr.get_file("src/win.py") is not None
+        assert mgr.get_file("src/win.py\r") is None
+
+    def test_crlf_snippet_search_matches(self):
+        mgr = DiffContextManager.from_diff(CRLF_DIFF)
+
+        assert mgr.find_line_by_snippet("src/win.py", "y = 2") == 2
+        # snippet itself polluted with \r (copy-paste from CRLF content)
+        assert mgr.find_line_by_snippet("src/win.py", "y = 2\r") == 2
+
+    def test_crlf_hunk_passes_self_check(self):
+        mgr = DiffContextManager.from_diff(CRLF_DIFF)
+
+        assert mgr.get_file("src/win.py").hunks_consistent is True
+        assert mgr.get_publishable_lines("src/win.py") == frozenset({2})

--- a/plugins/titan-plugin-github/tests/unit/test_worktree_operations.py
+++ b/plugins/titan-plugin-github/tests/unit/test_worktree_operations.py
@@ -127,6 +127,21 @@ class TestClearStaleWorktree:
 
         mock_git_client.prune_worktrees.assert_called_once()
 
+    def test_prune_runs_after_the_directory_removal(self, mock_git_client, tmp_path):
+        """prune only clears metadata for worktrees whose directory is MISSING —
+        pruning before the rmtree would leave the stale entry behind (PR #253
+        review finding on the original remove → prune → rmtree order)."""
+        leftover = tmp_path / "titan-review-7"
+        leftover.mkdir()
+        dir_exists_at_prune_time = {}
+        mock_git_client.prune_worktrees.side_effect = (
+            lambda: dir_exists_at_prune_time.setdefault("value", leftover.exists())
+        )
+
+        clear_stale_worktree(mock_git_client, "wt/path", str(leftover))
+
+        assert dir_exists_at_prune_time["value"] is False
+
     def test_removes_directory_even_when_git_steps_raise(self, mock_git_client, tmp_path):
         leftover = tmp_path / "titan-review-999"
         leftover.mkdir()

--- a/plugins/titan-plugin-github/tests/unit/test_worktree_operations.py
+++ b/plugins/titan-plugin-github/tests/unit/test_worktree_operations.py
@@ -2,11 +2,13 @@
 Unit tests for worktree operations
 """
 
+
 import pytest
 from titan_cli.core.result import ClientError
 from titan_plugin_github.operations.worktree_operations import (
     setup_worktree,
     cleanup_worktree,
+    clear_stale_worktree,
     commit_in_worktree,
 )
 
@@ -39,6 +41,84 @@ class TestSetupWorktree:
 
         mock_git_client.remove_worktree.assert_called_once()
         mock_git_client.create_worktree.assert_called_once()
+
+    def test_prunes_stale_metadata_before_creating(self, mock_git_client):
+        """A previous run whose directory vanished leaves metadata that makes
+        'remove' fail and 'add' refuse the path — only prune clears it."""
+        setup_worktree(mock_git_client, 123, "feature-branch")
+
+        mock_git_client.prune_worktrees.assert_called_once()
+
+    def test_creation_still_proceeds_when_remove_and_prune_fail(self, mock_git_client):
+        """Neither cleanup step is a precondition: a clean path needs no cleanup."""
+        mock_git_client.remove_worktree.side_effect = Exception("not a working tree")
+        mock_git_client.prune_worktrees.side_effect = Exception("prune exploded")
+
+        abs_path, success = setup_worktree(mock_git_client, 123, "feature-branch")
+
+        assert success is True
+        mock_git_client.create_worktree.assert_called_once()
+
+
+@pytest.mark.unit
+class TestClearStaleWorktree:
+    """Test making a worktree path reusable after a previous run left residue"""
+
+    def test_removes_leftover_directory_git_does_not_know_about(
+        self, mock_git_client, tmp_path
+    ):
+        """The residue git commands can't touch: a directory with no registration.
+        'worktree add' refuses a non-empty path, so it must be deleted."""
+        leftover = tmp_path / "titan-review-123"
+        leftover.mkdir()
+        (leftover / "some_file.txt").write_text("residue")
+
+        clear_stale_worktree(mock_git_client, ".titan/worktrees/titan-review-123", str(leftover))
+
+        assert not leftover.exists()
+
+    def test_calls_remove_then_prune(self, mock_git_client, tmp_path):
+        clear_stale_worktree(mock_git_client, "wt/path", str(tmp_path / "absent"))
+
+        mock_git_client.remove_worktree.assert_called_once_with("wt/path", force=True)
+        mock_git_client.prune_worktrees.assert_called_once()
+
+    def test_prunes_even_when_remove_raises(self, mock_git_client, tmp_path):
+        """'remove' fails with "not a working tree" for exactly the stale-metadata
+        case prune exists to fix — it must not short-circuit the prune."""
+        mock_git_client.remove_worktree.side_effect = Exception("not a working tree")
+
+        clear_stale_worktree(mock_git_client, "wt/path", str(tmp_path / "absent"))
+
+        mock_git_client.prune_worktrees.assert_called_once()
+
+    def test_removes_directory_even_when_git_steps_raise(self, mock_git_client, tmp_path):
+        leftover = tmp_path / "titan-review-999"
+        leftover.mkdir()
+        mock_git_client.remove_worktree.side_effect = Exception("boom")
+        mock_git_client.prune_worktrees.side_effect = Exception("boom")
+
+        clear_stale_worktree(mock_git_client, "wt/path", str(leftover))
+
+        assert not leftover.exists()
+
+    def test_no_directory_removal_without_absolute_path(self, mock_git_client):
+        clear_stale_worktree(mock_git_client, "wt/path")
+
+        mock_git_client.remove_worktree.assert_called_once()
+        mock_git_client.prune_worktrees.assert_called_once()
+
+    def test_tolerates_missing_directory(self, mock_git_client, tmp_path):
+        clear_stale_worktree(mock_git_client, "wt/path", str(tmp_path / "never_existed"))
+
+    def test_leaves_a_file_at_that_path_untouched(self, mock_git_client, tmp_path):
+        """Only directories are worktree residue; a file there is someone else's."""
+        not_a_dir = tmp_path / "titan-review-1"
+        not_a_dir.write_text("unrelated")
+
+        clear_stale_worktree(mock_git_client, "wt/path", str(not_a_dir))
+
+        assert not_a_dir.exists()
 
     def test_handles_refspec_fetch_failure(self, mock_git_client):
         """Test handling of refspec fetch failure for fork PRs."""

--- a/plugins/titan-plugin-github/tests/unit/test_worktree_operations.py
+++ b/plugins/titan-plugin-github/tests/unit/test_worktree_operations.py
@@ -59,6 +59,41 @@ class TestSetupWorktree:
         assert success is True
         mock_git_client.create_worktree.assert_called_once()
 
+    def test_handles_refspec_fetch_failure(self, mock_git_client):
+        """Test handling of refspec fetch failure for fork PRs."""
+        mock_git_client.fetch_refspec.return_value = ClientError(
+            error_message="Fetch failed", error_code="FETCH_ERROR"
+        )
+
+        abs_path, success = setup_worktree(mock_git_client, 123, "feature-branch")
+
+        assert success is False
+        assert abs_path == ""
+        mock_git_client.create_worktree.assert_not_called()
+
+    def test_handles_creation_failure(self, mock_git_client):
+        """Test handling of worktree creation failure"""
+        mock_git_client.create_worktree.return_value = ClientError(
+            error_message="Creation failed", error_code="WORKTREE_CREATE_ERROR"
+        )
+
+        abs_path, success = setup_worktree(mock_git_client, 123, "feature-branch")
+
+        assert success is False
+        assert abs_path == ""
+
+    def test_uses_custom_base_path(self, mock_git_client):
+        """Test using custom base path for worktrees"""
+        abs_path, success = setup_worktree(
+            mock_git_client,
+            456,
+            "branch",
+            base_path="/custom/path"
+        )
+
+        assert success is True
+        assert "titan-review-456" in abs_path
+
 
 @pytest.mark.unit
 class TestClearStaleWorktree:
@@ -119,42 +154,6 @@ class TestClearStaleWorktree:
         clear_stale_worktree(mock_git_client, "wt/path", str(not_a_dir))
 
         assert not_a_dir.exists()
-
-    def test_handles_refspec_fetch_failure(self, mock_git_client):
-        """Test handling of refspec fetch failure for fork PRs."""
-        mock_git_client.fetch_refspec.return_value = ClientError(
-            error_message="Fetch failed", error_code="FETCH_ERROR"
-        )
-
-        abs_path, success = setup_worktree(mock_git_client, 123, "feature-branch")
-
-        assert success is False
-        assert abs_path == ""
-        mock_git_client.create_worktree.assert_not_called()
-
-    def test_handles_creation_failure(self, mock_git_client):
-        """Test handling of worktree creation failure"""
-        from titan_cli.core.result import ClientError
-        mock_git_client.create_worktree.return_value = ClientError(
-            error_message="Creation failed", error_code="WORKTREE_CREATE_ERROR"
-        )
-
-        abs_path, success = setup_worktree(mock_git_client, 123, "feature-branch")
-
-        assert success is False
-        assert abs_path == ""
-
-    def test_uses_custom_base_path(self, mock_git_client):
-        """Test using custom base path for worktrees"""
-        abs_path, success = setup_worktree(
-            mock_git_client,
-            456,
-            "branch",
-            base_path="/custom/path"
-        )
-
-        assert success is True
-        assert "titan-review-456" in abs_path
 
 
 @pytest.mark.unit

--- a/plugins/titan-plugin-github/tests/unit/test_worktree_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_worktree_steps.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for worktree steps.
+
+Focus: cleanup must never stop the workflow. It runs after the review has been
+submitted, and it also has to tolerate a run where worktree creation failed —
+returning Exit in either case would abort the remaining steps.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_cli.engine import WorkflowContext
+from titan_cli.engine.results import Skip, Success
+from titan_plugin_github.steps.worktree_steps import cleanup_worktree_step
+
+
+class _FakeTextual:
+    def begin_step(self, _name):
+        pass
+
+    def end_step(self, _status):
+        pass
+
+    def dim_text(self, _text):
+        pass
+
+    def warning_text(self, _text):
+        pass
+
+    def success_text(self, _text):
+        pass
+
+    class _Loading:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def loading(self, _text):
+        return self._Loading()
+
+
+def _make_context(*, worktree_created=True, worktree_path="/tmp/wt", with_git=True):
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    if with_git:
+        ctx.git = Mock()
+        ctx.git.remove_worktree.return_value = ClientSuccess(data=None, message="Removed")
+    else:
+        ctx.git = None
+    ctx.data["worktree_created"] = worktree_created
+    if worktree_path is not None:
+        ctx.data["worktree_path"] = worktree_path
+    return ctx
+
+
+@pytest.mark.unit
+class TestCleanupWorktreeStep:
+    def test_successful_cleanup_returns_success(self):
+        ctx = _make_context()
+
+        result = cleanup_worktree_step(ctx)
+
+        assert isinstance(result, Success)
+        ctx.git.remove_worktree.assert_called_once_with("/tmp/wt", force=True)
+
+    def test_nothing_to_clean_up_skips_instead_of_exiting(self):
+        """A failed worktree creation must not abort everything downstream."""
+        ctx = _make_context(worktree_created=False)
+
+        result = cleanup_worktree_step(ctx)
+
+        assert isinstance(result, Skip)
+
+    def test_missing_path_skips(self):
+        ctx = _make_context(worktree_path=None)
+
+        result = cleanup_worktree_step(ctx)
+
+        assert isinstance(result, Skip)
+
+    def test_missing_git_client_skips(self):
+        ctx = _make_context(with_git=False)
+
+        result = cleanup_worktree_step(ctx)
+
+        assert isinstance(result, Skip)
+
+    def test_failed_removal_skips(self):
+        ctx = _make_context()
+        ctx.git.remove_worktree.return_value = ClientError(
+            error_message="not a working tree", error_code="WORKTREE_REMOVE_ERROR"
+        )
+
+        result = cleanup_worktree_step(ctx)
+
+        assert isinstance(result, Skip)

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/network/graphql_queries.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/network/graphql_queries.py
@@ -62,6 +62,21 @@ query($owner: String!, $repo: String!, $prNumber: Int!) {
           updatedAt
         }
       }
+      reviews(first: 50) {
+        nodes {
+          databaseId
+          body
+          state
+          author {
+            login
+            ... on User {
+              name
+            }
+          }
+          createdAt: submittedAt
+          updatedAt: submittedAt
+        }
+      }
     }
   }
 }

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/review_service.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/review_service.py
@@ -434,7 +434,9 @@ class ReviewService:
             args = [
                 "api", "-X", "POST",
                 f"/repos/{repo}/issues/{pr_number}/comments",
-                "-F", "body=-",
+                # "@-" makes gh read the field value from stdin; a bare "-" is
+                # taken literally and posts a one-dash comment.
+                "-F", "body=@-",
             ]
 
             self.gh.run_command(args, stdin_input=body)

--- a/plugins/titan-plugin-github/titan_plugin_github/clients/services/review_service.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/clients/services/review_service.py
@@ -113,8 +113,11 @@ class ReviewService:
         """
         Get general PR comments (not attached to code lines).
 
-        Uses GraphQL to fetch top-level PR comments and wraps each one as
-        a pseudo-thread (thread_id = "general_{id}") for uniform rendering.
+        Uses GraphQL to fetch top-level PR comments AND submitted review bodies
+        (the summary text of a review — where findings without an inline anchor
+        end up), wrapping each one as a pseudo-thread (thread_id = "general_{id}")
+        for uniform rendering. Pending reviews and empty review bodies (plain
+        approvals) are skipped.
 
         Args:
             pr_number: PR number
@@ -137,16 +140,22 @@ class ReviewService:
                 variables
             )
 
-            comments_data = (
+            pull_request = (
                 response.get("data", {})
                 .get("repository", {})
                 .get("pullRequest", {})
-                .get("comments", {})
-                .get("nodes", [])
             )
+            comments_data = pull_request.get("comments", {}).get("nodes", [])
+            # The query aliases submittedAt as createdAt/updatedAt, so review
+            # nodes parse with the same network model as issue comments.
+            reviews_data = [
+                r for r in pull_request.get("reviews", {}).get("nodes", [])
+                if (r.get("body") or "").strip() and r.get("state") != "PENDING"
+            ]
 
             network_comments = [
-                GraphQLIssueComment.from_graphql(c) for c in comments_data
+                GraphQLIssueComment.from_graphql(c)
+                for c in comments_data + reviews_data
             ]
 
             ui_threads = [

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -415,7 +415,10 @@ class DiffContextManager:
             lines = hunk.content.split("\n")
             current = hunk.new_line_start
             for line in lines[1:]:  # skip @@ header
-                if line.startswith("+") and not line.startswith("+++"):
+                # Inside a hunk body "+++" can only be an added line whose content
+                # starts with "++" (file headers precede the first @@) — a
+                # not-startswith("+++") guard here desyncs the counter on such lines.
+                if line.startswith("+"):
                     if snippet_stripped in line[1:].strip():
                         matches.append(current)
                     current += 1
@@ -725,7 +728,10 @@ def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
     current = new_start
 
     for line in lines[1:]:
-        if line.startswith("+") and not line.startswith("+++"):
+        # Inside a hunk body "+++" can only be an added line whose content starts
+        # with "++" (file headers precede the first @@) — guarding against it here
+        # would desync the counter on files that embed diff text.
+        if line.startswith("+"):
             valid_lines.add(current)
             added_lines.add(current)
             current += 1
@@ -790,10 +796,13 @@ def _build_focused_diff_from_hunk(
 
     parsed: list[tuple] = []  # (old_num, new_num, raw_line, idx)
     for idx, raw in enumerate(lines[1:], start=1):
-        if raw.startswith("+") and not raw.startswith("+++"):
+        # No "+++"/"---" guards: file headers precede the first @@, so inside a
+        # hunk body those prefixes are real added/deleted lines (e.g. embedded
+        # diff text) and skipping them would desync both counters.
+        if raw.startswith("+"):
             parsed.append((None, new_line, raw, idx))
             new_line += 1
-        elif raw.startswith("-") and not raw.startswith("---"):
+        elif raw.startswith("-"):
             parsed.append((old_line, None, raw, idx))
             old_line += 1
         elif raw.startswith(" ") or raw in ("", "\r"):
@@ -820,7 +829,16 @@ def _build_focused_diff_from_hunk(
     else:
         return hunk_content
 
-    return _rebuild_diff(extracted, old_start, new_start, header_suffix, target_line)
+    # In the outdated path target_line is an old-file number, but _rebuild_diff's
+    # ◄ marker compares against new-file numbers — a coincidental match would point
+    # the reader at the wrong line, so no marker is better than a lying one.
+    return _rebuild_diff(
+        extracted,
+        old_start,
+        new_start,
+        header_suffix,
+        None if is_outdated else target_line,
+    )
 
 
 def _rebuild_diff(
@@ -890,7 +908,9 @@ def _extract_lines_from_hunk(
     extracted: list[str] = []
 
     for line in lines[1:]:
-        if line.startswith("+") and not line.startswith("+++"):
+        # "+++" here is an added line starting with "++", not a file header —
+        # see _parse_hunk.
+        if line.startswith("+"):
             if current >= target_line and len(extracted) < count:
                 extracted.append(line[1:])
             current += 1

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -13,8 +13,9 @@ Usage:
 
 from __future__ import annotations
 
+import hashlib
 import re
-from typing import Optional
+from typing import Callable, Optional
 
 from titan_cli.core.logging import get_logger
 from ..models.diff_models import (
@@ -52,6 +53,9 @@ class DiffContextManager:
         # generated with extended context (-U20) for AI quality; GitHub validates inline
         # comment lines against ITS diff only, so publishable lines must come from here.
         self._github_parsed: Optional[ParsedDiff] = None
+        # Optional source of whole-file content, for code the diff does not contain at all.
+        self._content_provider: Optional[Callable[[str], Optional[str]]] = None
+        self._content_cache: dict[str, Optional[str]] = {}
 
     # ------------------------------------------------------------------
     # Construction
@@ -276,6 +280,92 @@ class DiffContextManager:
         if self._github_parsed is not None:
             paths |= set(self._github_parsed.files)
         return {path: self.get_publishable_lines(path) for path in paths}
+
+    # ------------------------------------------------------------------
+    # File content (code the diff does not contain)
+    # ------------------------------------------------------------------
+
+    def attach_content_provider(self, provider: Callable[[str], Optional[str]]) -> None:
+        """
+        Attach a source of whole-file content, keyed by repo-relative path.
+
+        Every other method here reads from the parsed diff, so it can only describe lines
+        the diff contains. A finding about pre-existing code the PR never touched has no
+        such lines — without a provider there is nothing to show for it at all. The
+        provider is expected to return content for the PR's head revision (or None), and
+        results are cached per path.
+        """
+        self._content_provider = provider
+        self._content_cache = {}
+        logger.debug("attach_content_provider: provider attached")
+
+    @property
+    def has_content_provider(self) -> bool:
+        """Return True when a file-content provider has been attached."""
+        return self._content_provider is not None
+
+    def get_file_content(self, path: str) -> Optional[str]:
+        """Return whole-file content for ``path`` via the attached provider, or None."""
+        if self._content_provider is None:
+            return None
+        if path in self._content_cache:
+            return self._content_cache[path]
+
+        try:
+            content = self._content_provider(path)
+        except Exception as e:
+            # A provider reads from a worktree or the network; neither should be able to
+            # break comment rendering.
+            logger.debug("get_file_content: provider failed for %s: %s", path, e)
+            content = None
+
+        self._content_cache[path] = content
+        logger.debug(
+            "get_file_content: path=%s found=%s", path, content is not None
+        )
+        return content
+
+    def build_file_excerpt(
+        self,
+        path: str,
+        line: int,
+        before: int = 6,
+        after: int = 4,
+    ) -> Optional[str]:
+        """
+        Return a numbered excerpt of ``path`` centred on ``line``, from file content.
+
+        Plain file text, not diff format: these lines are unchanged by the PR, so
+        there is no +/- to show. The target line is marked so it is identifiable at a
+        glance. Returns None when no content is available or ``line`` is out of range.
+        """
+        content = self.get_file_content(path)
+        if not content or line < 1:
+            return None
+
+        lines = content.split("\n")
+        if line > len(lines):
+            logger.debug(
+                "build_file_excerpt: path=%s line=%s beyond file length %s",
+                path,
+                line,
+                len(lines),
+            )
+            return None
+
+        start = max(1, line - before)
+        end = min(len(lines), line + after)
+        width = len(str(end))
+
+        excerpt = []
+        for number in range(start, end + 1):
+            marker = " ◄" if number == line else ""
+            excerpt.append(f"{str(number).rjust(width)} | {lines[number - 1]}{marker}")
+
+        logger.debug(
+            "build_file_excerpt: path=%s line=%s window=%s-%s", path, line, start, end
+        )
+        return "\n".join(excerpt)
 
     # ------------------------------------------------------------------
     # Valid review lines
@@ -890,14 +980,31 @@ def get_or_create_diff_manager(
     cache: Optional[dict] = None,
     cache_key: str = "review_diff_manager",
 ) -> DiffContextManager:
-    """Return a cached diff manager when available, otherwise parse once and store it."""
+    """
+    Return a cached diff manager when available, otherwise parse once and store it.
+
+    The cached manager is only reused when it was built from this exact diff. Without
+    that check, re-fetching the diff (after a push, or on a retry) would silently keep
+    serving line numbers parsed from the previous one, and every anchor resolved against
+    it would be off. The hash is kept next to the manager rather than folded into
+    ``cache_key`` so callers keep passing the same key they always did.
+    """
+    diff_hash = hashlib.sha256(diff.encode("utf-8", errors="replace")).hexdigest()
+    hash_key = f"{cache_key}__diff_hash"
+
     if cache is not None:
         existing = cache.get(cache_key)
         if existing is not None:
-            logger.debug("get_or_create_diff_manager: reusing cached manager")
-            return existing
+            if cache.get(hash_key) == diff_hash:
+                logger.debug("get_or_create_diff_manager: reusing cached manager")
+                return existing
+            logger.debug(
+                "get_or_create_diff_manager: cached manager was built from a different "
+                "diff — reparsing"
+            )
 
     manager = DiffContextManager.from_diff(diff)
     if cache is not None:
         cache[cache_key] = manager
+        cache[hash_key] = diff_hash
     return manager

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -239,8 +239,9 @@ class DiffContextManager:
 
         Files whose context-diff hunks failed the @@ line-count self-check
         return an empty set: every resolved line for them may be shifted, so they
-        degrade to general-body placement. A self-check failure in the GitHub diff
-        only drops that source, falling back to the added-lines floor.
+        degrade to general-body placement. A self-check failure in the GitHub diff —
+        or a path missing from it — only drops that source, falling back to the
+        added-lines floor.
         """
         context_file = self._parsed.files.get(path)
         if context_file is not None and not context_file.hunks_consistent:
@@ -255,14 +256,23 @@ class DiffContextManager:
 
         if self._github_parsed is not None:
             file_diff = self._github_parsed.files.get(path)
-            if file_diff is not None and not file_diff.hunks_consistent:
+            if file_diff is None:
+                # The attached diff may be assembled from files-API `patch` sections,
+                # which GitHub omits for large files — a missing entry doesn't mean
+                # the file is un-commentable, so drop the source, keep the floor.
+                logger.warning(
+                    "get_publishable_lines: path=%s missing from GitHub diff "
+                    "→ falling back to added lines",
+                    path,
+                )
+            elif not file_diff.hunks_consistent:
                 logger.warning(
                     "get_publishable_lines: path=%s GitHub diff failed line-count self-check "
                     "→ falling back to added lines",
                     path,
                 )
             else:
-                lines = file_diff.valid_review_lines if file_diff else frozenset()
+                lines = file_diff.valid_review_lines
                 logger.debug(
                     "get_publishable_lines: path=%s source=github_diff count=%s", path, len(lines)
                 )

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -42,6 +42,10 @@ class DiffContextManager:
 
     def __init__(self, parsed: ParsedDiff) -> None:
         self._parsed = parsed
+        # GitHub's own diff (3 context lines), when attached. The context diff above may be
+        # generated with extended context (-U20) for AI quality; GitHub validates inline
+        # comment lines against ITS diff only, so publishable lines must come from here.
+        self._github_parsed: Optional[ParsedDiff] = None
 
     # ------------------------------------------------------------------
     # Construction
@@ -186,6 +190,64 @@ class DiffContextManager:
                 return hunk
         logger.debug(f"get_hunk_for_old_line: path={path}, old_line={line} → fallback to last hunk ({hunks[-1].old_line_start}-{hunks[-1].old_line_end})")
         return hunks[-1]
+
+    # ------------------------------------------------------------------
+    # GitHub diff attachment (publishable-lines source)
+    # ------------------------------------------------------------------
+
+    def attach_github_diff(self, diff: str) -> None:
+        """
+        Attach GitHub's own PR diff (from ``gh pr diff`` or files-API ``patch`` sections).
+
+        Once attached, ``get_publishable_lines`` validates inline placement against
+        GitHub's hunks instead of the (possibly wider-context) local diff. Attaching an
+        empty diff is a no-op — the added-lines-only fallback stays in effect.
+        """
+        if not diff or not diff.strip():
+            logger.debug("attach_github_diff: empty diff ignored")
+            return
+        self._github_parsed = _parse_diff(diff)
+        logger.debug(
+            "attach_github_diff: %s files, %s hunks",
+            len(self._github_parsed.files),
+            sum(len(f.hunks) for f in self._github_parsed.files.values()),
+        )
+
+    @property
+    def has_github_diff(self) -> bool:
+        """Return True when GitHub's own diff has been attached."""
+        return self._github_parsed is not None
+
+    def get_publishable_lines(self, path: str) -> frozenset:
+        """
+        Return new-file line numbers GitHub will accept for inline comments on ``path``.
+
+        Source precedence (never fails, only narrows):
+        1. GitHub's own diff when attached — added + context lines of ITS hunks.
+        2. Added ('+') lines from the context diff — these exist identically in any
+           diff of the same change, so GitHub always accepts them.
+        """
+        if self._github_parsed is not None:
+            file_diff = self._github_parsed.files.get(path)
+            lines = file_diff.valid_review_lines if file_diff else frozenset()
+            logger.debug(
+                "get_publishable_lines: path=%s source=github_diff count=%s", path, len(lines)
+            )
+            return lines
+
+        file_diff = self._parsed.files.get(path)
+        lines = file_diff.added_lines if file_diff else frozenset()
+        logger.debug(
+            "get_publishable_lines: path=%s source=added_lines_fallback count=%s", path, len(lines)
+        )
+        return lines
+
+    def get_all_publishable_lines(self) -> dict[str, frozenset]:
+        """Return ``{path: frozenset[line]}`` of publishable lines for every file."""
+        paths = set(self._parsed.files)
+        if self._github_parsed is not None:
+            paths |= set(self._github_parsed.files)
+        return {path: self.get_publishable_lines(path) for path in paths}
 
     # ------------------------------------------------------------------
     # Valid review lines
@@ -465,11 +527,13 @@ def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
     new_count = int(header_match.group(4)) if header_match.group(4) else 1
 
     valid_lines: set[int] = set()
+    added_lines: set[int] = set()
     current = new_start
 
     for line in lines[1:]:
         if line.startswith("+") and not line.startswith("+++"):
             valid_lines.add(current)
+            added_lines.add(current)
             current += 1
         elif line.startswith(" "):
             valid_lines.add(current)
@@ -485,6 +549,7 @@ def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
         new_line_start=new_start,
         new_line_count=new_count,
         valid_review_lines=frozenset(valid_lines),
+        added_lines=frozenset(added_lines),
     )
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -323,17 +323,17 @@ class DiffContextManager:
 
         try:
             content = self._content_provider(path)
+            # Only cache successful lookups or legitimate None returns
+            self._content_cache[path] = content
+            logger.debug(
+                "get_file_content: path=%s found=%s", path, content is not None
+            )
+            return content
         except Exception as e:
-            # A provider reads from a worktree or the network; neither should be able to
-            # break comment rendering.
-            logger.debug("get_file_content: provider failed for %s: %s", path, e)
-            content = None
-
-        self._content_cache[path] = content
-        logger.debug(
-            "get_file_content: path=%s found=%s", path, content is not None
-        )
-        return content
+            # Provider reads from worktree or network — transient failures shouldn't
+            # permanently disable excerpts for this path. Log at warning and don't cache.
+            logger.warning("get_file_content: provider failed for %s: %s", path, e)
+            return None
 
     def build_file_excerpt(
         self,

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -28,7 +28,13 @@ from ..models.view import UIComment
 logger = get_logger(__name__)
 
 _HUNK_HEADER_RE = re.compile(r"@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@(.*)")
-_FILE_HEADER_RE = re.compile(r"^diff --git a/.+ b/(.+)$")
+# Git quotes both paths when they contain spaces/special chars:
+#   diff --git "a/my file.py" "b/my file.py"
+# The trailing \r? tolerates CRLF diffs (otherwise the captured path keeps the \r
+# and every subsequent lookup by path silently misses).
+_FILE_HEADER_RE = re.compile(
+    r'^diff --git (?:a/.+ b/(?P<path>.+?)|"a/.+" "b/(?P<quoted_path>.+?)")\r?$'
+)
 _COMMENT_PREFIXES = ("//", "#", "/*", "*/", "*")
 
 
@@ -226,17 +232,39 @@ class DiffContextManager:
         1. GitHub's own diff when attached — added + context lines of ITS hunks.
         2. Added ('+') lines from the context diff — these exist identically in any
            diff of the same change, so GitHub always accepts them.
+
+        Files whose context-diff hunks failed the @@ line-count self-check
+        return an empty set: every resolved line for them may be shifted, so they
+        degrade to general-body placement. A self-check failure in the GitHub diff
+        only drops that source, falling back to the added-lines floor.
         """
+        context_file = self._parsed.files.get(path)
+        if context_file is not None and not context_file.hunks_consistent:
+            # Anchors are resolved against the context diff — if its parse desynced,
+            # any line we'd publish may be shifted. Force general-body degradation.
+            logger.warning(
+                "get_publishable_lines: path=%s context diff failed line-count self-check "
+                "→ no inline placement",
+                path,
+            )
+            return frozenset()
+
         if self._github_parsed is not None:
             file_diff = self._github_parsed.files.get(path)
-            lines = file_diff.valid_review_lines if file_diff else frozenset()
-            logger.debug(
-                "get_publishable_lines: path=%s source=github_diff count=%s", path, len(lines)
-            )
-            return lines
+            if file_diff is not None and not file_diff.hunks_consistent:
+                logger.warning(
+                    "get_publishable_lines: path=%s GitHub diff failed line-count self-check "
+                    "→ falling back to added lines",
+                    path,
+                )
+            else:
+                lines = file_diff.valid_review_lines if file_diff else frozenset()
+                logger.debug(
+                    "get_publishable_lines: path=%s source=github_diff count=%s", path, len(lines)
+                )
+                return lines
 
-        file_diff = self._parsed.files.get(path)
-        lines = file_diff.added_lines if file_diff else frozenset()
+        lines = context_file.added_lines if context_file else frozenset()
         logger.debug(
             "get_publishable_lines: path=%s source=added_lines_fallback count=%s", path, len(lines)
         )
@@ -301,7 +329,9 @@ class DiffContextManager:
                     if snippet_stripped in line[1:].strip():
                         matches.append(current)
                     current += 1
-                elif line.startswith(" "):
+                elif line.startswith(" ") or line in ("", "\r"):
+                    # "" — empty context line whose leading space was stripped in
+                    # transport; must advance the counter to stay in sync
                     if snippet_stripped in line[1:].strip():
                         matches.append(current)
                     current += 1
@@ -551,7 +581,7 @@ def _parse_diff(raw: str) -> ParsedDiff:
         if file_match:
             _flush_hunk()
             current_hunk_lines = []
-            current_path = file_match.group(1)
+            current_path = file_match.group("path") or file_match.group("quoted_path")
             if current_path not in files:
                 logger.debug(f"_parse_diff: found file: {current_path}")
                 files[current_path] = ParsedFileDiff(path=current_path, hunks=[])
@@ -571,7 +601,16 @@ def _parse_diff(raw: str) -> ParsedDiff:
 
 
 def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
-    """Parse a single hunk string into a ``ParsedHunk``. Returns None on malformed header."""
+    """
+    Parse a single hunk string into a ``ParsedHunk``. Returns None on malformed header.
+
+    Empty lines (``""``/``"\\r"``) inside the body are counted as context lines: git
+    always emits the leading space, so a bare empty line means it was stripped in
+    transport — not counting it would silently shift every subsequent line.
+    After parsing, the counted new-file lines are checked against the @@ header's
+    declared count; a mismatch marks the hunk ``header_consistent=False`` so the
+    file degrades to general-body placement instead of publishing shifted lines.
+    """
     lines = content.split("\n")
     if not lines:
         return None
@@ -579,6 +618,12 @@ def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
     header_match = _HUNK_HEADER_RE.match(lines[0])
     if not header_match:
         return None
+
+    # Trailing empty lines are join/transport artifacts, not hunk content — a real
+    # empty context line inside the hunk is " " (or "" if space-stripped, handled below).
+    while len(lines) > 1 and lines[-1] in ("", "\r"):
+        lines.pop()
+    content = "\n".join(lines)
 
     old_start = int(header_match.group(1))
     old_count = int(header_match.group(2)) if header_match.group(2) else 1
@@ -594,10 +639,23 @@ def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
             valid_lines.add(current)
             added_lines.add(current)
             current += 1
-        elif line.startswith(" "):
+        elif line.startswith(" ") or line in ("", "\r"):
             valid_lines.add(current)
             current += 1
         # '-' lines: do not advance new-file counter
+        # '\ No newline at end of file' markers: not file lines, do not count
+
+    counted_new = current - new_start
+    header_consistent = counted_new == new_count
+    if not header_consistent:
+        logger.warning(
+            "hunk_header_desync: path=%s header=%r declares %s new-file lines, parsed %s "
+            "— file will be excluded from inline placement",
+            path,
+            lines[0],
+            new_count,
+            counted_new,
+        )
 
     return ParsedHunk(
         header=lines[0],
@@ -609,6 +667,7 @@ def _parse_hunk(path: str, content: str) -> Optional[ParsedHunk]:
         new_line_count=new_count,
         valid_review_lines=frozenset(valid_lines),
         added_lines=frozenset(added_lines),
+        header_consistent=header_consistent,
     )
 
 
@@ -628,6 +687,10 @@ def _build_focused_diff_from_hunk(
     if not header_match:
         return hunk_content
 
+    # Trailing empty lines are join artifacts, not hunk content
+    while len(lines) > 1 and lines[-1] in ("", "\r"):
+        lines.pop()
+
     old_start = int(header_match.group(1))
     new_start = int(header_match.group(3))
     header_suffix = header_match.group(5)
@@ -643,7 +706,8 @@ def _build_focused_diff_from_hunk(
         elif raw.startswith("-") and not raw.startswith("---"):
             parsed.append((old_line, None, raw, idx))
             old_line += 1
-        elif raw.startswith(" "):
+        elif raw.startswith(" ") or raw in ("", "\r"):
+            # "" — space-stripped empty context line; must advance both counters
             parsed.append((old_line, new_line, raw, idx))
             old_line += 1
             new_line += 1
@@ -693,8 +757,14 @@ def _rebuild_diff(
     if extracted_old_start is None:
         extracted_old_start = old_start
 
-    old_count = sum(1 for _, _, raw, _ in extracted if raw.startswith("-") or raw.startswith(" "))
-    new_count = sum(1 for _, _, raw, _ in extracted if raw.startswith("+") or raw.startswith(" "))
+    old_count = sum(
+        1 for _, _, raw, _ in extracted
+        if raw.startswith(("-", " ")) or raw in ("", "\r")
+    )
+    new_count = sum(
+        1 for _, _, raw, _ in extracted
+        if raw.startswith(("+", " ")) or raw in ("", "\r")
+    )
 
     header = (
         f"@@ -{extracted_old_start},{old_count}"
@@ -734,7 +804,8 @@ def _extract_lines_from_hunk(
             if current >= target_line and len(extracted) < count:
                 extracted.append(line[1:])
             current += 1
-        elif line.startswith(" "):
+        elif line.startswith(" ") or line in ("", "\r"):
+            # "" — space-stripped empty context line; counts toward the new file
             if current >= target_line and len(extracted) < count:
                 extracted.append(line[1:])
             current += 1
@@ -779,10 +850,10 @@ code as ``NN | code`` (full_content) or ``NN [ADDED] code`` / ``NN [CONTEXT] cod
 
 
 def _sanitize_snippet(snippet: Optional[str]) -> str:
-    """Strip prompt-annotation prefixes and diff markers from a model-provided snippet."""
+    """Strip prompt-annotation prefixes, diff markers, and CR chars from a snippet."""
     if not snippet:
         return ""
-    text = snippet.strip()
+    text = snippet.replace("\r", "").strip()
     cleaned = _SNIPPET_ANNOTATION_RE.sub("", text)
     if cleaned != text:
         text = cleaned.strip()

--- a/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/managers/diff_context_manager.py
@@ -278,34 +278,47 @@ class DiffContextManager:
     # Snippet search
     # ------------------------------------------------------------------
 
-    def find_line_by_snippet(self, path: str, snippet: str) -> Optional[int]:
+    def find_lines_by_snippet(self, path: str, snippet: str) -> list[int]:
         """
-        Find the new-file line number of the first added/context line containing
-        ``snippet`` in ``path``.
+        Find ALL new-file line numbers of added/context lines containing
+        ``snippet`` in ``path``, in hunk order.
 
-        Returns None if the snippet is not found.
+        The snippet is sanitized first (prompt-annotation prefixes like
+        ``NN | ``, ``NN [ADDED]`` and leading diff markers are stripped —
+        models copy them from the annotated prompt code).
         """
-        if not snippet:
-            logger.debug(f"find_line_by_snippet: path={path}, snippet=<empty> → skipped")
-            return None
-        snippet_stripped = snippet.strip()
-        logger.debug(f"find_line_by_snippet: path={path}, snippet='{snippet_stripped[:50]}...'")
+        snippet_stripped = _sanitize_snippet(snippet)
+        if not snippet_stripped:
+            logger.debug(f"find_lines_by_snippet: path={path}, snippet=<empty> → skipped")
+            return []
+        logger.debug(f"find_lines_by_snippet: path={path}, snippet='{snippet_stripped[:50]}...'")
+        matches: list[int] = []
         for hunk in self.get_hunks(path):
             lines = hunk.content.split("\n")
             current = hunk.new_line_start
             for line in lines[1:]:  # skip @@ header
                 if line.startswith("+") and not line.startswith("+++"):
                     if snippet_stripped in line[1:].strip():
-                        logger.debug(f"find_line_by_snippet: found at line {current}")
-                        return current
+                        matches.append(current)
                     current += 1
                 elif line.startswith(" "):
                     if snippet_stripped in line[1:].strip():
-                        logger.debug(f"find_line_by_snippet: found at line {current}")
-                        return current
+                        matches.append(current)
                     current += 1
-        logger.debug(f"find_line_by_snippet: path={path} → not found")
-        return None
+        logger.debug(f"find_lines_by_snippet: path={path} → {len(matches)} match(es): {matches[:10]}")
+        return matches
+
+    def find_line_by_snippet(self, path: str, snippet: str) -> Optional[int]:
+        """
+        Find the new-file line number of the first added/context line containing
+        ``snippet`` in ``path``.
+
+        Returns None if the snippet is not found. Prefer ``resolve_line_anchor``
+        for anchoring decisions — first-occurrence alone is ambiguous when the
+        snippet repeats across hunks (D-002/D-005).
+        """
+        matches = self.find_lines_by_snippet(path, snippet)
+        return matches[0] if matches else None
 
     def resolve_line_anchor(
         self,
@@ -314,17 +327,63 @@ class DiffContextManager:
         snippet: Optional[str] = None,
         evidence: Optional[str] = None,
     ) -> Optional[int]:
-        """Resolve the best inline comment line using snippet/evidence before trusting AI line."""
-        search_candidates = [snippet, _extract_best_anchor_from_text(evidence)]
-        for candidate in search_candidates:
-            resolved = self.find_line_by_snippet(path, candidate or "")
-            if resolved is not None:
+        """
+        Resolve the best inline comment line for a finding.
+
+        Scoring per candidate source (snippet first, then an anchor extracted
+        from evidence), designed against the reproduced D-002/D-005 false
+        positive (duplicate snippet across hunks relocating a correct comment):
+
+        - unique match → trust it (may legitimately correct a slightly-off AI line)
+        - ambiguous match containing the AI line → the AI line
+        - ambiguous match, AI line valid elsewhere → the AI line wins over a guess
+        - ambiguous match, no usable AI line → prefer publishable lines, then
+          nearest to the AI line, then first occurrence
+        - no source matched → the AI line if valid, else None
+        """
+        for candidate in (snippet, _extract_best_anchor_from_text(evidence)):
+            matches = self.find_lines_by_snippet(path, candidate or "")
+            if not matches:
+                continue
+
+            if len(matches) == 1:
                 logger.debug(
-                    "resolve_line_anchor: path=%s resolved via snippet/evidence to line=%s",
-                    path,
-                    resolved,
+                    "resolve_line_anchor: path=%s unique snippet match line=%s", path, matches[0]
                 )
-                return resolved
+                return matches[0]
+
+            if line is not None and line in matches:
+                logger.debug(
+                    "resolve_line_anchor: path=%s ambiguous snippet, AI line %s among matches",
+                    path,
+                    line,
+                )
+                return line
+            if line is not None and line in self.get_valid_review_lines(path):
+                logger.debug(
+                    "resolve_line_anchor: path=%s ambiguous snippet %s, valid AI line %s wins",
+                    path,
+                    matches,
+                    line,
+                )
+                return line
+
+            publishable = self.get_publishable_lines(path)
+            best = min(
+                matches,
+                key=lambda m: (
+                    m not in publishable,
+                    abs(m - line) if line is not None else 0,
+                    m,
+                ),
+            )
+            logger.debug(
+                "resolve_line_anchor: path=%s ambiguous snippet %s, no usable AI line → %s",
+                path,
+                matches,
+                best,
+            )
+            return best
 
         if line is not None and line in self.get_valid_review_lines(path):
             logger.debug("resolve_line_anchor: path=%s using validated line=%s", path, line)
@@ -709,6 +768,30 @@ def build_focused_diff_from_hunk(
     and comment_view), not a full diff. Delegates to the internal helper.
     """
     return _build_focused_diff_from_hunk(hunk_content, target_line, is_outdated, before, after)
+
+
+_SNIPPET_ANNOTATION_RE = re.compile(
+    r"^\s*(?:\d+\s*)?(?:\|\s?|\[(?:ADDED|CONTEXT)\]\s?)"
+)
+"""Prompt-annotation prefixes models copy into `snippet`: the findings prompt renders
+code as ``NN | code`` (full_content) or ``NN [ADDED] code`` / ``NN [CONTEXT] code``
+(annotated hunks) — see findings_operations._add_line_numbers/_annotate_diff_hunk."""
+
+
+def _sanitize_snippet(snippet: Optional[str]) -> str:
+    """Strip prompt-annotation prefixes and diff markers from a model-provided snippet."""
+    if not snippet:
+        return ""
+    text = snippet.strip()
+    cleaned = _SNIPPET_ANNOTATION_RE.sub("", text)
+    if cleaned != text:
+        text = cleaned.strip()
+    elif text.startswith(("+", "-")) and not text.startswith(("++", "--")):
+        # A single leading diff marker (e.g. "+return None") — strip it; real code
+        # lines starting with +/- followed by code are rare, and the substring
+        # match still works either way for most of them.
+        text = text[1:].strip()
+    return text
 
 
 def _extract_best_anchor_from_text(text: Optional[str]) -> Optional[str]:

--- a/plugins/titan-plugin-github/titan_plugin_github/models/diff_models.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/diff_models.py
@@ -28,6 +28,12 @@ class ParsedHunk:
         added_lines: New-file line numbers of added ('+') lines only. Added lines
                      exist identically in any diff of the same change regardless of
                      context width, so they are always safe inline targets for GitHub.
+        header_consistent: True when the number of new-file lines counted while
+                           parsing matches the @@ header's declared new-line count.
+                           False means the hunk body desynced from its header (e.g.
+                           lines lost or mangled in transport) and every computed
+                           line number after the desync point may be shifted —
+                           such hunks must not be trusted for inline placement.
     """
     header: str
     content: str
@@ -38,6 +44,7 @@ class ParsedHunk:
     new_line_count: int
     valid_review_lines: frozenset = field(default_factory=frozenset)
     added_lines: frozenset = field(default_factory=frozenset)
+    header_consistent: bool = True
 
     @property
     def new_line_end(self) -> int:
@@ -85,6 +92,16 @@ class ParsedFileDiff:
         for hunk in self.hunks:
             result.update(hunk.added_lines)
         return frozenset(result)
+
+    @property
+    def hunks_consistent(self) -> bool:
+        """
+        True when every hunk passed the @@ header line-count self-check.
+
+        False means at least one hunk's parsed line numbers may be shifted —
+        the file is unreliable for inline comment placement.
+        """
+        return all(hunk.header_consistent for hunk in self.hunks)
 
 
 @dataclass

--- a/plugins/titan-plugin-github/titan_plugin_github/models/diff_models.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/diff_models.py
@@ -25,6 +25,9 @@ class ParsedHunk:
         new_line_count: Number of new-file lines in this hunk
         valid_review_lines: New-file line numbers valid for inline comments
                             (added '+' and context ' ' lines only, not deleted '-')
+        added_lines: New-file line numbers of added ('+') lines only. Added lines
+                     exist identically in any diff of the same change regardless of
+                     context width, so they are always safe inline targets for GitHub.
     """
     header: str
     content: str
@@ -34,6 +37,7 @@ class ParsedHunk:
     new_line_start: int
     new_line_count: int
     valid_review_lines: frozenset = field(default_factory=frozenset)
+    added_lines: frozenset = field(default_factory=frozenset)
 
     @property
     def new_line_end(self) -> int:
@@ -72,6 +76,14 @@ class ParsedFileDiff:
         result: set[int] = set()
         for hunk in self.hunks:
             result.update(hunk.valid_review_lines)
+        return frozenset(result)
+
+    @property
+    def added_lines(self) -> frozenset:
+        """Union of added-line numbers across all hunks."""
+        result: set[int] = set()
+        for hunk in self.hunks:
+            result.update(hunk.added_lines)
         return frozenset(result)
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
@@ -24,6 +24,8 @@ from .comment_operations import (
 from .pr_operations import (
     fetch_pr_threads,
     fetch_pr_general_comments,
+    split_titan_review_body,
+    build_quote_reply,
 )
 
 from .pr_selection_operations import (
@@ -73,6 +75,8 @@ __all__ = [
     # PR operations
     "fetch_pr_threads",
     "fetch_pr_general_comments",
+    "split_titan_review_body",
+    "build_quote_reply",
     "build_pr_selection_description",
     "build_pr_selection_title",
     "format_review_status_badge",

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/__init__.py
@@ -35,6 +35,7 @@ from .pr_selection_operations import (
 from .worktree_operations import (
     setup_worktree,
     cleanup_worktree,
+    clear_stale_worktree,
     commit_in_worktree,
 )
 
@@ -79,6 +80,7 @@ __all__ = [
     # Worktree operations
     "setup_worktree",
     "cleanup_worktree",
+    "clear_stale_worktree",
     "commit_in_worktree",
 
     # PR creation operations

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -213,6 +213,15 @@ def build_review_context_package(
     manager = diff_manager or get_or_create_diff_manager(diff)
     applicable_ids = set(plan.review_axes)
     checklist_applicable = [item for item in checklist if item.id in applicable_ids] or checklist[:2]
+
+    if len(plan.extra_context_requests) > 1:
+        logger.info(
+            "extra_context_requests_trimmed: planned=%d resolved=%d dropped=%d",
+            len(plan.extra_context_requests),
+            1,
+            len(plan.extra_context_requests) - 1,
+        )
+
     related_files = resolve_context_requests(
         plan.extra_context_requests[:1], cwd, allow_file_reads=allow_file_reads
     )

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -1,5 +1,6 @@
 """Operations for resolving bounded review context from a focused review plan."""
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -23,6 +24,71 @@ from ..models.review_models import (
 )
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class FileReadAccess:
+    """
+    Whether files read from a directory can be trusted to be the PR's head revision.
+
+    Attributes:
+        allowed: True when reading files from ``root`` yields the code the diff
+                 describes. False means only diff hunks may be used.
+        source: Where the trusted content comes from — "worktree", "checkout",
+                or "none" when reads are not allowed.
+        reason: Short explanation, shown in the UI and logged.
+    """
+    allowed: bool
+    source: str
+    reason: str
+
+
+def resolve_file_read_access(
+    worktree_path: Optional[str],
+    head_sha: Optional[str] = None,
+    checkout_sha: Optional[str] = None,
+    checkout_dirty: Optional[bool] = None,
+) -> FileReadAccess:
+    """
+    Decide whether file content on disk may be used as this PR's code.
+
+    A dedicated worktree is checked out at the PR head, so it is always trusted. Without
+    one, the only directory available is the user's own checkout, which sits on whatever
+    branch they happen to be on. Reading a file from there and pairing it with the PR's
+    diff silently mixes two revisions: line numbers stop matching the hunks, and the AI
+    reviews code that is not in the PR at all. So the checkout is trusted only when it is
+    provably at the head commit with nothing modified on top.
+
+    Args:
+        worktree_path: Path to a worktree created for this PR, if any
+        head_sha: The PR head commit SHA the diff was computed against
+        checkout_sha: HEAD of the user's checkout
+        checkout_dirty: Whether the user's checkout has uncommitted changes
+
+    Returns:
+        FileReadAccess with the verdict and a reason for display
+    """
+    if worktree_path:
+        return FileReadAccess(True, "worktree", f"worktree at PR head: {worktree_path}")
+
+    if not head_sha or not checkout_sha:
+        return FileReadAccess(
+            False, "none", "no worktree and the checkout revision could not be verified"
+        )
+
+    if checkout_sha != head_sha:
+        return FileReadAccess(
+            False,
+            "none",
+            f"checkout is at {checkout_sha[:8]}, PR head is {head_sha[:8]}",
+        )
+
+    if checkout_dirty:
+        return FileReadAccess(
+            False, "none", "checkout is at the PR head but has uncommitted changes"
+        )
+
+    return FileReadAccess(True, "checkout", f"checkout verified at PR head {head_sha[:8]}")
 
 
 def extract_hunks_only(
@@ -96,7 +162,20 @@ def _find_related_context(path: str, cwd: Optional[str] = None) -> Optional[str]
     return None
 
 
-def resolve_context_requests(requests: list[ContextRequest], cwd: Optional[str] = None) -> dict[str, str]:
+def resolve_context_requests(
+    requests: list[ContextRequest],
+    cwd: Optional[str] = None,
+    allow_file_reads: bool = True,
+) -> dict[str, str]:
+    """
+    Resolve extra context requests by reading sibling files.
+
+    Returns nothing when ``allow_file_reads`` is False: these files are read whole from
+    disk, so an unverified revision would put unrelated code in the prompt.
+    """
+    if not allow_file_reads:
+        return {}
+
     result: dict[str, str] = {}
     for req in requests:
         key = f"{req.type}:{req.for_path}"
@@ -118,11 +197,21 @@ def build_review_context_package(
     strategy: ReviewStrategy,
     cwd: Optional[str] = None,
     diff_manager: Optional[DiffContextManager] = None,
+    allow_file_reads: bool = True,
 ) -> ReviewContextPackage:
+    """
+    Build the batched review context package for the AI prompt.
+
+    When ``allow_file_reads`` is False, no file is read from ``cwd``: every file falls
+    back to its diff hunks. Callers set this when the content on disk cannot be proven to
+    be the PR's head revision — see ``resolve_file_read_access``.
+    """
     manager = diff_manager or get_or_create_diff_manager(diff)
     applicable_ids = set(plan.review_axes)
     checklist_applicable = [item for item in checklist if item.id in applicable_ids] or checklist[:2]
-    related_files = resolve_context_requests(plan.extra_context_requests[:1], cwd)
+    related_files = resolve_context_requests(
+        plan.extra_context_requests[:1], cwd, allow_file_reads=allow_file_reads
+    )
     comment_context = comment_context[: strategy.max_comment_entries]
     content_budget = get_prompt_budget_manager().content_budget(strategy)
 
@@ -133,7 +222,9 @@ def build_review_context_package(
     carry_excluded: list[ExcludedFileEntry] = []
 
     for file_plan in plan.focus_files:
-        entry = _resolve_file_context(file_plan, diff, strategy, cwd, manager)
+        entry = _resolve_file_context(
+            file_plan, diff, strategy, cwd, manager, allow_file_reads=allow_file_reads
+        )
         entry_chars = entry.approximate_chars or get_prompt_budget_manager().estimate_entry_chars(entry)
         # A worktree_reference file forces the CLI to read it from disk itself, which is
         # expensive regardless of how cheap its prompt text looks — cap how many of them
@@ -197,12 +288,23 @@ def _resolve_file_context(
     strategy: ReviewStrategy,
     cwd: Optional[str] = None,
     diff_manager: Optional[DiffContextManager] = None,
+    allow_file_reads: bool = True,
 ) -> FileContextEntry:
     manager = diff_manager or DiffContextManager.from_diff(diff)
     desired_mode = file_plan.read_mode
     hunk_headers = [hunk.header for hunk in manager.get_hunks(file_plan.path)[:5]]
     file_limits = _file_limits(strategy, file_plan.path)
     resolved_entry: FileContextEntry | None = None
+
+    if not allow_file_reads and desired_mode in (FileReadMode.FULL_FILE, FileReadMode.EXPANDED_HUNKS):
+        # Content on disk is not provably this PR's revision; hunks come from the diff
+        # itself and are always correct.
+        logger.debug(
+            "file_read_not_allowed: path=%s requested_mode=%s → hunks_only",
+            file_plan.path,
+            desired_mode,
+        )
+        desired_mode = FileReadMode.HUNKS_ONLY
 
     if desired_mode == FileReadMode.FULL_FILE:
         content = read_file_content(file_plan.path, cwd)
@@ -243,7 +345,11 @@ def _resolve_file_context(
     if desired_mode == FileReadMode.HUNKS_ONLY:
         hunks = manager.get_hunk_texts(file_plan.path)
         hunks_chars = sum(len(hunk) for hunk in hunks)
-        if hunks and hunks_chars <= file_limits["max_file_chars"]:
+        if hunks and (hunks_chars <= file_limits["max_file_chars"] or not allow_file_reads):
+            # Over-budget hunks are still preferable to the worktree_reference fallback
+            # when reads are not allowed: that mode has the CLI open the file itself, which
+            # is the same wrong-revision read, just delegated. The batching loop keeps the
+            # prompt bounded via approximate_chars.
             resolved_entry = FileContextEntry(
                 path=file_plan.path,
                 read_mode=FileReadMode.HUNKS_ONLY,
@@ -252,6 +358,20 @@ def _resolve_file_context(
                 approximate_chars=hunks_chars,
             )
             return _log_file_context(resolved_entry, file_plan.path)
+
+    if not allow_file_reads:
+        # No hunks and no trustworthy file to read: headers only, so the AI still knows
+        # the file changed but is never handed content from another revision.
+        resolved_entry = FileContextEntry(
+            path=file_plan.path,
+            read_mode=FileReadMode.HUNKS_ONLY,
+            changed_hunk_headers=hunk_headers,
+            review_hint=(
+                "File content unavailable: no PR worktree and the local checkout is not "
+                "at this PR's head commit. Review from the diff only."
+            ),
+        )
+        return _log_file_context(resolved_entry, file_plan.path)
 
     resolved_entry = FileContextEntry(
         path=file_plan.path,

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/context_resolution_operations.py
@@ -83,9 +83,13 @@ def resolve_file_read_access(
             f"checkout is at {checkout_sha[:8]}, PR head is {head_sha[:8]}",
         )
 
-    if checkout_dirty:
+    if checkout_dirty or checkout_dirty is None:
         return FileReadAccess(
-            False, "none", "checkout is at the PR head but has uncommitted changes"
+            False,
+            "none",
+            "checkout is at the PR head but has uncommitted changes"
+            if checkout_dirty
+            else "checkout is at the PR head but its dirty state could not be verified",
         )
 
     return FileReadAccess(True, "checkout", f"checkout verified at PR head {head_sha[:8]}")

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -7,7 +7,7 @@ from titan_cli.core.result import ClientError, ClientResult, ClientSuccess
 
 from ..models.review_models import Finding, FocusContextBatch, ReviewChecklistItem
 from .ai_response_parsing_operations import extract_json_payload
-from .prompt_formatting_operations import comment_context_to_json
+from .prompt_formatting_operations import comment_context_to_json, extract_pr_intent_line
 
 
 def build_findings_prompt_parts(batch: FocusContextBatch) -> dict[str, str]:
@@ -72,15 +72,35 @@ def _pr_context_to_text(batch: FocusContextBatch) -> str:
     if not batch.pr_manifest:
         return f"Batch {batch.batch_id}"
     pr = batch.pr_manifest
+    # One-line intent only (cap 200 chars ≈ 50 tokens): this block repeats once per
+    # batch, so it must stay minimal (D-002 token mandate). The fuller trimmed
+    # description goes to the single-call plan phase instead.
+    intent = extract_pr_intent_line(pr.description)
     return (
         f"PR #{pr.number}: {_short_title(pr.title)}\n"
-        f"{pr.base} -> {pr.head}\n"
+        + (f"Intent: {intent}\n" if intent else "")
+        + f"{pr.base} -> {pr.head}\n"
         f"Batch: {batch.batch_id}"
     )
 
 
+_CHECKLIST_DESCRIPTION_CAP = 200
+"""Hard cap per checklist description in the findings prompt (D-002 token mandate:
+~590 chars ≈ 150 tokens per batch for 4 real items — measured on ragnarok's checklist)."""
+
+
 def _checklist_to_json(checklist: list[ReviewChecklistItem]) -> str:
-    return json.dumps([str(item.id) for item in checklist[:4]], indent=2)
+    return json.dumps(
+        [
+            {
+                "id": str(item.id),
+                "name": item.name,
+                "description": item.description[:_CHECKLIST_DESCRIPTION_CAP],
+            }
+            for item in checklist[:4]
+        ],
+        indent=2,
+    )
 def _files_context_to_text(files_context: dict) -> str:
     if not files_context:
         return "(no files to review)\n"

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/plan_prompt_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/plan_prompt_operations.py
@@ -12,7 +12,7 @@ from ..models.review_models import (
     ScoredReviewCandidate,
 )
 from ..models.review_profile_models import ReviewProfile
-from .prompt_formatting_operations import comment_context_to_json
+from .prompt_formatting_operations import comment_context_to_json, extract_pr_intent
 from .review_strategy_operations import build_deterministic_review_plan, summarize_candidate_clusters
 
 
@@ -99,7 +99,9 @@ def _manifest_to_json(manifest: ChangeManifest) -> str:
                 "base": manifest.pr.base,
                 "head": manifest.pr.head,
                 "author": manifest.pr.author,
-                "description": manifest.pr.description[:300],
+                # Deterministic trim (strip images/HTML comments/checkboxes) instead of a
+                # raw [:300] cut, which on real PRs often yields only a meme/badge URL.
+                "description": extract_pr_intent(manifest.pr.description, max_chars=800),
             },
             "files_changed": len(manifest.files),
             "total_additions": manifest.total_additions,

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/pr_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/pr_operations.py
@@ -5,9 +5,93 @@ Pure business logic for PR-related operations.
 No UI dependencies - all functions can be unit tested.
 """
 
+import re
+from dataclasses import replace
 from typing import List
 from titan_cli.core.result import ClientSuccess, ClientError
 from ..models.view import UICommentThread
+
+# One section of a Titan-generated general review body, as built by
+# build_review_action_payload: "**path** (line N):\n<body>" (or "General:" when
+# the finding had no path). Sections are joined with "\n\n---\n\n".
+_TITAN_BODY_SECTION_RE = re.compile(
+    r"^(?:\*\*(?P<path>[^*\n]+)\*\*|General)(?: \(line (?P<line>\d+)\))?:\n(?P<body>.+)$",
+    re.DOTALL,
+)
+
+
+def split_titan_review_body(thread: UICommentThread) -> List[UICommentThread]:
+    """
+    Split a Titan-generated general review body into one pseudo-thread per finding.
+
+    Titan's publish pipeline degrades findings without a valid inline anchor to
+    the review's general body, one "**path** (line N):" section per finding. As a
+    single blob those findings can't be worked one by one, so this recovers the
+    per-finding structure — each part keeps the original author/date and carries
+    its own path/line for display and AI context.
+
+    Only bodies where EVERY section matches Titan's exact format are split;
+    anything else (human general comments) is returned unchanged as a single
+    pseudo-thread.
+
+    Args:
+        thread: A general-comment pseudo-thread (is_general_comment=True)
+
+    Returns:
+        One pseudo-thread per finding, or [thread] unchanged
+    """
+    comment = thread.main_comment
+    if not thread.is_general_comment or not comment or not comment.body:
+        return [thread]
+
+    sections = comment.body.strip().split("\n\n---\n\n")
+    matches = [_TITAN_BODY_SECTION_RE.match(s.strip()) for s in sections]
+    if not all(matches):
+        return [thread]
+
+    parts: List[UICommentThread] = []
+    for i, m in enumerate(matches):
+        part_comment = replace(
+            comment,
+            # Negative synthetic id: unique per part for the reply/commit maps,
+            # and can never collide with a real (positive) GitHub comment id.
+            # General replies go via add_issue_comment, which never uses the id.
+            id=-(comment.id * 100 + i),
+            body=m.group("body").strip(),
+            path=m.group("path"),
+            line=int(m.group("line")) if m.group("line") else None,
+        )
+        parts.append(
+            UICommentThread(
+                thread_id=f"{thread.thread_id}_f{i}",
+                main_comment=part_comment,
+                replies=[],
+                is_resolved=False,
+                is_outdated=False,
+            )
+        )
+    return parts
+
+
+def build_quote_reply(original_body: str, reply_text: str, max_quote_lines: int = 6) -> str:
+    """
+    Build a GitHub quote reply: the original comment quoted in markdown, then the
+    reply. General PR comments have no thread to reply into, so the quote is what
+    ties the new issue comment back to what it answers.
+
+    Args:
+        original_body: Body of the comment being answered
+        reply_text: The reply itself
+        max_quote_lines: Quote at most this many lines of the original
+
+    Returns:
+        "> original...\\n\\nreply" markdown text
+    """
+    lines = [line for line in original_body.strip().splitlines()]
+    quoted = [f"> {line}" for line in lines[:max_quote_lines]]
+    if len(lines) > max_quote_lines:
+        quoted.append("> […]")
+    return "\n".join(quoted) + "\n\n" + reply_text.strip()
 
 
 def fetch_pr_general_comments(
@@ -15,7 +99,11 @@ def fetch_pr_general_comments(
     pr_number: int,
 ) -> List[UICommentThread]:
     """
-    Fetch general PR comments (not attached to code lines).
+    Fetch general PR comments (not attached to code lines), including submitted
+    review bodies — where Titan's own unanchorable findings end up.
+
+    Titan-generated review bodies are split into one pseudo-thread per finding
+    (see split_titan_review_body); other comments stay whole.
 
     Filters out:
     - Bot comments
@@ -54,7 +142,7 @@ def fetch_pr_general_comments(
         body_stripped = comment.body.strip()
         if body_stripped.startswith('{') and body_stripped.endswith('}'):
             continue
-        filtered.append(thread)
+        filtered.extend(split_titan_review_body(thread))
 
     return filtered
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/prompt_formatting_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/prompt_formatting_operations.py
@@ -1,8 +1,65 @@
 """Shared formatting helpers for AI review prompts."""
 
 import json
+import re
 
 from ..models.review_models import CommentContextEntry
+
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_MD_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_CHECKBOX_LINE_RE = re.compile(r"^\s*[-*]\s*\[[ xX]\]")
+_BARE_LINK_LINE_RE = re.compile(r"^\s*\[?!?\[?[^\]]*\]?\(?https?://\S+\)?\s*$")
+
+
+def extract_pr_intent(description: str, max_chars: int = 800) -> str:
+    """
+    Deterministically trim a PR description down to its reviewable intent.
+
+    Strips HTML comments (template remnants), markdown images (memes/badges),
+    checkbox lines, and bare-link lines; keeps prose and bullet text. Purely
+    deterministic — never an AI call. Returns "" when nothing meaningful remains.
+    """
+    if not description:
+        return ""
+
+    text = _HTML_COMMENT_RE.sub("", description)
+    text = _MD_IMAGE_RE.sub("", text)
+
+    kept: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if _CHECKBOX_LINE_RE.match(line) or _BARE_LINK_LINE_RE.match(line):
+            continue
+        line = line.lstrip("#").strip()
+        if line:
+            kept.append(line)
+
+    result = "\n".join(kept)
+    return result[:max_chars].rstrip()
+
+
+_MIN_INTENT_LINE_CHARS = 30
+
+
+def extract_pr_intent_line(description: str, max_chars: int = 200) -> str:
+    """
+    Return a single-line PR intent for per-batch prompts (~50 tokens max).
+
+    First substantive line of the trimmed description — short lines (section
+    headings like "PR's key points" survive the trim but carry no intent) are
+    skipped when a longer line follows. Hard-capped. Empty string when the
+    description has no reviewable prose.
+    """
+    intent = extract_pr_intent(description, max_chars=max_chars * 4)
+    if not intent:
+        return ""
+    lines = intent.splitlines()
+    first_substantive = next(
+        (line for line in lines if len(line) >= _MIN_INTENT_LINE_CHARS), lines[0]
+    )
+    return first_substantive[:max_chars].rstrip()
 
 
 def comment_context_to_json(comments: list[CommentContextEntry]) -> str:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/prompt_formatting_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/prompt_formatting_operations.py
@@ -8,7 +8,9 @@ from ..models.review_models import CommentContextEntry
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _MD_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
 _CHECKBOX_LINE_RE = re.compile(r"^\s*[-*]\s*\[[ xX]\]")
-_BARE_LINK_LINE_RE = re.compile(r"^\s*\[?!?\[?[^\]]*\]?\(?https?://\S+\)?\s*$")
+_BARE_LINK_LINE_RE = re.compile(
+    r"^\s*!?\[[^\]]*\]\(https?://\S+\)\s*$|^\s*https?://\S+\s*$"
+)
 
 
 def extract_pr_intent(description: str, max_chars: int = 800) -> str:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
@@ -262,13 +262,17 @@ def extract_diff_hunk_for_action(
     Returns:
         Hunk string starting with @@, or None if not found
     """
-    if not diff or not action.path or not action.line:
+    # Gate on resolved_line, not action.line: a finding the AI reported with
+    # line=null can still be anchored via a unique snippet match, and it deserves
+    # its hunk like any other resolved action.
+    if (not diff and diff_manager is None) or not action.path:
         return None
 
-    manager = diff_manager or get_or_create_diff_manager(diff)
     resolved_line = action.resolved_line
     if resolved_line is None:
         return None
+
+    manager = diff_manager or get_or_create_diff_manager(diff)
 
     hunk = manager.get_hunk_for_line(action.path, resolved_line, allow_fallback=False)
     return hunk.content if hunk else None
@@ -311,7 +315,9 @@ def resolve_action_anchors(
     diff_manager: Optional[DiffContextManager] = None,
 ) -> List[ReviewActionProposal]:
     """Return actions enriched with resolved inline anchors for UI and submission."""
-    if not diff:
+    # An explicitly supplied manager can anchor even when the raw diff string is
+    # empty — bailing on `not diff` alone would silently unresolve every action.
+    if not diff and diff_manager is None:
         return actions
 
     manager = diff_manager or get_or_create_diff_manager(diff)

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
@@ -6,6 +6,7 @@ converting Finding objects into ReviewActionProposal objects and building
 the GitHub API payload for submission.
 """
 
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from titan_cli.core.logging.config import get_logger
@@ -15,6 +16,57 @@ from ..models.review_models import Finding, ReviewActionProposal
 from ..managers.diff_context_manager import DiffContextManager, get_or_create_diff_manager
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class HeadShaDrift:
+    """
+    Whether the PR moved between the diff being fetched and the review being submitted.
+
+    Attributes:
+        drifted: True when the PR head is no longer the commit the anchors were
+                 resolved against.
+        reviewed_sha: Head commit the review was prepared against.
+        current_sha: Head commit the PR is on now.
+        message: Ready-to-display explanation, empty when there is no drift.
+    """
+    drifted: bool
+    reviewed_sha: str
+    current_sha: str
+    message: str = ""
+
+
+def detect_head_sha_drift(reviewed_sha: Optional[str], current_sha: Optional[str]) -> HeadShaDrift:
+    """
+    Compare the commit the review was prepared against with the PR's current head.
+
+    Every resolved inline line is a position in the diff of one specific commit. If the
+    PR is pushed to in between, those positions describe code that is no longer there:
+    GitHub rejects them, or worse, accepts them against shifted content. Callers should
+    degrade such comments to the general review body rather than publish them inline.
+
+    When either SHA is unknown, no drift is reported — an unverifiable comparison is not
+    evidence of a change, and the publish gate already validates lines against the diff.
+
+    Args:
+        reviewed_sha: Head SHA captured when the review bundle was fetched
+        current_sha: Head SHA of the PR right now
+
+    Returns:
+        HeadShaDrift describing the comparison
+    """
+    reviewed = (reviewed_sha or "").strip()
+    current = (current_sha or "").strip()
+
+    if not reviewed or not current or reviewed == current:
+        return HeadShaDrift(False, reviewed, current)
+
+    return HeadShaDrift(
+        True,
+        reviewed,
+        current,
+        f"the PR head moved from {reviewed[:8]} to {current[:8]} since the review started",
+    )
 
 
 def classify_github_review_rejection(error_message: str) -> str:
@@ -65,6 +117,7 @@ def build_review_action_payload(
     commit_sha: str,
     diff: str = "",
     diff_manager: Optional[DiffContextManager] = None,
+    force_general_body: bool = False,
 ) -> Dict:
     """
     Build the GitHub API payload from approved ReviewActionProposal objects.
@@ -80,6 +133,10 @@ def build_review_action_payload(
         actions: Approved ReviewActionProposal objects
         commit_sha: Head commit SHA for inline comments
         diff: Full PR unified diff (used to validate inline line positions)
+        diff_manager: Pre-built manager, so the diff is parsed once per review
+        force_general_body: Send every comment to the review body instead of inline.
+                            Used when the resolved lines are known to be stale, e.g.
+                            the PR was pushed to after the anchors were resolved.
 
     Returns:
         Dict with keys: commit_id, comments (list), body (str, optional)
@@ -94,6 +151,7 @@ def build_review_action_payload(
         action_count=len(actions),
         files_in_diff=len(valid_lines),
         publishable_source="github_diff" if manager and manager.has_github_diff else "added_lines_fallback",
+        force_general_body=force_general_body,
     )
     if valid_lines:
         for path, lines in valid_lines.items():  # Log TODOS los archivos
@@ -115,7 +173,7 @@ def build_review_action_payload(
         # new_comment — try inline first, fall back to general body
         resolved_line = action.resolved_line
 
-        if action.path and resolved_line:
+        if action.path and resolved_line and not force_general_body:
             file_valid_lines = valid_lines.get(action.path, set())
             inline_safe = resolved_line in file_valid_lines
             logger.debug("validate_comment_action",
@@ -214,6 +272,37 @@ def extract_diff_hunk_for_action(
 
     hunk = manager.get_hunk_for_line(action.path, resolved_line, allow_fallback=False)
     return hunk.content if hunk else None
+
+
+def extract_file_excerpt_for_action(
+    action: ReviewActionProposal,
+    diff_manager: Optional[DiffContextManager] = None,
+) -> Optional[str]:
+    """
+    Extract a plain-file code excerpt for an action the diff cannot anchor.
+
+    ``extract_diff_hunk_for_action`` returns nothing when the anchor is unresolved,
+    which is correct — the diff has no lines there. But the finding may still be real:
+    a reviewer reading the whole file can flag pre-existing code the PR never touched.
+    This reads the actual file so that finding is shown with its code instead of as a
+    bare assertion, using the AI's reported line as the centre.
+
+    Returns None for anchored actions (they get a diff hunk instead), when the action
+    has no path or line, or when no content provider is attached.
+
+    Args:
+        action: The action whose anchor could not be resolved
+        diff_manager: Manager holding the file-content provider
+
+    Returns:
+        Numbered code excerpt, or None
+    """
+    if diff_manager is None or action.resolved_line is not None:
+        return None
+    if not action.path or not action.line:
+        return None
+
+    return diff_manager.build_file_excerpt(action.path, action.line)
 
 
 def resolve_action_anchors(

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
@@ -243,11 +243,11 @@ def resolve_action_anchors(
         inline_reason = None
         why_inline_allowed = None
         if resolved_line is not None:
-            if action.anchor_snippet and manager.find_line_by_snippet(action.path, action.anchor_snippet) == resolved_line:
+            if action.anchor_snippet and resolved_line in manager.find_lines_by_snippet(action.path, action.anchor_snippet):
                 resolution_source = "snippet"
                 anchor_confidence = "high"
                 inline_reason = "snippet_match"
-            elif action.evidence and manager.find_line_by_snippet(action.path, action.evidence) == resolved_line:
+            elif action.evidence and resolved_line in manager.find_lines_by_snippet(action.path, action.evidence):
                 resolution_source = "evidence"
                 anchor_confidence = "medium"
                 inline_reason = "evidence_match"

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/review_action_operations.py
@@ -85,8 +85,16 @@ def build_review_action_payload(
         Dict with keys: commit_id, comments (list), body (str, optional)
     """
     manager = diff_manager or (get_or_create_diff_manager(diff) if diff else None)
-    valid_lines = {p: set(ls) for p, ls in manager.get_all_valid_lines().items()} if manager else {}
-    logger.debug("build_review_payload_start", action_count=len(actions), files_in_diff=len(valid_lines))
+    # Publishable lines come from GitHub's own diff when attached (D-008): the local
+    # context diff may use extended context (-U20) whose extra context lines GitHub
+    # rejects with 422 "line could not be resolved".
+    valid_lines = {p: set(ls) for p, ls in manager.get_all_publishable_lines().items()} if manager else {}
+    logger.debug(
+        "build_review_payload_start",
+        action_count=len(actions),
+        files_in_diff=len(valid_lines),
+        publishable_source="github_diff" if manager and manager.has_github_diff else "added_lines_fallback",
+    )
     if valid_lines:
         for path, lines in valid_lines.items():  # Log TODOS los archivos
             sorted_lines = sorted(list(lines))[:10]  # First 10 lines
@@ -252,13 +260,15 @@ def resolve_action_anchors(
                 anchor_confidence = "low"
                 inline_reason = "context_match"
 
-            is_inline_safe_for_github = resolved_line in manager.get_valid_review_lines(action.path)
+            is_inline_safe_for_github = resolved_line in manager.get_publishable_lines(action.path)
             if is_inline_safe_for_github:
                 why_inline_allowed = (
-                    f"resolved via {resolution_source} to changed line {resolved_line} present in diff reviewable lines"
+                    f"resolved via {resolution_source} to line {resolved_line} present in GitHub-publishable lines"
                 )
             else:
-                why_inline_allowed = f"resolved via {resolution_source} but line {resolved_line} not in diff reviewable lines"
+                why_inline_allowed = (
+                    f"resolved via {resolution_source} but line {resolved_line} not in GitHub-publishable lines"
+                )
         else:
             is_inline_safe_for_github = False
             why_inline_allowed = "no resolved line could be inferred from snippet/evidence/AI line"

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
@@ -79,11 +79,11 @@ def clear_stale_worktree(
     different remedies, so all three are attempted in order:
 
     1. A live registered worktree — ``git worktree remove --force`` handles it.
-    2. Stale metadata under ``.git/worktrees`` after the directory was deleted by
-       hand or a removal was interrupted — ``remove`` rejects it ("not a working
-       tree") and only ``git worktree prune`` clears it.
-    3. A leftover directory with no registration — neither git command touches it
-       and ``add`` refuses a non-empty path, so it is deleted directly.
+    2. A leftover directory git commands can't touch (unregistered, or ``remove``
+       failed on it) — ``add`` refuses a non-empty path, so it is deleted directly.
+    3. Stale metadata under ``.git/worktrees`` — only ``git worktree prune`` clears
+       it, and prune only acts on entries whose directory is MISSING, so it must
+       run after the directory removal, not before.
 
     Best-effort by design: every step is optional cleanup, so failures are ignored
     and the caller proceeds to creation, which reports the real error if any residue
@@ -97,11 +97,6 @@ def clear_stale_worktree(
     """
     try:
         git_client.remove_worktree(worktree_path, force=True)
-    except Exception:
-        pass
-
-    try:
-        git_client.prune_worktrees()
     except Exception:
         pass
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
@@ -111,6 +111,11 @@ def clear_stale_worktree(
         except OSError:
             pass
 
+    try:
+        git_client.prune_worktrees()
+    except Exception:
+        pass
+
 
 def cleanup_worktree(
     git_client,

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/worktree_operations.py
@@ -6,6 +6,7 @@ These functions wrap git worktree commands without UI dependencies.
 """
 
 import os
+import shutil
 from typing import Tuple
 from titan_cli.core.result import ClientSuccess, ClientError
 
@@ -29,13 +30,6 @@ def setup_worktree(
 
     Returns:
         Tuple of (absolute_path, created_successfully)
-
-    Example:
-        >>> abs_path, created = setup_worktree(git, 123, "feature-branch")
-        >>> abs_path
-        '/home/user/project/.titan/worktrees/titan-review-123'
-        >>> created
-        True
     """
     try:
         worktree_name = f"titan-review-{pr_number}"
@@ -43,16 +37,7 @@ def setup_worktree(
         original_cwd = os.getcwd()
         full_worktree_path = os.path.join(original_cwd, worktree_path)
 
-        # Remove worktree if it already exists
-        try:
-            result = git_client.remove_worktree(worktree_path, force=True)
-            match result:
-                case ClientSuccess():
-                    pass
-                case ClientError():
-                    pass  # Worktree might not exist
-        except Exception:
-            pass
+        clear_stale_worktree(git_client, worktree_path, full_worktree_path)
 
         # Fetch the PR ref into a stable local ref. This works for both same-repo
         # and fork-based PRs where origin/<head_branch> does not exist locally.
@@ -80,6 +65,51 @@ def setup_worktree(
 
     except Exception:
         return ("", False)
+
+
+def clear_stale_worktree(
+    git_client,
+    worktree_path: str,
+    full_worktree_path: str = "",
+) -> None:
+    """
+    Make ``worktree_path`` reusable, whatever state a previous run left it in.
+
+    Three residues can block ``git worktree add`` on the same path, and they need
+    different remedies, so all three are attempted in order:
+
+    1. A live registered worktree — ``git worktree remove --force`` handles it.
+    2. Stale metadata under ``.git/worktrees`` after the directory was deleted by
+       hand or a removal was interrupted — ``remove`` rejects it ("not a working
+       tree") and only ``git worktree prune`` clears it.
+    3. A leftover directory with no registration — neither git command touches it
+       and ``add`` refuses a non-empty path, so it is deleted directly.
+
+    Best-effort by design: every step is optional cleanup, so failures are ignored
+    and the caller proceeds to creation, which reports the real error if any residue
+    survived.
+
+    Args:
+        git_client: Git client instance
+        worktree_path: Worktree path as git knows it (usually repo-relative)
+        full_worktree_path: Absolute path on disk; when empty, the directory
+                            removal step is skipped
+    """
+    try:
+        git_client.remove_worktree(worktree_path, force=True)
+    except Exception:
+        pass
+
+    try:
+        git_client.prune_worktrees()
+    except Exception:
+        pass
+
+    if full_worktree_path and os.path.isdir(full_worktree_path):
+        try:
+            shutil.rmtree(full_worktree_path)
+        except OSError:
+            pass
 
 
 def cleanup_worktree(

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -811,15 +811,17 @@ def fetch_pr_review_bundle(ctx: WorkflowContext) -> WorkflowResult:
         match threads_result:
             case ClientSuccess(data=threads):
                 review_threads = threads
-            case ClientError():
-                pass
+            case ClientError(error_message=err):
+                # Threads drive dedup against existing comments — reviewing without
+                # them risks re-proposing duplicates, so the degradation must be visible.
+                ctx.textual.warning_text(f"Could not fetch review threads: {err}")
 
         general_result = ctx.github.get_pr_general_comments(pr_number)
         match general_result:
             case ClientSuccess(data=general):
                 general_comments = general
-            case ClientError():
-                pass
+            case ClientError(error_message=err):
+                ctx.textual.warning_text(f"Could not fetch general comments: {err}")
 
         current_user_result = ctx.github.get_current_user()
         match current_user_result:

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -40,6 +40,7 @@ from ..operations.review_action_operations import (
     build_review_action_payload,
     classify_github_review_rejection,
     extract_diff_hunk_for_action,
+    extract_file_excerpt_for_action,
     resolve_action_anchors,
 )
 from ..operations.thread_resolution_operations import (
@@ -406,6 +407,7 @@ def _show_review_action_and_get_decision(
     idx: int,
     total: int,
     review_threads: Optional[List[UICommentThread]] = None,
+    file_excerpt: Optional[str] = None,
 ) -> str:
     """
     Display a ReviewActionProposal and return the user's chosen decision.
@@ -413,6 +415,9 @@ def _show_review_action_and_get_decision(
     For resolve_thread actions, shows thread context and resolve confirmation.
     For reply_to_thread actions, shows the original thread context and proposed reply.
     For new_comment actions, shows just the proposed comment.
+
+    ``file_excerpt`` carries real file content for findings the diff cannot anchor, so
+    they are shown with their code rather than as an unsupported claim.
 
     Returns:
         "approve", "edit", "skip", or "exit"
@@ -480,7 +485,9 @@ def _show_review_action_and_get_decision(
 
         # Show the action (proposed reply or new comment)
         from titan_plugin_github.widgets import CommentView
-        ctx.textual.mount(CommentView.from_action(action, diff_hunk=diff_hunk))
+        ctx.textual.mount(
+            CommentView.from_action(action, diff_hunk=diff_hunk, file_excerpt=file_excerpt)
+        )
         ctx.textual.text("")
 
         options = [
@@ -1730,6 +1737,21 @@ def _render_findings_batch_result(
     ctx.textual.warning_text(message)
 
 
+def _attach_content_provider(diff_manager, root: Optional[str]) -> None:
+    """
+    Give the diff manager a way to read whole files from ``root``.
+
+    Only call this with a root already verified to hold the PR's head revision — the
+    provider is trusted to return the code the diff describes.
+    """
+    if diff_manager is None or not root:
+        return
+
+    from ..operations.context_resolution_operations import read_file_content
+
+    diff_manager.attach_content_provider(lambda path: read_file_content(path, root))
+
+
 def _resolve_file_read_access(ctx: WorkflowContext, worktree_path: Optional[str]):
     """
     Decide whether files on disk may be used as this PR's code.
@@ -1827,6 +1849,9 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
     read_access = _resolve_file_read_access(ctx, worktree_path)
     if read_access.allowed:
         ctx.textual.dim_text(f"Reading files from {read_access.source} ({read_access.reason})")
+        # Same verified root powers the comment-rendering path, so a finding about
+        # pre-existing code can show that code instead of nothing.
+        _attach_content_provider(diff_manager, project_root)
     else:
         ctx.textual.warning_text(
             f"Reviewing from the diff only — {read_access.reason}. "
@@ -2395,11 +2420,15 @@ def validate_review_actions(ctx: WorkflowContext) -> WorkflowResult:
 
         current = action
         diff_hunk = extract_diff_hunk_for_action(current, diff, diff_manager=diff_manager)
+        # Unanchored findings have no diff hunk by definition — read the real file so the
+        # user judges the finding against its code instead of a bare assertion.
+        file_excerpt = extract_file_excerpt_for_action(current, diff_manager=diff_manager)
 
         while True:
             choice = _show_review_action_and_get_decision(
                 ctx, current, diff_hunk or "", idx, len(sorted_actions),
-                review_threads=review_threads
+                review_threads=review_threads,
+                file_excerpt=file_excerpt,
             )
 
             if choice == "exit":

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -761,6 +761,10 @@ def fetch_pr_review_bundle(ctx: WorkflowContext) -> WorkflowResult:
                     # Files-API patches ARE GitHub's diff hunks — valid as the
                     # publishable-lines source.
                     diff_is_github_source = True
+                case ClientError(error_message=err):
+                    ctx.textual.error_text(f"Failed to fetch file patches: {err}")
+                    ctx.textual.end_step("error")
+                    return Error(f"Could not fetch file patches: {err}")
                 case _:
                     ctx.textual.end_step("error")
                     return Error("Could not fetch file patches for large PR")

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -716,7 +716,7 @@ def fetch_pr_review_bundle(ctx: WorkflowContext) -> WorkflowResult:
     # Fetch diff. For fork PRs, gh pr diff is the source of truth because the
     # head branch usually does not exist under the local origin remote.
     with ctx.textual.loading(f"Fetching PR #{pr_number} diff..."):
-        diff_result = _get_review_diff(ctx, pr_number, pr, all_files_with_stats)
+        diff_result, diff_is_github_source = _get_review_diff(ctx, pr_number, pr, all_files_with_stats)
 
     # Validate diff — fallback to per-file patches if PR is too large
     match diff_result:
@@ -751,6 +751,9 @@ def fetch_pr_review_bundle(ctx: WorkflowContext) -> WorkflowResult:
             match patches_result:
                 case ClientSuccess(data=patches_diff) if patches_diff:
                     diff = patches_diff
+                    # Files-API patches ARE GitHub's diff hunks — valid as the
+                    # publishable-lines source.
+                    diff_is_github_source = True
                 case _:
                     ctx.textual.end_step("error")
                     return Error("Could not fetch file patches for large PR")
@@ -770,6 +773,26 @@ def fetch_pr_review_bundle(ctx: WorkflowContext) -> WorkflowResult:
     # Display file changes summary
     formatted_files, formatted_summary = compute_diff_stat(diff)
     diff_manager = get_or_create_diff_manager(diff, ctx.data)
+
+    # Attach GitHub's own diff as the publishable-lines source (D-008). The review diff
+    # may be a local `git diff -U20` whose extra context lines GitHub rejects for inline
+    # comments; publish validation must use GitHub's hunks. When unavailable, the manager
+    # falls back to added-lines-only, which GitHub always accepts.
+    github_diff = diff if diff_is_github_source else None
+    if github_diff is None:
+        github_diff_result = ctx.github.get_pr_diff(pr_number)
+        match github_diff_result:
+            case ClientSuccess(data=gh_diff) if gh_diff and gh_diff.strip():
+                github_diff = gh_diff
+            case _:
+                logger.warning(
+                    "github_diff_unavailable_for_publish_validation",
+                    pr_number=pr_number,
+                    fallback="added_lines_only",
+                )
+    if github_diff:
+        diff_manager.attach_github_diff(github_diff)
+
     ctx.textual.show_diff_stat(formatted_files, formatted_summary, title="Files affected:")
 
     # Fetch inline review threads and general comments separately
@@ -830,7 +853,14 @@ def _get_review_diff(
     pr: UIPullRequest,
     all_files_with_stats: list,
 ):
-    """Resolve the most trustworthy diff source for a PR review."""
+    """
+    Resolve the most trustworthy diff source for a PR review.
+
+    Returns:
+        Tuple of (diff ClientResult, is_github_source). ``is_github_source`` is True when
+        the diff came from GitHub itself (``gh pr diff``) — that diff can then double as
+        the publishable-lines source without a second fetch.
+    """
     if pr.is_cross_repository:
         logger.info(
             "review_diff_using_github",
@@ -838,11 +868,11 @@ def _get_review_diff(
             reason="cross_repository_pr",
             head_repository_owner=pr.head_repository_owner,
         )
-        return ctx.github.get_pr_diff(pr_number)
+        return ctx.github.get_pr_diff(pr_number), True
 
     if not ctx.git:
         logger.debug("Git plugin not available; using gh pr diff")
-        return ctx.github.get_pr_diff(pr_number)
+        return ctx.github.get_pr_diff(pr_number), True
 
     fetch_result = ctx.git.fetch(all=True)
     match fetch_result:
@@ -860,7 +890,7 @@ def _get_review_diff(
 
     match git_diff_result:
         case ClientSuccess(data=diff) if diff and diff.strip():
-            return git_diff_result
+            return git_diff_result, False
         case ClientSuccess(data=_):
             if all_files_with_stats:
                 logger.warning(
@@ -870,8 +900,8 @@ def _get_review_diff(
                     head_ref=pr.head_ref,
                     files_changed=len(all_files_with_stats),
                 )
-                return ctx.github.get_pr_diff(pr_number)
-            return git_diff_result
+                return ctx.github.get_pr_diff(pr_number), True
+            return git_diff_result, False
         case ClientError(error_message=err):
             logger.warning(
                 "git_diff_failed_falling_back_to_github",
@@ -880,7 +910,7 @@ def _get_review_diff(
                 head_ref=pr.head_ref,
                 error=err,
             )
-            return ctx.github.get_pr_diff(pr_number)
+            return ctx.github.get_pr_diff(pr_number), True
 
 
 def _resolve_headless_adapter(cli_preference: str):

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1730,6 +1730,51 @@ def _render_findings_batch_result(
     ctx.textual.warning_text(message)
 
 
+def _resolve_file_read_access(ctx: WorkflowContext, worktree_path: Optional[str]):
+    """
+    Decide whether files on disk may be used as this PR's code.
+
+    Worktree creation is allowed to fail in the workflow, and the fallback root is the
+    user's own checkout — which is usually on a different branch. Query its HEAD and
+    dirty state so the decision is made on facts rather than assumed.
+    """
+    from ..operations.context_resolution_operations import resolve_file_read_access
+
+    if worktree_path:
+        return resolve_file_read_access(worktree_path)
+
+    head_sha = ctx.data.get("review_commit_sha")
+    checkout_sha = None
+    checkout_dirty = None
+
+    if ctx.git:
+        match ctx.git.get_current_commit():
+            case ClientSuccess(data=sha):
+                checkout_sha = (sha or "").strip()
+            case ClientError(error_message=err):
+                logger.debug("checkout_sha_unavailable", error=err)
+
+        match ctx.git.has_uncommitted_changes():
+            case ClientSuccess(data=dirty):
+                checkout_dirty = dirty
+            case ClientError(error_message=err):
+                logger.debug("checkout_dirty_state_unavailable", error=err)
+
+    access = resolve_file_read_access(
+        worktree_path=None,
+        head_sha=head_sha,
+        checkout_sha=checkout_sha,
+        checkout_dirty=checkout_dirty,
+    )
+    logger.debug(
+        "file_read_access_resolved",
+        allowed=access.allowed,
+        source=access.source,
+        reason=access.reason,
+    )
+    return access
+
+
 def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
     """
     Fetch the exact code context according to the validated review plan.
@@ -1779,8 +1824,14 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
     from ..operations.context_resolution_operations import build_review_context_package
     diff_manager = ctx.get("review_diff_manager")
 
-    if worktree_path:
-        ctx.textual.dim_text(f"Using worktree: {worktree_path}")
+    read_access = _resolve_file_read_access(ctx, worktree_path)
+    if read_access.allowed:
+        ctx.textual.dim_text(f"Reading files from {read_access.source} ({read_access.reason})")
+    else:
+        ctx.textual.warning_text(
+            f"Reviewing from the diff only — {read_access.reason}. "
+            "Full-file and expanded-hunk context are disabled to avoid mixing revisions."
+        )
 
     try:
         with ctx.textual.loading("Extracting code context…"):
@@ -1793,6 +1844,7 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
                 strategy=strategy,
                 cwd=project_root,
                 diff_manager=diff_manager,
+                allow_file_reads=read_access.allowed,
             )
     except Exception as e:
         ctx.textual.end_step("error")
@@ -1800,6 +1852,7 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
 
     ctx.data["review_context_package"] = package
     ctx.data["review_context_batches"] = package.batches
+    ctx.data["review_file_reads_allowed"] = read_access.allowed
 
     batch_count = len(package.batches)
     files_count = sum(len(batch.files_context) for batch in package.batches)
@@ -1821,6 +1874,7 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
         metadata={
             "review_context_package": package,
             "review_context_batches": package.batches,
+            "review_file_reads_allowed": read_access.allowed,
         },
     )
 
@@ -2389,6 +2443,36 @@ def validate_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     )
 
 
+def _detect_submit_time_sha_drift(ctx: WorkflowContext, pr_number: int, reviewed_sha: str):
+    """
+    Re-read the PR's head SHA and compare it with the one the review was prepared against.
+
+    The bundle's SHA is captured minutes earlier, before the user inspects findings. A push
+    in that window invalidates every resolved line, so this is checked at submit time
+    rather than trusted from the bundle.
+    """
+    from ..operations.review_action_operations import detect_head_sha_drift
+
+    current_sha = ""
+    match ctx.github.get_pr_commit_sha(pr_number):
+        case ClientSuccess(data=sha):
+            current_sha = (sha or "").strip()
+        case ClientError(error_message=err):
+            # Unverifiable is not the same as drifted: the publish gate still validates
+            # every line against the diff, so proceed rather than block the submission.
+            logger.debug("submit_sha_recheck_failed", pr_number=pr_number, error=err)
+
+    drift = detect_head_sha_drift(reviewed_sha, current_sha)
+    logger.debug(
+        "submit_sha_drift_check",
+        pr_number=pr_number,
+        reviewed_sha=drift.reviewed_sha,
+        current_sha=drift.current_sha,
+        drifted=drift.drifted,
+    )
+    return drift
+
+
 def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     """
     Submit approved ReviewActionProposal objects to GitHub.
@@ -2468,6 +2552,27 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
                 ctx.textual.end_step("error")
                 return Error(f"Missing commit SHA for inline review: {err}")
 
+    # The anchors were resolved against commit_sha's diff. If the PR has been pushed to
+    # since, every inline line describes code that moved — degrade them to the review body
+    # rather than publish comments on the wrong lines.
+    force_general_body = False
+    if comment_actions:
+        drift = _detect_submit_time_sha_drift(ctx, pr_number, commit_sha)
+        if drift.drifted:
+            ctx.textual.warning_text(f"⚠ PR head changed: {drift.message}")
+            ctx.textual.dim_text(
+                f"reviewed: {drift.reviewed_sha[:8]} · current: {drift.current_sha[:8]}"
+            )
+            ctx.textual.text(
+                f"The {len(comment_actions)} comment(s) will go in the review body instead "
+                "of inline, since their line numbers no longer match the PR's diff."
+            )
+            if not ctx.textual.ask_confirm("Publish the review anyway?", default=True):
+                ctx.textual.warning_text("Review cancelled")
+                ctx.textual.end_step("skip")
+                return Skip("User cancelled after head SHA drift")
+            force_general_body = True
+
     # Show AI's opinion and prepare action options
     ctx.textual.text("")
     if comment_actions:
@@ -2509,7 +2614,13 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
         review_body = ctx.textual.ask_multiline("General review comment:", default="")
 
     # Build payload from comment actions
-    payload = build_review_action_payload(comment_actions, commit_sha, diff, diff_manager=diff_manager)
+    payload = build_review_action_payload(
+        comment_actions,
+        commit_sha,
+        diff,
+        diff_manager=diff_manager,
+        force_general_body=force_general_body,
+    )
 
     if review_body and review_body.strip():
         existing_body = payload.get("body", "")

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/pr_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/pr_review_steps.py
@@ -17,6 +17,7 @@ from ..models import UICommentThread
 from ..operations import (
     fetch_pr_threads,
     fetch_pr_general_comments,
+    build_quote_reply,
     build_ai_review_context,
     build_ai_review_prompt,
     find_ai_response_file,
@@ -978,8 +979,18 @@ def send_comment_replies_step(ctx: WorkflowContext) -> WorkflowResult:
         ctx.textual.end_step("skip")
         return Skip("No replies sent")
 
-    # Split replies: general comments use add_issue_comment, review comments use reply_to_comment
-    general_replies = {cid: text for cid, text in final_replies.items() if cid in general_comment_ids}
+    # Split replies: general comments use add_issue_comment, review comments use reply_to_comment.
+    # A general comment has no thread for the reply to land in, so quote the
+    # original (GitHub's "quote reply") to tie the new issue comment back to it.
+    general_replies = {}
+    for cid, text in final_replies.items():
+        if cid not in general_comment_ids:
+            continue
+        thread = thread_by_id.get(cid)
+        if thread and thread.main_comment and thread.main_comment.body:
+            general_replies[cid] = build_quote_reply(thread.main_comment.body, text)
+        else:
+            general_replies[cid] = text
     review_replies = {cid: text for cid, text in final_replies.items() if cid not in general_comment_ids}
 
     with ctx.textual.loading(f"Sending {len(final_replies)} reply(s)..."):

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/worktree_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/worktree_steps.py
@@ -5,7 +5,7 @@ Steps for creating and cleaning up git worktrees.
 Available for use in any workflow that needs isolated branch checkouts.
 """
 import os
-from titan_cli.engine import WorkflowContext, WorkflowResult, Success, Error, Exit
+from titan_cli.engine import WorkflowContext, WorkflowResult, Success, Error, Skip
 from ..operations import setup_worktree, cleanup_worktree
 
 def create_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
@@ -74,7 +74,11 @@ def cleanup_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
 
     Returns:
         Success: Worktree cleaned up
-        Exit: No worktree to cleanup
+        Skip: Nothing to clean up, no git client, or removal failed
+
+    Never returns Exit: that would stop the whole workflow, and this step may run
+    before others (nothing was created is a normal case when worktree setup was
+    allowed to fail). Skip keeps the workflow going.
     """
     if not ctx.textual:
         return Error("Textual UI context is not available for this step.")
@@ -87,12 +91,12 @@ def cleanup_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
     if not worktree_created or not worktree_path:
         ctx.textual.dim_text("No worktree to cleanup")
         ctx.textual.end_step("skip")
-        return Exit("No worktree to cleanup")
+        return Skip("No worktree to cleanup")
 
     if not ctx.git:
         ctx.textual.warning_text("Git client not available - cannot cleanup")
         ctx.textual.end_step("skip")
-        return Exit("Git client not available")
+        return Skip("Git client not available")
 
     with ctx.textual.loading("Cleaning up worktree..."):
         success = cleanup_worktree(ctx.git, worktree_path)
@@ -104,7 +108,7 @@ def cleanup_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
     else:
         ctx.textual.warning_text("Failed to cleanup worktree")
         ctx.textual.end_step("skip")
-        return Exit("Cleanup failed")
+        return Skip("Cleanup failed")
 
 
 __all__ = [

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
@@ -219,13 +219,20 @@ class CommentView(Widget):
         )
 
     @classmethod
-    def from_action(cls, action: Any, diff_hunk: Optional[str] = None) -> "CommentView":
+    def from_action(
+        cls,
+        action: Any,
+        diff_hunk: Optional[str] = None,
+        file_excerpt: Optional[str] = None,
+    ) -> "CommentView":
         """
         Build a CommentView from a ReviewActionProposal model.
 
         Args:
             action: ReviewActionProposal instance from the new review pipeline.
             diff_hunk: Pre-extracted diff hunk for the action's file/line (optional).
+            file_excerpt: Plain-file code excerpt for an action the diff cannot anchor
+                          (optional) — see extract_file_excerpt_for_action.
 
         Returns:
             CommentView configured to display the review action.
@@ -246,6 +253,8 @@ class CommentView(Widget):
             diff_hunk=diff_hunk,
             severity=action.severity,
             line_label=_build_action_line_label(action),
+            file_excerpt=file_excerpt,
+            file_excerpt_line=action.line,
         )
 
     def compose(self) -> ComposeResult:
@@ -275,6 +284,10 @@ class CommentView(Widget):
         has_diff = self.focused_diff or self.diff_hunk
         if has_diff and self.line:
             yield self._code_context_widget()
+        elif self.file_excerpt:
+            # No diff to show: the finding is about code this PR did not change, read
+            # straight from the file. Captioned so it is never mistaken for the diff.
+            yield from self._file_excerpt_widgets()
 
         # 5. Comment body
         if self.body and self.body.strip():
@@ -368,6 +381,24 @@ class CommentView(Widget):
             language="diff",
             theme="native",
             line_numbers=True,
+        )
+
+    def _file_excerpt_widgets(self):
+        """Yield the caption + plain code block for a pre-existing-code excerpt."""
+        caption = (
+            f"pre-existing code around line {self.file_excerpt_line} "
+            "(unchanged by this PR)"
+            if self.file_excerpt_line
+            else "pre-existing code (unchanged by this PR)"
+        )
+        yield DimItalicText(caption)
+        yield CodeBlock(
+            code=self.file_excerpt,
+            # Plain file text, not a diff: these lines have no +/- prefix, and
+            # highlighting them as a diff would render every line as unchanged context.
+            language="text",
+            theme="native",
+            line_numbers=False,
         )
 
     def _parse_and_render_body(self) -> List[Any]:

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
@@ -261,7 +261,9 @@ class CommentView(Widget):
         """Compose the comment view: severity badge, metadata, location, code, body."""
         # 1. Severity badge (AI suggestions only)
         if self.severity:
-            yield self._severity_badge()
+            badge = self._severity_badge()
+            if badge is not None:
+                yield badge
 
         # 2. Author + date (omitted for AI suggestions that have no human author)
         if self.author_name:
@@ -300,8 +302,12 @@ class CommentView(Widget):
     # Private helpers
     # ──────────────────────────────────────────────────────────────────────────
 
-    def _severity_badge(self) -> Text:
-        """Create severity badge widget for AI suggestions."""
+    def _severity_badge(self) -> Optional[Text]:
+        """Create severity badge widget for AI suggestions.
+
+        Returns None for severities with no badge (e.g. ThreadSeverity.NONE, which
+        is truthy as a StrEnum) — the widget must not crash on a label-less value.
+        """
         badge_labels = {
             FindingSeverity.BLOCKING: "🔴 BLOCKING",
             FindingSeverity.IMPORTANT: "🟡 IMPORTANT",
@@ -309,7 +315,9 @@ class CommentView(Widget):
             ThreadSeverity.IMPORTANT: "🟡 IMPORTANT",
             ThreadSeverity.NIT: "🔵 NIT",
         }
-        badge_text = badge_labels[self.severity]
+        badge_text = badge_labels.get(self.severity)
+        if badge_text is None:
+            return None
         badge = Text(badge_text)
         badge.add_class("severity-badge")
         badge.add_class(self.severity.value)

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
@@ -253,7 +253,7 @@ class CommentView(Widget):
             diff_hunk=diff_hunk,
             severity=action.severity,
             line_label=_build_action_line_label(action),
-            file_excerpt=file_excerpt,
+            file_excerpt=file_excerpt if is_new_comment else None,
             file_excerpt_line=action.line,
         )
 

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
@@ -20,7 +20,7 @@ from titan_cli.ui.tui.widgets import BoldText, DimText, ItalicText, Text, DimIta
 
 from ..managers.diff_context_manager import DiffContextManager
 from ..models.diff_models import ResolvedCommentContext
-from ..models.review_enums import FindingSeverity, ThreadSeverity
+from ..models.review_enums import FindingSeverity, ReviewActionType, ThreadSeverity
 from .code_block import CodeBlock
 from .comment_utils import render_comment_elements
 
@@ -96,6 +96,8 @@ class CommentView(Widget):
         severity: Optional[FindingSeverity | ThreadSeverity] = None,
         is_outdated: bool = False,
         line_label: Optional[str] = None,
+        file_excerpt: Optional[str] = None,
+        file_excerpt_line: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -111,6 +113,10 @@ class CommentView(Widget):
             focused_diff: Pre-trimmed diff for display (7 before + target + 3 after).
             severity: Severity level for AI suggestions or thread follow-ups.
             is_outdated: Whether the comment references outdated code.
+            line_label: Pre-built location label, overriding the default "Line N".
+            file_excerpt: Numbered plain-file excerpt, for findings about code this PR
+                          did not change (no diff hunk exists for them).
+            file_excerpt_line: Line the excerpt is centred on, shown in its caption.
         """
         super().__init__(**kwargs)
         self.body = body
@@ -123,6 +129,8 @@ class CommentView(Widget):
         self.severity = severity
         self.is_outdated = is_outdated
         self.line_label = line_label
+        self.file_excerpt = file_excerpt
+        self.file_excerpt_line = file_excerpt_line
 
     @classmethod
     def from_resolved_context(cls, ctx: ResolvedCommentContext) -> "CommentView":
@@ -222,10 +230,19 @@ class CommentView(Widget):
         Returns:
             CommentView configured to display the review action.
         """
+        # A reply to an existing thread inherits that thread's position, which GitHub
+        # already accepted — its line needs no anchoring. Only a brand-new comment has to
+        # be anchored into this PR's diff, so only it can be left unanchored.
+        is_new_comment = _is_new_comment_action(action)
+
         return cls(
             body=action.body,
             file_path=action.path,
-            line=action.resolved_line or action.line,
+            # For a new comment, only the resolved line is a real position in this PR's
+            # diff. Falling back to the raw AI line would render a code block around a
+            # line nothing verified — extract_diff_hunk_for_action already returns no hunk
+            # in that case, so the block would be empty or, worse, from elsewhere.
+            line=action.resolved_line if is_new_comment else (action.resolved_line or action.line),
             diff_hunk=diff_hunk,
             severity=action.severity,
             line_label=_build_action_line_label(action),
@@ -362,8 +379,24 @@ class CommentView(Widget):
         )
 
 
+def _is_new_comment_action(action: Any) -> bool:
+    """Return True for a brand-new comment (not a reply to, or resolution of, a thread)."""
+    action_type = getattr(action, "action_type", None)
+    value = getattr(action_type, "value", action_type)
+    return value == ReviewActionType.NEW_COMMENT.value
+
+
 def _build_action_line_label(action: Any) -> Optional[str]:
-    """Build a user-facing line label for review action preview."""
+    """
+    Build a user-facing line label for review action preview.
+
+    For a new comment whose anchor could not be resolved, the label says so instead of
+    showing the AI's raw line number: that number was never validated against the diff,
+    and a finding about pre-existing code outside this PR carries no valid line at all.
+    Presenting it like a resolved one would claim a precision nothing backs, and hide why
+    the comment cannot be published inline. Thread replies keep their line as-is — it
+    comes from the existing thread, not from anchoring.
+    """
     resolved_line = getattr(action, "resolved_line", None)
     original_line = getattr(action, "original_line", None) or getattr(action, "line", None)
     resolution_source = getattr(action, "resolution_source", None)
@@ -373,9 +406,13 @@ def _build_action_line_label(action: Any) -> Optional[str]:
         return f"Line {resolved_line} (AI {original_line}{suffix})"
     if resolved_line:
         return f"Line {resolved_line}"
+
+    if not _is_new_comment_action(action):
+        return f"Line {original_line}" if original_line else None
+
     if original_line:
-        return f"Line {original_line}"
-    return None
+        return f"⚠ outside this PR's diff (AI said {original_line})"
+    return "⚠ outside this PR's diff"
 
 
 __all__ = ["CommentView"]

--- a/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr.yaml
+++ b/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr.yaml
@@ -74,12 +74,6 @@ steps:
     step: ai_review_findings
     on_error: continue
 
-  - id: cleanup_worktree
-    name: "Cleanup PR Worktree"
-    plugin: github
-    step: cleanup_worktree
-    on_error: continue
-
   - id: normalize
     name: "Normalize Findings"
     plugin: github
@@ -106,4 +100,13 @@ steps:
     name: "Submit Review"
     plugin: github
     step: submit_review_actions
+    on_error: continue
+
+  # Runs last on purpose: the worktree is the source of real file content while the
+  # user inspects findings in validate_actions and while comments are being placed.
+  # on_error: continue so a failed cleanup never masks the review's outcome.
+  - id: cleanup_worktree
+    name: "Cleanup PR Worktree"
+    plugin: github
+    step: cleanup_worktree
     on_error: continue


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
This PR improves code review quality by adding file excerpt support for unanchored findings (so reviewers always have context even when line anchoring fails), introducing a `prune_worktrees` operation to fix stale Git worktree metadata that blocked path reuse, and adding a GitHub diff validation gate alongside PR intent extraction and checklist description caps to reduce review noise.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- **File excerpt fallback**: When a code review finding cannot be anchored to a specific line, a relevant file excerpt is now included so the finding still has meaningful context
- **`prune_worktrees` operation**: Added `git worktree prune` support to `WorktreeService`, `GitClient`, and the client API — clears stale `.git/worktrees` metadata that caused "already registered" / "not a working tree" errors when reusing a worktree path
- **Duplicate snippet false positive fix**: Resolved an incorrect duplicate-detection hit in the line anchor resolver that was suppressing valid findings
- **GitHub diff validation gate**: Prevents review from proceeding when the diff is missing or invalid, improving overall review quality
- **PR intent extraction**: Extracts the intent/goal of the PR to better guide checklist generation and review focus
- **Checklist description caps**: Limits checklist item description length to reduce verbosity and keep reviews actionable
- **Parser hardening**: Added edge-case tests for the diff context manager to guard against regressions in context extraction

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New tests cover:
- `WorktreeService.prune_worktrees()` — happy path (verifies `git worktree prune` is called) and error path (verifies `WORKTREE_PRUNE_ERROR` code is returned)
- `resolve_file_read_access` — worktree trust rules and SHA verification logic
- Diff context manager edge cases to harden the parser against malformed input
- Default checklist rendering with descriptions to catch display regressions

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

## ✅ Checklist
- [ ] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [ ] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)