### PR TITLE
feat: Add adversarial verification and cross-file synthesis to PR review

### DIFF
--- a/.titan/review/profile.yaml
+++ b/.titan/review/profile.yaml
@@ -261,3 +261,8 @@ review_axes:
       - "docs/**"
       - "README.md"
       - "DEVELOPMENT.md"
+
+# Cross-file synthesis batch (review-quality-004): one extra AI call per review that
+# looks for contract mismatches between the PR's own files. Enabled here to gather
+# real cost data — the built-in default is false.
+findings_synthesis_enabled: true

--- a/docs/plugins/github/workflow-steps.md
+++ b/docs/plugins/github/workflow-steps.md
@@ -53,6 +53,7 @@ For full contract details for every public step, including documented inputs, ou
 | `ai_review_findings` | Code Review | - |
 | `normalize_findings` | Code Review | - |
 | `dedupe_findings` | Code Review | - |
+| `verify_findings` | Code Review | - |
 | `build_new_comment_actions` | Code Review | - |
 | `validate_review_actions` | Code Review | - |
 | `submit_review_actions` | Code Review | - |
@@ -124,6 +125,7 @@ These are advanced review-pipeline steps for structured AI-assisted code review.
 - `ai_review_findings`: run targeted AI analysis and produce candidate findings
 - `normalize_findings`: normalize raw findings into workflow-friendly structures
 - `dedupe_findings`: remove duplicate or overlapping findings before submission
+- `verify_findings`: adversarial AI pass that drops findings refuted against the code (fail-open)
 - `build_new_comment_actions`: translate findings into GitHub review actions
 - `validate_review_actions`: validate those review actions before posting
 - `submit_review_actions`: submit review comments or review actions to GitHub
@@ -1477,6 +1479,49 @@ How to read these contracts:
     | Result | Saved for later steps | Description |
     |--------|-----------------------|-------------|
     | `Success or Error` | - | - |
+
+
+??? info "`verify_findings`"
+    Adversarial verification pass: one batched AI call (low effort) tries to REFUTE
+    each non-nit finding against the code it targets; findings refuted with evidence
+    are dropped before the human gate. Fail-open: any CLI, parse, or budget problem
+    keeps all findings. Gated by `findings_verification_enabled` in the project
+    review profile (`.titan/review/profile.yaml`, default `true`).
+
+    **Workflow usage**
+
+    ```yaml
+    - plugin: github
+      step: verify_findings
+      on_error: continue
+    ```
+
+    **Used by built-in workflows:** `review-pr`
+
+    **Available to later steps:** `deduped_findings` (verified set), `refuted_findings`
+
+    **Inputs (from ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `deduped_findings` | List[Finding] | Findings after duplicate removal |
+    | `review_context_batches` | List[FocusContextBatch] | Source of the focused hunks shown to the verifier |
+    | `review_strategy` | ReviewStrategy | Prompt budget cap |
+    | `cli_preference` | str | Headless CLI selection |
+
+    **Outputs (saved to ctx.data)**
+
+    | Name | Type | Description |
+    |------|------|-------------|
+    | `deduped_findings` | List[Finding] | Verified findings (refuted ones removed) |
+    | `refuted_findings` | List[Finding] | Findings dropped by the verifier, with reasons shown in the UI |
+
+    **Returns**
+
+    | Result | Saved for later steps | Description |
+    |--------|-----------------------|-------------|
+    | `Success` | `deduped_findings`, `refuted_findings` | Verification applied. |
+    | `Skip` | - | No findings, only nits, verification disabled, no CLI, over budget, or verification failed (fail-open). |
 
 
 ??? info "`build_new_comment_actions`"

--- a/docs/plugins/github/workflow-steps.md
+++ b/docs/plugins/github/workflow-steps.md
@@ -1391,6 +1391,14 @@ How to read these contracts:
 ??? info "`ai_review_findings`"
     Second AI call: find actionable problems in the exact code context.
 
+    When `findings_synthesis_enabled` is `true` in the project review profile
+    (`.titan/review/profile.yaml`, default `false`) and the PR touches more than one
+    focus file, one extra best-effort cross-file synthesis batch runs after the
+    per-file batches: every reviewed file's hunks together (hunks_only, no expansion),
+    instructed to look only for cross-file inconsistencies introduced by the PR.
+    Skipped silently when the combined hunks exceed the prompt budget; its findings
+    are deduped against the per-file batches' findings before aggregation.
+
     **Workflow usage**
 
     ```yaml

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -509,7 +509,8 @@ def test_dedupe_synthesis_findings_drops_similar_and_keeps_distinct():
         {"path": "b.py", "line": None, "title": "Missing error handling"},
         # One line None, the other not -> kept.
         {"path": "b.py", "line": 5, "title": "Missing error handling"},
-        # Non-dict synthesis item tolerated and kept for normalize to reject later.
+        # Non-dict synthesis item dropped (it would inflate the unique count and
+        # normalize would reject it anyway).
         42,
     ]
 
@@ -519,5 +520,55 @@ def test_dedupe_synthesis_findings_drops_similar_and_keeps_distinct():
         {"path": "c.py", "line": 10, "title": "Null pointer risk in parse_config"},
         {"path": "a.py", "line": 200, "title": "Null pointer risk in parse_config"},
         {"path": "b.py", "line": 5, "title": "Missing error handling"},
-        42,
     ]
+
+
+# ============================================================================
+# build_timeout_fallback_batch (worktree_reference timeout fallback)
+# ============================================================================
+
+
+def test_timeout_fallback_batch_builds_hunks_only_from_original():
+    from titan_plugin_github.models.review_enums import FileReadMode
+    from titan_plugin_github.models.review_models import FileContextEntry, FocusContextBatch
+    from titan_plugin_github.operations.findings_operations import build_timeout_fallback_batch
+
+    original = FocusContextBatch(
+        batch_id="batch_2",
+        files_context={
+            "border.py": FileContextEntry(
+                path="border.py",
+                read_mode=FileReadMode.WORKTREE_REFERENCE,
+                worktree_reference=True,
+                review_hint="huge file",
+            )
+        },
+    )
+
+    fallback = build_timeout_fallback_batch(original, _rescue_diff())
+
+    assert fallback is not None
+    assert fallback.batch_id == "batch_2_retry"
+    entry = fallback.files_context["border.py"]
+    assert entry.read_mode == FileReadMode.HUNKS_ONLY
+    assert entry.worktree_reference is False
+    assert any("added line" in hunk for hunk in entry.hunks)
+
+
+def test_timeout_fallback_batch_returns_none_without_hunks():
+    from titan_plugin_github.models.review_enums import FileReadMode
+    from titan_plugin_github.models.review_models import FileContextEntry, FocusContextBatch
+    from titan_plugin_github.operations.findings_operations import build_timeout_fallback_batch
+
+    original = FocusContextBatch(
+        batch_id="batch_9",
+        files_context={
+            "binary.bin": FileContextEntry(
+                path="binary.bin",
+                read_mode=FileReadMode.WORKTREE_REFERENCE,
+                worktree_reference=True,
+            )
+        },
+    )
+
+    assert build_timeout_fallback_batch(original, _rescue_diff()) is None

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -343,3 +343,60 @@ def test_default_titan_checklist_renders_with_descriptions_too():
 
     assert '"name": "Functional Correctness"' in rendered
     assert "Logic bugs" in rendered
+
+
+# ============================================================================
+# build_empty_findings_rescue_batch (review-quality-007)
+# ============================================================================
+
+
+def _rescue_diff() -> str:
+    return (
+        "diff --git a/border.py b/border.py\n"
+        "index 111..222 100644\n"
+        "--- a/border.py\n"
+        "+++ b/border.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " context\n"
+        "+added line\n"
+        " context\n"
+    )
+
+
+def test_rescue_batch_builds_hunks_only_entries():
+    from titan_plugin_github.models.review_enums import FileReadMode
+    from titan_plugin_github.operations.findings_operations import (
+        RESCUE_BATCH_ID,
+        build_empty_findings_rescue_batch,
+    )
+
+    batch = build_empty_findings_rescue_batch(["border.py"], _rescue_diff(), [], None)
+
+    assert batch is not None
+    assert batch.batch_id == RESCUE_BATCH_ID
+    entry = batch.files_context["border.py"]
+    assert entry.read_mode == FileReadMode.HUNKS_ONLY
+    assert any("added line" in hunk for hunk in entry.hunks)
+    assert entry.full_content is None
+
+
+def test_rescue_batch_caps_files_and_skips_paths_without_hunks():
+    from titan_plugin_github.operations.findings_operations import build_empty_findings_rescue_batch
+
+    diff = _rescue_diff() + _rescue_diff().replace("border.py", "second.py") + _rescue_diff().replace(
+        "border.py", "third.py"
+    )
+    batch = build_empty_findings_rescue_batch(
+        ["missing_a.py", "border.py", "second.py", "third.py"], diff, [], None
+    )
+
+    # Paths without hunks don't burn a rescue slot; the cap (2) applies to files
+    # that actually made it into the batch.
+    assert batch is not None
+    assert set(batch.files_context) == {"border.py", "second.py"}
+
+
+def test_rescue_batch_returns_none_when_no_paths_have_hunks():
+    from titan_plugin_github.operations.findings_operations import build_empty_findings_rescue_batch
+
+    assert build_empty_findings_rescue_batch(["nope.py"], _rescue_diff(), [], None) is None

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -791,3 +791,74 @@ def test_dedupe_synthesis_findings_lineless_requires_exact_title():
     unique = dedupe_synthesis_findings(synthesis, existing)
 
     assert unique == [{"path": "a.py", "line": None, "title": "Missing error handling in retries"}]
+
+
+def test_dedupe_synthesis_same_category_needs_a_wording_match():
+    """Sharing a category is a hint, not proof: a cross-file finding lands on the call
+    site, so it routinely sits within the line window of a per-file finding in the same
+    category while describing a DIFFERENT defect. Dropping it on category alone would
+    silently delete exactly what the synthesis pass exists to surface."""
+    from titan_plugin_github.operations.findings_operations import dedupe_synthesis_findings
+
+    existing = [
+        {
+            "path": "a.py",
+            "line": 10,
+            "category": "error_handling",
+            "title": "Missing null check on user input",
+        }
+    ]
+    distinct_cross_file = {
+        "path": "a.py",
+        "line": 12,
+        "category": "error_handling",
+        "title": "Caller does not handle the new error contract from b.py",
+    }
+
+    assert dedupe_synthesis_findings([distinct_cross_file], existing) == [distinct_cross_file]
+
+
+def test_dedupe_synthesis_same_category_drops_restatements():
+    """Same category + same spot + a loose wording match (below the 0.75 title bar but
+    above the 0.5 same-category bar) is a restatement, and gets dropped."""
+    from titan_plugin_github.operations.findings_operations import dedupe_synthesis_findings
+
+    existing = [
+        {
+            "path": "a.py",
+            "line": 10,
+            "category": "error_handling",
+            "title": "Missing null check on user input",
+        }
+    ]
+    restatement = {
+        "path": "a.py",
+        "line": 11,
+        "category": "error_handling",
+        "title": "Null check missing for user input",
+    }
+
+    assert dedupe_synthesis_findings([restatement], existing) == []
+
+
+def test_dedupe_synthesis_different_categories_keep_the_strict_title_bar():
+    """With different categories the strict 0.75 title threshold still applies, so a
+    0.71-similar title survives."""
+    from titan_plugin_github.operations.findings_operations import dedupe_synthesis_findings
+
+    existing = [
+        {
+            "path": "a.py",
+            "line": 10,
+            "category": "error_handling",
+            "title": "Missing null check on user input",
+        }
+    ]
+    other_category = {
+        "path": "a.py",
+        "line": 11,
+        "category": "security",
+        "title": "Null check missing for user input",
+    }
+
+    assert dedupe_synthesis_findings([other_category], existing) == [other_category]

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -572,3 +572,155 @@ def test_timeout_fallback_batch_returns_none_without_hunks():
     )
 
     assert build_timeout_fallback_batch(original, _rescue_diff()) is None
+
+
+# ============================================================================
+# trim_hunks_for_synthesis (synthesis budget fix)
+# ============================================================================
+
+
+def test_trim_hunks_keeps_line_numbering_exact():
+    from titan_plugin_github.operations.findings_operations import (
+        _annotate_diff_hunk,
+        trim_hunks_for_synthesis,
+    )
+
+    # One change buried in 8 context lines each side (like -U20 diffs).
+    body = [f" ctx{i}" for i in range(8)] + ["+added line"] + [f" ctx{i + 8}" for i in range(8)]
+    hunk = "@@ -100,16 +100,17 @@\n" + "\n".join(body)
+
+    [trimmed] = trim_hunks_for_synthesis([hunk], context_lines=3)
+
+    # 3 context lines each side survive; header is recalculated so the annotator
+    # still numbers the added line as 108 (100 + 8 lines above it originally).
+    assert trimmed.startswith("@@ -105,6 +105,7 @@")
+    annotated = _annotate_diff_hunk(trimmed)
+    assert "108 [ADDED] added line" in annotated
+    assert "ctx0" not in trimmed
+    assert "ctx5" in trimmed
+
+
+def test_trim_hunks_splits_distant_changes_into_sub_hunks():
+    from titan_plugin_github.operations.findings_operations import trim_hunks_for_synthesis
+
+    body = (
+        ["+first change"]
+        + [f" gap{i}" for i in range(20)]
+        + ["+second change"]
+    )
+    hunk = "@@ -1,20 +1,22 @@\n" + "\n".join(body)
+
+    trimmed = trim_hunks_for_synthesis([hunk], context_lines=3)
+
+    assert len(trimmed) == 2
+    assert "first change" in trimmed[0] and "second change" not in trimmed[0]
+    assert "second change" in trimmed[1]
+    # Bulk of the gap is gone.
+    assert sum(len(t) for t in trimmed) < len(hunk)
+
+
+def test_trim_hunks_passes_through_short_or_headerless_hunks():
+    from titan_plugin_github.operations.findings_operations import trim_hunks_for_synthesis
+
+    short = "@@ -1,2 +1,3 @@\n context\n+added\n context"
+    headerless = "not a hunk at all"
+
+    assert trim_hunks_for_synthesis([short]) == [short]
+    assert trim_hunks_for_synthesis([headerless]) == [headerless]
+
+
+def test_synthesis_batch_trims_wide_context_hunks():
+    from titan_plugin_github.operations.findings_operations import build_cross_file_synthesis_batch
+
+    def _wide_diff(path: str) -> str:
+        body = [f" pad{i}" for i in range(20)] + ["+added line"] + [f" pad{i + 20}" for i in range(20)]
+        return (
+            f"diff --git a/{path} b/{path}\n"
+            "index 111..222 100644\n"
+            f"--- a/{path}\n"
+            f"+++ b/{path}\n"
+            "@@ -1,40 +1,41 @@\n" + "\n".join(body) + "\n"
+        )
+
+    diff = _wide_diff("a.py") + _wide_diff("b.py")
+    batch = build_cross_file_synthesis_batch(["a.py", "b.py"], diff, None)
+
+    assert batch is not None
+    for entry in batch.files_context.values():
+        assert entry.approximate_chars < 200  # vs ~360 chars of untrimmed padding
+        assert all("pad0" not in hunk for hunk in entry.hunks)
+
+
+def test_timeout_fallback_batch_propagates_batch_context():
+    """The bounded retry must not silently lose the original batch's guidance:
+    checklist, existing-comment context, related files and PR manifest carry over."""
+    from titan_plugin_github.models.review_enums import FileReadMode
+    from titan_plugin_github.models.review_models import (
+        FileContextEntry,
+        FocusContextBatch,
+        PullRequestManifest,
+        ReviewChecklistItem,
+    )
+    from titan_plugin_github.models.review_enums import ChecklistCategory
+    from titan_plugin_github.operations.findings_operations import build_timeout_fallback_batch
+
+    manifest = PullRequestManifest(
+        number=7, title="T", base="main", head="feat", author="a", description=""
+    )
+    checklist = [
+        ReviewChecklistItem(id=ChecklistCategory.ERROR_HANDLING, name="Errors", description="d")
+    ]
+    original = FocusContextBatch(
+        batch_id="batch_2",
+        files_context={
+            "border.py": FileContextEntry(
+                path="border.py",
+                read_mode=FileReadMode.WORKTREE_REFERENCE,
+                worktree_reference=True,
+            )
+        },
+        checklist_applicable=checklist,
+        related_files={"helper.py": "def helper(): ..."},
+        pr_manifest=manifest,
+    )
+
+    fallback = build_timeout_fallback_batch(original, _rescue_diff())
+
+    assert fallback is not None
+    assert fallback.checklist_applicable == checklist
+    assert fallback.related_files == {"helper.py": "def helper(): ..."}
+    assert fallback.pr_manifest is manifest
+
+
+def test_dedupe_synthesis_findings_dedupes_within_its_own_list():
+    from titan_plugin_github.operations.findings_operations import dedupe_synthesis_findings
+
+    synthesis = [
+        {"path": "a.py", "line": 10, "title": "Contract mismatch"},
+        {"path": "a.py", "line": 12, "title": "Contract mismatch!"},  # near-dup of the first
+        {"path": "b.py", "line": 3, "title": "Other issue"},
+    ]
+
+    unique = dedupe_synthesis_findings(synthesis, [])
+
+    assert unique == [
+        {"path": "a.py", "line": 10, "title": "Contract mismatch"},
+        {"path": "b.py", "line": 3, "title": "Other issue"},
+    ]
+
+
+def test_dedupe_synthesis_findings_lineless_requires_exact_title():
+    from titan_plugin_github.operations.findings_operations import dedupe_synthesis_findings
+
+    existing = [{"path": "a.py", "line": None, "title": "Missing error handling"}]
+    synthesis = [
+        # Similar-but-not-identical title with no line info on either side: kept —
+        # proximity says nothing, similarity alone must not drop it.
+        {"path": "a.py", "line": None, "title": "Missing error handling in retries"},
+        # Exact title repeat with no lines: dropped.
+        {"path": "a.py", "line": None, "title": "Missing error handling"},
+    ]
+
+    unique = dedupe_synthesis_findings(synthesis, existing)
+
+    assert unique == [{"path": "a.py", "line": None, "title": "Missing error handling in retries"}]

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -400,3 +400,124 @@ def test_rescue_batch_returns_none_when_no_paths_have_hunks():
     from titan_plugin_github.operations.findings_operations import build_empty_findings_rescue_batch
 
     assert build_empty_findings_rescue_batch(["nope.py"], _rescue_diff(), [], None) is None
+
+
+# ============================================================================
+# build_cross_file_synthesis_batch + dedupe_synthesis_findings (review-quality-004)
+# ============================================================================
+
+
+def _synthesis_diff() -> str:
+    return (
+        _rescue_diff()
+        + _rescue_diff().replace("border.py", "second.py")
+        + _rescue_diff().replace("border.py", "third.py")
+    )
+
+
+def test_synthesis_batch_builds_hunks_only_entries_for_all_paths():
+    from titan_plugin_github.models.review_enums import FileReadMode
+    from titan_plugin_github.operations.findings_operations import (
+        SYNTHESIS_BATCH_ID,
+        build_cross_file_synthesis_batch,
+    )
+
+    batch = build_cross_file_synthesis_batch(
+        ["border.py", "second.py", "third.py"], _synthesis_diff(), None
+    )
+
+    assert batch is not None
+    assert batch.batch_id == SYNTHESIS_BATCH_ID
+    # No file cap: unlike the rescue batch, every path with hunks gets an entry.
+    assert set(batch.files_context) == {"border.py", "second.py", "third.py"}
+    for entry in batch.files_context.values():
+        assert entry.read_mode == FileReadMode.HUNKS_ONLY
+        assert entry.full_content is None
+        assert entry.expanded_hunks == []
+        assert entry.approximate_chars > 0
+    assert batch.checklist_applicable == []
+
+
+def test_synthesis_batch_skips_paths_without_hunks():
+    from titan_plugin_github.operations.findings_operations import (
+        build_cross_file_synthesis_batch,
+    )
+
+    batch = build_cross_file_synthesis_batch(
+        ["missing.py", "border.py", "second.py"], _synthesis_diff(), None
+    )
+
+    assert batch is not None
+    assert set(batch.files_context) == {"border.py", "second.py"}
+
+
+def test_synthesis_batch_returns_none_with_fewer_than_two_hunk_files():
+    from titan_plugin_github.operations.findings_operations import (
+        build_cross_file_synthesis_batch,
+    )
+
+    # Only one path with hunks (plus one without): a synthesis over one file is
+    # meaningless.
+    assert (
+        build_cross_file_synthesis_batch(["border.py", "missing.py"], _rescue_diff(), None)
+        is None
+    )
+
+
+def test_build_findings_prompt_parts_instructions_override():
+    from titan_plugin_github.operations.findings_operations import (
+        SYNTHESIS_INSTRUCTIONS,
+        build_cross_file_synthesis_batch,
+        build_findings_prompt_parts,
+        summarize_findings_prompt_parts,
+    )
+
+    batch = build_cross_file_synthesis_batch(
+        ["border.py", "second.py"], _synthesis_diff(), None
+    )
+    parts = build_findings_prompt_parts(batch, instructions_override=SYNTHESIS_INSTRUCTIONS)
+
+    assert parts["instructions"] == SYNTHESIS_INSTRUCTIONS
+    assert "cross-file inconsistencies" in parts["prompt"]
+    assert "Only report actionable issues" not in parts["prompt"]
+    # The summarizer's hardcoded keys must keep working on overridden parts.
+    summary = summarize_findings_prompt_parts(parts)
+    assert summary["instructions_chars"] == len(SYNTHESIS_INSTRUCTIONS)
+
+    default_parts = build_findings_prompt_parts(batch)
+    assert "Only report actionable issues" in default_parts["instructions"]
+
+
+def test_dedupe_synthesis_findings_drops_similar_and_keeps_distinct():
+    from titan_plugin_github.operations.findings_operations import dedupe_synthesis_findings
+
+    existing = [
+        {"path": "a.py", "line": 10, "title": "Null pointer risk in parse_config"},
+        {"path": "b.py", "line": None, "title": "Missing error handling"},
+        "not-a-dict",
+    ]
+    synthesis = [
+        # Exact duplicate (same path/line/title) -> dropped.
+        {"path": "a.py", "line": 10, "title": "Null pointer risk in parse_config"},
+        # Near-duplicate: line within window, very similar title -> dropped.
+        {"path": "a.py", "line": 12, "title": "Null pointer risk in parse_config()"},
+        # Same title but different path -> kept.
+        {"path": "c.py", "line": 10, "title": "Null pointer risk in parse_config"},
+        # Same path/title but line far outside the window -> kept.
+        {"path": "a.py", "line": 200, "title": "Null pointer risk in parse_config"},
+        # Both lines None with similar title -> dropped.
+        {"path": "b.py", "line": None, "title": "Missing error handling"},
+        # One line None, the other not -> kept.
+        {"path": "b.py", "line": 5, "title": "Missing error handling"},
+        # Non-dict synthesis item tolerated and kept for normalize to reject later.
+        42,
+    ]
+
+    unique = dedupe_synthesis_findings(synthesis, existing)
+
+    assert unique == [
+        {"path": "c.py", "line": 10, "title": "Null pointer risk in parse_config"},
+        {"path": "a.py", "line": 200, "title": "Null pointer risk in parse_config"},
+        {"path": "b.py", "line": 5, "title": "Missing error handling"},
+        42,
+    ]

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -464,6 +464,42 @@ def test_synthesis_batch_returns_none_with_fewer_than_two_hunk_files():
     )
 
 
+def _comment_context_entry():
+    from titan_plugin_github.models.review_enums import CommentContextKind
+    from titan_plugin_github.models.review_models import CommentContextEntry
+
+    return CommentContextEntry(
+        kind=CommentContextKind.COMMENT,
+        thread_id="t1",
+        path="border.py",
+        title="Existing comment",
+        summary="Already reported here",
+    )
+
+
+def test_synthesis_and_rescue_batches_carry_comment_context():
+    from titan_plugin_github.operations.findings_operations import (
+        build_cross_file_synthesis_batch,
+        build_empty_findings_rescue_batch,
+        build_findings_prompt_parts,
+    )
+
+    comments = [_comment_context_entry()]
+
+    synthesis = build_cross_file_synthesis_batch(
+        ["border.py", "second.py"], _synthesis_diff(), None, comment_context=comments
+    )
+    rescue = build_empty_findings_rescue_batch(
+        ["border.py"], _rescue_diff(), [], None, comment_context=comments
+    )
+
+    # The prompt tells the model not to duplicate existing comments, so they must
+    # actually reach the prompt.
+    for batch in (synthesis, rescue):
+        assert batch.comment_context == comments
+        assert "Already reported here" in build_findings_prompt_parts(batch)["comments"]
+
+
 def test_build_findings_prompt_parts_instructions_override():
     from titan_plugin_github.operations.findings_operations import (
         SYNTHESIS_INSTRUCTIONS,

--- a/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_findings_operations.py
@@ -402,6 +402,37 @@ def test_rescue_batch_returns_none_when_no_paths_have_hunks():
     assert build_empty_findings_rescue_batch(["nope.py"], _rescue_diff(), [], None) is None
 
 
+def test_rescue_batch_carries_capped_checklist_and_manifest():
+    from titan_plugin_github.models.review_enums import ChecklistCategory
+    from titan_plugin_github.models.review_models import PullRequestManifest, ReviewChecklistItem
+    from titan_plugin_github.operations.findings_operations import build_empty_findings_rescue_batch
+
+    checklist = [
+        ReviewChecklistItem(id=category, name=category.value, description="d")
+        for category in (
+            ChecklistCategory.FUNCTIONAL_CORRECTNESS,
+            ChecklistCategory.ERROR_HANDLING,
+            ChecklistCategory.SEMANTIC_CORRECTNESS,
+            ChecklistCategory.STATE_CONSISTENCY,
+            ChecklistCategory.TEST_COVERAGE,
+            ChecklistCategory.SECURITY,
+        )
+    ]
+    manifest = PullRequestManifest(
+        number=7, title="T", base="main", head="feat", author="a", description=""
+    )
+
+    batch = build_empty_findings_rescue_batch(
+        ["border.py"], _rescue_diff(), checklist, manifest
+    )
+
+    # The rescue batch must still run with review axes: only the first 4 items travel.
+    assert batch is not None
+    assert batch.checklist_applicable == checklist[:4]
+    assert len(batch.checklist_applicable) == 4
+    assert batch.pr_manifest is manifest
+
+
 # ============================================================================
 # build_cross_file_synthesis_batch + dedupe_synthesis_findings (review-quality-004)
 # ============================================================================

--- a/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_action_operations.py
@@ -162,7 +162,7 @@ def test_comment_view_from_action_prefers_resolved_line_label():
     view = CommentView.from_action(action, diff_hunk="@@ -10,1 +10,2 @@")
 
     assert view.line == 12
-    assert view.line_label == "Line 12 (AI 999 via snippet)"
+    assert view.line_label == "Line 12 (adjusted from AI's line 999)"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/titan-plugin-github/tests/operations/test_review_strategy_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_review_strategy_operations.py
@@ -341,3 +341,24 @@ def test_deterministic_plan_uses_profile_review_axes():
     plan = build_deterministic_review_plan(candidates, excluded, checklist, strategy, review_profile=profile)
 
     assert ChecklistCategory.SECURITY in plan.review_axes
+
+
+def test_classify_pr_comment_threads_do_not_change_size_class():
+    """review-quality-010: review activity must not inflate the size class — a review's
+    own published comments would otherwise push the same unchanged PR into a bigger
+    class on the next run, changing focus/budget between passes."""
+    manifest = make_manifest(
+        [
+            ChangedFileEntry(path=f"src/file_{idx}.py", status="modified", additions=40, deletions=10)
+            for idx in range(10)
+        ]
+    )
+
+    quiet = classify_pr(manifest, comment_entries=0, comment_threads=0)
+    noisy = classify_pr(manifest, comment_entries=40, comment_threads=25)
+
+    assert noisy.size_class == quiet.size_class
+    assert noisy.complexity_score == quiet.complexity_score
+    # The activity signal is still captured — just not as size.
+    assert noisy.active_review is True
+    assert quiet.active_review is False

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -299,3 +299,22 @@ def test_code_map_prefers_expanded_hunks_over_hunks():
     code_map = build_verification_code_map([_make_finding(path="a.py")], [batch])
 
     assert code_map["a.py"] == "expanded hunk with surrounding context"
+
+
+def test_code_map_skips_entries_with_only_full_content():
+    """A hunk-less entry contributes no code, so its findings have no context to be
+    refuted against and survive verification (see `apply_verdicts`)."""
+    batch = FocusContextBatch(
+        batch_id="batch_1",
+        files_context={
+            "a.py": FileContextEntry(
+                path="a.py",
+                read_mode=FileReadMode.FULL_FILE,
+                full_content="FULL FILE CONTENT " * 500,
+            ),
+        },
+    )
+
+    code_map = build_verification_code_map([_make_finding(path="a.py")], [batch])
+
+    assert "a.py" not in code_map

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -128,6 +128,24 @@ def test_apply_verdicts_fails_open():
 
     assert outcome.refuted == []
     assert len(outcome.kept) == 5
+    # unknown verdict + out-of-range + malformed; the evidence-less refutation is a
+    # well-formed verdict, so it is not counted as invalid.
+    assert outcome.invalid_verdicts == 3
+
+
+def test_apply_verdicts_counts_zero_invalid_when_all_usable():
+    findings = [_make_finding(f"f{i}") for i in range(2)]
+
+    outcome = apply_verification_verdicts(
+        findings,
+        findings,
+        [
+            {"index": 0, "verdict": "confirmed", "reasoning": "ok"},
+            {"index": 1, "verdict": "uncertain", "reasoning": "hmm"},
+        ],
+    )
+
+    assert outcome.invalid_verdicts == 0
 
 
 def test_code_map_uses_hunks_never_full_content():

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -61,7 +61,8 @@ def test_prompt_includes_findings_and_capped_code():
 
 def test_prompt_survives_missing_code_context():
     parts = build_verification_prompt_parts([_make_finding(path="gone.py")], {})
-    assert "(no code context available)" in parts["code"]
+    assert "### gone.py" in parts["code"]
+    assert "no code context available for this file" in parts["code"]
 
 
 def test_parse_structured_response_unwraps_verdicts():
@@ -145,7 +146,7 @@ def test_code_map_uses_hunks_never_full_content():
     assert "FULL FILE CONTENT" not in code_map["a.py"]
 
 
-def test_code_map_only_includes_finding_paths_and_caps():
+def test_code_map_only_includes_finding_paths_without_truncating():
     batch = FocusContextBatch(
         batch_id="batch_1",
         files_context={
@@ -154,10 +155,11 @@ def test_code_map_only_includes_finding_paths_and_caps():
         },
     )
 
-    code_map = build_verification_code_map([_make_finding(path="a.py")], [batch], cap_chars=100)
+    code_map = build_verification_code_map([_make_finding(path="a.py")], [batch])
 
+    # Capping (with its visible marker) happens at prompt build, not here.
     assert set(code_map) == {"a.py"}
-    assert len(code_map["a.py"]) == 100
+    assert len(code_map["a.py"]) == 9000
 
 
 def test_schema_and_telemetry_shapes():
@@ -172,3 +174,78 @@ def test_schema_and_telemetry_shapes():
     parts = build_verification_prompt_parts([_make_finding()], {"a.py": "code"})
     telemetry = summarize_verification_prompt_parts(parts)
     assert set(telemetry) == {"findings_chars", "code_chars", "instructions_chars"}
+
+
+# ============================================================================
+# Fixes from the 2026-08-03 validation-run findings
+# ============================================================================
+
+
+def test_prompt_marks_paths_without_code_context():
+    """A finding whose path has no code must not silently share the prompt with other
+    files' code — the model could read absence as contradiction and refute it."""
+    parts = build_verification_prompt_parts(
+        [_make_finding(path="missing.py"), _make_finding(path="a.py")],
+        {"a.py": "some code"},
+    )
+
+    assert "### missing.py" in parts["code"]
+    assert "no code context available for this file" in parts["code"]
+    assert 'must be "uncertain"' in parts["code"]
+
+
+def test_prompt_marks_truncated_code_blocks():
+    parts = build_verification_prompt_parts(
+        [_make_finding(path="a.py")], {"a.py": "x" * 5000}, code_cap_chars=100
+    )
+
+    assert "code truncated here" in parts["code"]
+
+    intact = build_verification_prompt_parts(
+        [_make_finding(path="a.py")], {"a.py": "short"}, code_cap_chars=100
+    )
+    assert "code truncated here" not in intact["code"]
+
+
+def test_apply_verdicts_ignores_refutation_without_code_context():
+    """The model cannot legitimately contradict code it never saw: a refutation for a
+    path outside `paths_with_code` is dropped (finding kept), deterministically."""
+    no_code = _make_finding("No code one", path="missing.py")
+    with_code = _make_finding("With code one", path="a.py")
+
+    outcome = apply_verification_verdicts(
+        [no_code, with_code],
+        [
+            {"index": 0, "verdict": "refuted", "reasoning": "not present in the code"},
+            {"index": 1, "verdict": "refuted", "reasoning": "check exists at line 12"},
+        ],
+        exempt=[],
+        paths_with_code={"a.py"},
+    )
+
+    assert no_code in outcome.kept
+    assert with_code in outcome.refuted
+    assert outcome.refuted_reasons == ["check exists at line 12"]
+
+
+def test_apply_verdicts_keeps_uncertain_findings():
+    """`uncertain` is a declared verdict value and must behave as keep, not drop."""
+    finding = _make_finding("Uncertain one")
+
+    outcome = apply_verification_verdicts(
+        [finding],
+        [{"index": 0, "verdict": "uncertain", "reasoning": "not enough code shown"}],
+        exempt=[],
+    )
+
+    assert outcome.refuted == []
+    assert finding in outcome.kept
+
+
+def test_parse_verification_response_handles_non_json_and_empty():
+    """Fail-open depends on parse returning an error, never raising, on prose or
+    empty output — the most likely real-world CLI failure shapes."""
+    for stdout in ("I could not verify these findings, sorry.", "", "   \n"):
+        for structured in (True, False):
+            result = parse_verification_response(stdout, structured=structured)
+            assert isinstance(result, ClientError)

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -91,12 +91,12 @@ def test_apply_verdicts_drops_only_evidenced_refutations():
     nit = _make_finding("Nit one", severity=FindingSeverity.NIT)
 
     outcome = apply_verification_verdicts(
+        [refuted, confirmed, nit],
         [refuted, confirmed],
         [
             {"index": 0, "verdict": "refuted", "reasoning": "the check exists at line 12"},
             {"index": 1, "verdict": "confirmed", "reasoning": "claim holds"},
         ],
-        exempt=[nit],
     )
 
     assert refuted in outcome.refuted
@@ -104,6 +104,9 @@ def test_apply_verdicts_drops_only_evidenced_refutations():
     assert confirmed in outcome.kept
     assert nit in outcome.kept
     assert refuted not in outcome.kept
+    # Kept must preserve the input order (most-severe first) — exempt nits must not
+    # jump ahead of verified blocking findings in the gate or the posted comments.
+    assert outcome.kept == [confirmed, nit]
 
 
 def test_apply_verdicts_fails_open():
@@ -113,6 +116,7 @@ def test_apply_verdicts_fails_open():
 
     outcome = apply_verification_verdicts(
         findings,
+        findings,
         [
             {"index": 1, "verdict": "refuted", "reasoning": ""},  # no evidence → kept
             {"index": 2, "verdict": "maybe", "reasoning": "?"},  # unknown verdict → kept
@@ -120,7 +124,6 @@ def test_apply_verdicts_fails_open():
             {"verdict": "refuted"},  # malformed (no index) → ignored
             # index 0, 3, 4: no verdict at all → kept
         ],
-        exempt=[],
     )
 
     assert outcome.refuted == []
@@ -215,11 +218,11 @@ def test_apply_verdicts_ignores_refutation_without_code_context():
 
     outcome = apply_verification_verdicts(
         [no_code, with_code],
+        [no_code, with_code],
         [
             {"index": 0, "verdict": "refuted", "reasoning": "not present in the code"},
             {"index": 1, "verdict": "refuted", "reasoning": "check exists at line 12"},
         ],
-        exempt=[],
         paths_with_code={"a.py"},
     )
 
@@ -234,8 +237,8 @@ def test_apply_verdicts_keeps_uncertain_findings():
 
     outcome = apply_verification_verdicts(
         [finding],
+        [finding],
         [{"index": 0, "verdict": "uncertain", "reasoning": "not enough code shown"}],
-        exempt=[],
     )
 
     assert outcome.refuted == []
@@ -266,7 +269,7 @@ def test_apply_verdicts_conflicting_duplicate_indices_prefer_keep():
             {"index": 0, "verdict": "refuted", "reasoning": "stray refutation"},
         ],
     ):
-        outcome = apply_verification_verdicts([finding], verdicts, exempt=[])
+        outcome = apply_verification_verdicts([finding], [finding], verdicts)
         assert outcome.refuted == []
         assert finding in outcome.kept
 

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -127,7 +127,9 @@ def test_apply_verdicts_fails_open():
     )
 
     assert outcome.refuted == []
-    assert len(outcome.kept) == 5
+    # Identity and order, not just the count: a change that duplicated, dropped or
+    # reordered findings before the human gate must fail here.
+    assert outcome.kept == findings
     # unknown verdict + out-of-range + malformed; the evidence-less refutation is a
     # well-formed verdict, so it is not counted as invalid.
     assert outcome.invalid_verdicts == 3

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -1,0 +1,174 @@
+"""Tests for the adversarial findings-verification operations (review-quality-003)."""
+
+import json
+
+from titan_cli.core.result import ClientError, ClientSuccess
+from titan_plugin_github.models.review_enums import FileReadMode, FindingSeverity
+from titan_plugin_github.models.review_models import FileContextEntry, Finding, FocusContextBatch
+from titan_plugin_github.operations.verification_operations import (
+    apply_verification_verdicts,
+    build_verification_code_map,
+    build_verification_prompt_parts,
+    parse_verification_response,
+    select_findings_for_verification,
+    summarize_verification_prompt_parts,
+    verification_json_schema,
+)
+
+
+def _make_finding(
+    title: str = "Null check missing",
+    severity: FindingSeverity = FindingSeverity.IMPORTANT,
+    path: str = "a.py",
+) -> Finding:
+    return Finding(
+        severity=severity,
+        category="error_handling",
+        path=path,
+        line=10,
+        title=title,
+        why="The value may be None",
+        evidence="value.method()",
+        suggested_comment="Add a null check",
+    )
+
+
+def test_select_findings_exempts_nits():
+    important = _make_finding("Important one")
+    nit = _make_finding("Nit one", severity=FindingSeverity.NIT)
+
+    to_verify, exempt = select_findings_for_verification([important, nit])
+
+    assert to_verify == [important]
+    assert exempt == [nit]
+
+
+def test_prompt_includes_findings_and_capped_code():
+    finding = _make_finding(path="a.py")
+    parts = build_verification_prompt_parts(
+        [finding], {"a.py": "x" * 5000, "unrelated.py": "y" * 100}, code_cap_chars=100
+    )
+
+    findings_payload = json.loads(parts["findings"])
+    assert findings_payload[0]["title"] == "Null check missing"
+    assert findings_payload[0]["index"] == 0
+    # Code is capped and only the findings' paths are included.
+    assert "x" * 100 in parts["code"]
+    assert "x" * 101 not in parts["code"]
+    assert "unrelated.py" not in parts["code"]
+    assert "REFUTE" in parts["prompt"]
+
+
+def test_prompt_survives_missing_code_context():
+    parts = build_verification_prompt_parts([_make_finding(path="gone.py")], {})
+    assert "(no code context available)" in parts["code"]
+
+
+def test_parse_structured_response_unwraps_verdicts():
+    stdout = json.dumps({"verdicts": [{"index": 0, "verdict": "refuted", "reasoning": "line 12 has the check"}]})
+    result = parse_verification_response(stdout, structured=True)
+    assert isinstance(result, ClientSuccess)
+    assert result.data[0]["verdict"] == "refuted"
+
+
+def test_parse_structured_response_without_verdicts_list_errors():
+    result = parse_verification_response(json.dumps({"verdicts": {"index": 0}}), structured=True)
+    assert isinstance(result, ClientError)
+    assert result.error_code == "MISSING_VERDICTS_FIELD"
+
+
+def test_parse_unstructured_response_extracts_array():
+    stdout = '```json\n[{"index": 0, "verdict": "confirmed"}]\n```'
+    result = parse_verification_response(stdout, structured=False)
+    assert isinstance(result, ClientSuccess)
+    assert result.data[0]["verdict"] == "confirmed"
+
+
+def test_apply_verdicts_drops_only_evidenced_refutations():
+    refuted = _make_finding("Refuted one")
+    confirmed = _make_finding("Confirmed one")
+    nit = _make_finding("Nit one", severity=FindingSeverity.NIT)
+
+    outcome = apply_verification_verdicts(
+        [refuted, confirmed],
+        [
+            {"index": 0, "verdict": "refuted", "reasoning": "the check exists at line 12"},
+            {"index": 1, "verdict": "confirmed", "reasoning": "claim holds"},
+        ],
+        exempt=[nit],
+    )
+
+    assert refuted in outcome.refuted
+    assert outcome.refuted_reasons == ["the check exists at line 12"]
+    assert confirmed in outcome.kept
+    assert nit in outcome.kept
+    assert refuted not in outcome.kept
+
+
+def test_apply_verdicts_fails_open():
+    """Missing verdicts, out-of-range indices, unknown verdict values, malformed items,
+    and reasoning-less refutations must all KEEP the finding."""
+    findings = [_make_finding(f"f{i}") for i in range(5)]
+
+    outcome = apply_verification_verdicts(
+        findings,
+        [
+            {"index": 1, "verdict": "refuted", "reasoning": ""},  # no evidence → kept
+            {"index": 2, "verdict": "maybe", "reasoning": "?"},  # unknown verdict → kept
+            {"index": 99, "verdict": "refuted", "reasoning": "x"},  # out of range → ignored
+            {"verdict": "refuted"},  # malformed (no index) → ignored
+            # index 0, 3, 4: no verdict at all → kept
+        ],
+        exempt=[],
+    )
+
+    assert outcome.refuted == []
+    assert len(outcome.kept) == 5
+
+
+def test_code_map_uses_hunks_never_full_content():
+    batch = FocusContextBatch(
+        batch_id="batch_1",
+        files_context={
+            "a.py": FileContextEntry(
+                path="a.py",
+                read_mode=FileReadMode.FULL_FILE,
+                full_content="FULL FILE CONTENT " * 500,
+                hunks=["@@ -1,2 +1,3 @@\n+added line"],
+            )
+        },
+    )
+
+    code_map = build_verification_code_map([_make_finding(path="a.py")], [batch])
+
+    assert "added line" in code_map["a.py"]
+    assert "FULL FILE CONTENT" not in code_map["a.py"]
+
+
+def test_code_map_only_includes_finding_paths_and_caps():
+    batch = FocusContextBatch(
+        batch_id="batch_1",
+        files_context={
+            "a.py": FileContextEntry(path="a.py", read_mode=FileReadMode.HUNKS_ONLY, hunks=["h" * 9000]),
+            "b.py": FileContextEntry(path="b.py", read_mode=FileReadMode.HUNKS_ONLY, hunks=["other"]),
+        },
+    )
+
+    code_map = build_verification_code_map([_make_finding(path="a.py")], [batch], cap_chars=100)
+
+    assert set(code_map) == {"a.py"}
+    assert len(code_map["a.py"]) == 100
+
+
+def test_schema_and_telemetry_shapes():
+    schema = verification_json_schema()
+    assert schema["required"] == ["verdicts"]
+    assert schema["properties"]["verdicts"]["items"]["properties"]["verdict"]["enum"] == [
+        "confirmed",
+        "refuted",
+        "uncertain",
+    ]
+
+    parts = build_verification_prompt_parts([_make_finding()], {"a.py": "code"})
+    telemetry = summarize_verification_prompt_parts(parts)
+    assert set(telemetry) == {"findings_chars", "code_chars", "instructions_chars"}

--- a/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
+++ b/plugins/titan-plugin-github/tests/operations/test_verification_operations.py
@@ -249,3 +249,50 @@ def test_parse_verification_response_handles_non_json_and_empty():
         for structured in (True, False):
             result = parse_verification_response(stdout, structured=structured)
             assert isinstance(result, ClientError)
+
+
+def test_apply_verdicts_conflicting_duplicate_indices_prefer_keep():
+    """Duplicate indices are malformed output — whichever order they arrive in, the
+    verdict that KEEPS the finding must win (fail-open)."""
+    finding = _make_finding("Contested one")
+
+    for verdicts in (
+        [
+            {"index": 0, "verdict": "refuted", "reasoning": "stray refutation"},
+            {"index": 0, "verdict": "confirmed", "reasoning": "holds"},
+        ],
+        [
+            {"index": 0, "verdict": "confirmed", "reasoning": "holds"},
+            {"index": 0, "verdict": "refuted", "reasoning": "stray refutation"},
+        ],
+    ):
+        outcome = apply_verification_verdicts([finding], verdicts, exempt=[])
+        assert outcome.refuted == []
+        assert finding in outcome.kept
+
+
+def test_parse_structured_response_accepts_bare_array():
+    """The shared prompt text asks for a bare JSON array (the unstructured shape);
+    a model honoring the prompt over the schema must still be parseable."""
+    stdout = '[{"index": 0, "verdict": "confirmed", "reasoning": "holds"}]'
+    result = parse_verification_response(stdout, structured=True)
+    assert isinstance(result, ClientSuccess)
+    assert result.data[0]["verdict"] == "confirmed"
+
+
+def test_code_map_prefers_expanded_hunks_over_hunks():
+    batch = FocusContextBatch(
+        batch_id="batch_1",
+        files_context={
+            "a.py": FileContextEntry(
+                path="a.py",
+                read_mode=FileReadMode.EXPANDED_HUNKS,
+                hunks=["plain hunk"],
+                expanded_hunks=["expanded hunk with surrounding context"],
+            ),
+        },
+    )
+
+    code_map = build_verification_code_map([_make_finding(path="a.py")], [batch])
+
+    assert code_map["a.py"] == "expanded hunk with surrounding context"

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -2,13 +2,14 @@ from unittest.mock import Mock
 
 from titan_cli.core.result import ClientError, ClientSuccess
 from titan_cli.engine import WorkflowContext
-from titan_cli.engine.results import Error, Exit, Success
+from titan_cli.engine.results import Error, Exit, Skip, Success
 from titan_cli.external_cli.adapters import HeadlessResponse
 from titan_cli.external_cli.adapters.base import SupportedCLI
-from titan_plugin_github.models.review_enums import FileReadMode, PRSizeClass, ReviewStrategyType
+from titan_plugin_github.models.review_enums import FileReadMode, FindingSeverity, PRSizeClass, ReviewStrategyType
 from titan_plugin_github.models.review_models import (
     ChangeManifest,
     FileContextEntry,
+    Finding,
     FocusContextBatch,
     PullRequestManifest,
     ReferencedCommitContext,
@@ -17,6 +18,7 @@ from titan_plugin_github.models.review_models import (
     ThreadReviewContext,
 )
 from titan_plugin_github.models.review_enums import FileChangeStatus
+from titan_plugin_github.models.review_profile_models import ReviewProfile
 from titan_plugin_github.models.view import UIComment, UICommentThread, UIFileChange, UIPullRequest
 import titan_plugin_github.steps.code_review_steps as code_review_steps
 from titan_plugin_github.steps.code_review_steps import (
@@ -26,6 +28,7 @@ from titan_plugin_github.steps.code_review_steps import (
     build_thread_review_contexts,
     fetch_pr_review_bundle,
     score_review_candidates,
+    verify_findings,
 )
 
 
@@ -1282,3 +1285,136 @@ def test_submit_sha_drift_ignores_surrounding_whitespace():
     drift = code_review_steps._detect_submit_time_sha_drift(ctx, 123, "a" * 40)
 
     assert drift.drifted is False
+
+
+# ============================================================================
+# verify_findings (review-quality-003)
+# ============================================================================
+
+
+def _make_finding_model(
+    title: str = "Null check missing",
+    severity: FindingSeverity = FindingSeverity.IMPORTANT,
+    path: str = "a.py",
+) -> Finding:
+    return Finding(
+        severity=severity,
+        category="error_handling",
+        path=path,
+        line=10,
+        title=title,
+        why="The value may be None",
+        evidence="value.method()",
+        suggested_comment="Add a null check",
+    )
+
+
+def _verify_ctx(findings: list, adapter_stdout: str | None = None) -> WorkflowContext:
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["deduped_findings"] = findings
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["review_profile"] = ReviewProfile()
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+    return ctx
+
+
+def test_verify_findings_drops_refuted_finding(monkeypatch):
+    """review-quality-003: a finding the verifier refutes with evidence is removed
+    from deduped_findings before the human gate, and published as refuted."""
+    refuted = _make_finding_model("False positive")
+    confirmed = _make_finding_model("Real bug")
+    stdout = '{"verdicts": [{"index": 0, "verdict": "refuted", "reasoning": "check exists at line 12"}, {"index": 1, "verdict": "confirmed", "reasoning": "holds"}]}'
+    fake_adapter = _FakeStructuredOutputAdapter(stdout)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([refuted, confirmed])
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["deduped_findings"] == [confirmed]
+    assert ctx.data["refuted_findings"] == [refuted]
+    # Verification must run at low effort with the verdicts schema (D-002/D-003).
+    assert fake_adapter.calls[0]["effort"] == "low"
+    assert fake_adapter.calls[0]["json_schema"]["required"] == ["verdicts"]
+
+
+def test_verify_findings_fails_open_on_cli_failure(monkeypatch):
+    finding = _make_finding_model()
+    fake_adapter = _FakeFailingCLIAdapter(exit_code=1)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([finding])
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Skip)
+    assert ctx.data["deduped_findings"] == [finding]
+
+
+def test_verify_findings_fails_open_on_unparseable_response(monkeypatch):
+    finding = _make_finding_model()
+    fake_adapter = _FakeStructuredOutputAdapter("I cannot judge these findings, sorry.")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([finding])
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Skip)
+    assert ctx.data["deduped_findings"] == [finding]
+
+
+def test_verify_findings_skips_when_profile_disables_it(monkeypatch):
+    finding = _make_finding_model()
+    fake_adapter = _FakeStructuredOutputAdapter("should never be called")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([finding])
+    ctx.data["review_profile"] = ReviewProfile(findings_verification_enabled=False)
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Skip)
+    assert fake_adapter.calls == []
+    assert ctx.data["deduped_findings"] == [finding]
+
+
+def test_verify_findings_skips_nit_only_findings(monkeypatch):
+    nit = _make_finding_model("Style nit", severity=FindingSeverity.NIT)
+    fake_adapter = _FakeStructuredOutputAdapter("should never be called")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([nit])
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Skip)
+    assert fake_adapter.calls == []
+    assert ctx.data["deduped_findings"] == [nit]
+
+
+def test_verify_findings_fails_open_when_prompt_over_budget(monkeypatch):
+    finding = _make_finding_model()
+    fake_adapter = _FakeStructuredOutputAdapter("should never be called")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([finding])
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=100,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Skip)
+    assert fake_adapter.calls == []
+    assert ctx.data["deduped_findings"] == [finding]

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -669,9 +669,190 @@ def test_ai_review_findings_marks_batch_failed_when_reformat_retry_also_fails(mo
 
     result = ai_review_findings(ctx)
 
-    assert isinstance(result, Success)
+    # The only batch failed, so the whole step must fail visibly (0/1 produced output).
+    assert isinstance(result, Error)
     assert len(fake_adapter.calls) == 2
     assert ctx.data["ai_findings_failed"] is True
+    assert ctx.data["raw_findings"] == []
+
+
+def test_ai_review_findings_partial_batch_failure_still_succeeds_with_flag(monkeypatch):
+    """One batch fails parse (main + retry), the other returns findings: the step
+    succeeds but ai_findings_failed must be True so the outcome isn't presented
+    as a fully clean review."""
+    fake_adapter = _FakeSequentialAdapter(
+        [
+            "Reported one finding: fix the null check.",  # batch_1 main call (prose)
+            "Still no JSON here, sorry.",  # batch_1 reformat retry
+            '[{"title": "Bug"}]',  # batch_2 main call
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [
+        _make_findings_batch("batch_1", {"a.py": 100}),
+        _make_findings_batch("batch_2", {"b.py": 100}),
+    ]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == [{"title": "Bug"}]
+    assert ctx.data["ai_findings_failed"] is True
+
+
+class _FakeFailingCLIAdapter:
+    """Fake headless adapter whose every call fails with a non-zero exit code."""
+
+    cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = False
+    supports_tool_restriction = False
+    supports_effort_control = False
+
+    def __init__(self, exit_code: int = 1):
+        self._exit_code = exit_code
+        self.calls = 0
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
+        self.calls += 1
+        return HeadlessResponse(stdout="", stderr="credit balance too low", exit_code=self._exit_code)
+
+
+def test_ai_review_findings_returns_error_when_all_batches_fail(monkeypatch):
+    """review-quality-005: when every batch fails (e.g. headless CLI without credits,
+    observed live 2026-07-31), the step must NOT report plain Success — a total AI
+    failure was indistinguishable from a clean review. raw_findings stays published
+    (empty) so downstream steps and worktree cleanup still run via on_error: continue."""
+    fake_adapter = _FakeFailingCLIAdapter(exit_code=1)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [
+        _make_findings_batch("batch_1", {"a.py": 100}),
+        _make_findings_batch("batch_2", {"b.py": 100}),
+    ]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Error)
+    assert "0/2" in result.message
+    assert fake_adapter.calls == 2
+    assert ctx.data["raw_findings"] == []
+    assert ctx.data["ai_findings_failed"] is True
+
+
+class _FakeStructuredSequentialAdapter:
+    """Fake structured-output adapter returning one canned stdout per call, in order."""
+
+    cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = True
+    supports_tool_restriction = True
+    supports_effort_control = True
+
+    def __init__(self, stdouts: list[str]):
+        self._stdouts = list(stdouts)
+        self.calls: list[dict] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
+        self.calls.append({"prompt": prompt, "timeout": timeout, "json_schema": json_schema})
+        stdout = self._stdouts[len(self.calls) - 1]
+        return HeadlessResponse(stdout=stdout, stderr="", exit_code=0)
+
+
+def test_ai_review_findings_non_list_payload_goes_through_reformat_retry(monkeypatch):
+    """review-quality-005: a structured success whose findings payload isn't a list
+    (e.g. a dict) used to hit `case ClientSuccess(): pass` and vanish — no failure
+    flag, no batch result rendered. It must go through the reformat-retry path and
+    recover when the retry returns a proper list."""
+    fake_adapter = _FakeStructuredSequentialAdapter(
+        [
+            '{"findings": {"title": "Bug"}}',  # main call: dict payload, not a list
+            '{"findings": [{"title": "Bug"}]}',  # reformat retry: proper list
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    assert ctx.data["raw_findings"] == [{"title": "Bug"}]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_non_list_payload_marks_failed_when_retry_also_non_list(monkeypatch):
+    fake_adapter = _FakeStructuredSequentialAdapter(
+        [
+            '{"findings": {"title": "Bug"}}',  # main call: dict payload
+            '{"findings": {"title": "Bug"}}',  # retry: still a dict
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=6000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+
+    result = ai_review_findings(ctx)
+
+    # Single batch, non-list payload twice: batch failed, so 0/1 → step fails visibly.
+    assert isinstance(result, Error)
+    assert len(fake_adapter.calls) == 2
+    assert ctx.data["ai_findings_failed"] is True
+    assert ctx.data["raw_findings"] == []
 
 
 class _FakeStructuredOutputAdapter:
@@ -756,7 +937,8 @@ def test_ai_review_findings_structured_output_retry_also_requests_schema(monkeyp
 
     result = ai_review_findings(ctx)
 
-    assert isinstance(result, Success)
+    # The only batch failed even after the retry, so the step fails (0/1 produced output).
+    assert isinstance(result, Error)
     assert len(fake_adapter.calls) == 2
     assert fake_adapter.calls[1]["json_schema"] is not None
     assert ctx.data["ai_findings_failed"] is True
@@ -842,7 +1024,8 @@ def test_ai_review_findings_reformat_retry_also_restricts_tools(monkeypatch):
 
     result = ai_review_findings(ctx)
 
-    assert isinstance(result, Success)
+    # The only batch failed even after the retry, so the step fails (0/1 produced output).
+    assert isinstance(result, Error)
     assert len(fake_adapter.calls) == 2
     assert fake_adapter.calls[1]["disallowed_tools"] == list(FINDINGS_DISALLOWED_TOOLS)
 

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -1664,3 +1664,165 @@ def test_ai_review_findings_no_rescue_when_not_suspicious(monkeypatch):
 
     assert isinstance(result, Success)
     assert len(fake_adapter.calls) == 1
+
+
+# ============================================================================
+# ai_review_findings cross-file synthesis (review-quality-004)
+# ============================================================================
+
+
+def _synthesis_diff(line: str = "added line") -> str:
+    def _file_diff(path: str) -> str:
+        return (
+            f"diff --git a/{path} b/{path}\n"
+            "index 111..222 100644\n"
+            f"--- a/{path}\n"
+            f"+++ b/{path}\n"
+            "@@ -1,2 +1,3 @@\n"
+            " context\n"
+            f"+{line}\n"
+            " context\n"
+        )
+
+    return _file_diff("a.py") + _file_diff("b.py")
+
+
+def _synthesis_ctx(
+    adapter_stdouts: list[str],
+    *,
+    enabled: bool = True,
+    batch_files: list[dict[str, int]] | None = None,
+    diff: str | None = None,
+) -> tuple[WorkflowContext, "_FakeSequentialAdapter"]:
+    fake_adapter = _FakeSequentialAdapter(adapter_stdouts)
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_profile"] = ReviewProfile(
+        findings_batch_concurrency=1, findings_synthesis_enabled=enabled
+    )
+    files = batch_files if batch_files is not None else [{"a.py": 100}, {"b.py": 100}]
+    ctx.data["review_context_batches"] = [
+        _make_findings_batch(f"batch_{index + 1}", file_chars)
+        for index, file_chars in enumerate(files)
+    ]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+        suspicious_empty_findings=False,
+    )
+    ctx.data["review_diff"] = diff if diff is not None else _synthesis_diff()
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+    return ctx, fake_adapter
+
+
+def test_ai_review_findings_runs_synthesis_when_enabled_and_multi_file(monkeypatch):
+    """review-quality-004: with the profile flag on and >1 focus file, one extra
+    cross-file synthesis batch runs after the per-file batches — even when the
+    per-file batches already produced findings (unlike the 007 rescue)."""
+    ctx, fake_adapter = _synthesis_ctx(
+        [
+            '[{"title": "Bug in a", "path": "a.py", "line": 5}]',  # batch_1
+            "[]",  # batch_2
+            '[{"title": "Contract mismatch", "path": "b.py", "line": 2}]',  # synthesis
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 3
+    synthesis_prompt = fake_adapter.calls[2]["prompt"]
+    assert "cross-file inconsistencies" in synthesis_prompt
+    assert "a.py" in synthesis_prompt and "b.py" in synthesis_prompt
+    assert ctx.data["raw_findings"] == [
+        {"title": "Bug in a", "path": "a.py", "line": 5},
+        {"title": "Contract mismatch", "path": "b.py", "line": 2},
+    ]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_synthesis_disabled_by_default(monkeypatch):
+    ctx, fake_adapter = _synthesis_ctx(["[]", "[]"], enabled=False)
+    # Same as the default profile: the flag is opt-in (D-002 token mandate).
+    assert ReviewProfile().findings_synthesis_enabled is False
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+
+
+def test_ai_review_findings_no_synthesis_single_focus_file(monkeypatch):
+    ctx, fake_adapter = _synthesis_ctx(["[]"], batch_files=[{"a.py": 100}])
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 1
+
+
+def test_ai_review_findings_synthesis_skipped_over_budget(monkeypatch):
+    """Over-budget synthesis skips silently — no split/degrade machinery, no 3rd call."""
+    # Big diff hunks blow the synthesis prompt past the budget, while the per-file
+    # batches (100 chars each) still fit comfortably.
+    ctx, fake_adapter = _synthesis_ctx(
+        ["[]", "[]"], diff=_synthesis_diff(line="z" * 15000)
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_synthesis_failure_is_best_effort(monkeypatch):
+    """A failed synthesis call must not mark an otherwise-successful review as failed."""
+    ctx, fake_adapter = _synthesis_ctx(
+        [
+            '[{"title": "Bug in a", "path": "a.py", "line": 5}]',  # batch_1
+            "[]",  # batch_2
+            "no json from the synthesis call",  # synthesis main call
+            "still no json",  # synthesis reformat retry
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == [{"title": "Bug in a", "path": "a.py", "line": 5}]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_synthesis_dedupes_against_per_file_findings(monkeypatch):
+    """Synthesis near-duplicates of per-file findings are dropped before aggregation;
+    only genuinely new cross-file findings are added."""
+    ctx, fake_adapter = _synthesis_ctx(
+        [
+            '[{"title": "Bug in a", "path": "a.py", "line": 5}]',  # batch_1
+            "[]",  # batch_2
+            (
+                '[{"title": "Bug in a", "path": "a.py", "line": 7},'
+                ' {"title": "Contract mismatch", "path": "b.py", "line": 2}]'
+            ),  # synthesis: near-dup (same path, line within 5, same title) + new
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == [
+        {"title": "Bug in a", "path": "a.py", "line": 5},
+        {"title": "Contract mismatch", "path": "b.py", "line": 2},
+    ]

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -6,7 +6,7 @@ from titan_cli.engine import WorkflowContext
 from titan_cli.engine.results import Error, Exit, Skip, Success
 from titan_cli.external_cli.adapters import HeadlessResponse
 from titan_cli.external_cli.adapters.base import SupportedCLI
-from titan_plugin_github.models.review_enums import FileReadMode, FindingSeverity, PRSizeClass, ReviewStrategyType
+from titan_plugin_github.models.review_enums import FileReadMode, FileReviewPriority, FindingSeverity, PRSizeClass, ReviewStrategyType
 from titan_plugin_github.models.review_models import (
     ChangeManifest,
     FileContextEntry,
@@ -15,6 +15,7 @@ from titan_plugin_github.models.review_models import (
     PullRequestManifest,
     ReferencedCommitContext,
     ReviewStrategy,
+    ScoredReviewCandidate,
     ThreadReviewCandidate,
     ThreadReviewContext,
 )
@@ -1557,9 +1558,6 @@ def test_ai_review_findings_worker_crash_marks_batch_failed_not_step_crash(monke
 # ============================================================================
 # ai_review_findings empty-findings rescue (review-quality-007)
 # ============================================================================
-
-from titan_plugin_github.models.review_enums import FileReviewPriority
-from titan_plugin_github.models.review_models import ScoredReviewCandidate
 
 
 def _rescue_ctx(adapter_stdouts: list[str]) -> tuple[WorkflowContext, "_FakeSequentialAdapter"]:

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -1826,3 +1826,272 @@ def test_ai_review_findings_synthesis_dedupes_against_per_file_findings(monkeypa
         {"title": "Bug in a", "path": "a.py", "line": 5},
         {"title": "Contract mismatch", "path": "b.py", "line": 2},
     ]
+
+
+# ============================================================================
+# Fixes from the 2026-08-03 validation-run findings
+# ============================================================================
+
+
+def test_verify_findings_mixed_nit_and_non_nit_index_remapping(monkeypatch):
+    """Verdict indices address the FILTERED (non-nit) list. With nits mixed in, a
+    refutation of filtered-index 0 must drop the right non-nit finding while every
+    nit rides through untouched."""
+    nit_first = _make_finding_model("Style nit", severity=FindingSeverity.NIT)
+    false_positive = _make_finding_model("False positive")
+    real_bug = _make_finding_model("Real bug")
+    nit_last = _make_finding_model("Another nit", severity=FindingSeverity.NIT)
+    stdout = (
+        '{"verdicts": [{"index": 0, "verdict": "refuted", "reasoning": "check exists"},'
+        ' {"index": 1, "verdict": "confirmed", "reasoning": "holds"}]}'
+    )
+    fake_adapter = _FakeStructuredOutputAdapter(stdout)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([nit_first, false_positive, real_bug, nit_last])
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Success)
+    # Index 0 of the filtered list is "False positive", NOT the leading nit.
+    assert ctx.data["refuted_findings"] == [false_positive]
+    assert set(f.title for f in ctx.data["deduped_findings"]) == {
+        "Style nit",
+        "Real bug",
+        "Another nit",
+    }
+    # Only the 2 non-nit findings were sent to the verifier.
+    prompt = fake_adapter.calls[0]["prompt"]
+    assert "Style nit" not in prompt
+    assert "False positive" in prompt
+
+
+def test_verify_findings_refutation_ignored_when_path_has_no_code(monkeypatch):
+    """A refutation for a finding whose path has no hunks in any batch is ignored:
+    the model never saw that code, so its contradiction is worthless."""
+    orphan = _make_finding_model("Orphan finding", path="not_in_batches.py")
+    stdout = '{"verdicts": [{"index": 0, "verdict": "refuted", "reasoning": "no such code"}]}'
+    fake_adapter = _FakeStructuredOutputAdapter(stdout)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _verify_ctx([orphan])
+    result = verify_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["deduped_findings"] == [orphan]
+    assert ctx.data["refuted_findings"] == []
+
+
+def _three_file_diff() -> str:
+    def _file_diff(path: str) -> str:
+        return (
+            f"diff --git a/{path} b/{path}\n"
+            "index 111..222 100644\n"
+            f"--- a/{path}\n"
+            f"+++ b/{path}\n"
+            "@@ -1,2 +1,3 @@\n"
+            " context\n"
+            "+added line\n"
+            " context\n"
+        )
+
+    return _file_diff("a.py") + _file_diff("b.py") + _file_diff("c.py")
+
+
+def test_ai_review_findings_synthesis_excludes_failed_batches_paths(monkeypatch):
+    """A failed batch's files were NOT reviewed — the synthesis prompt must not
+    include them under instructions claiming their single-file issues were already
+    covered (that would suppress findings nobody ever looked for)."""
+    ctx, fake_adapter = _synthesis_ctx(
+        [
+            "[]",  # batch_1 (a.py) ok
+            "[]",  # batch_2 (b.py) ok
+            "no json from batch_3",  # batch_3 (c.py) main call
+            "still no json",  # batch_3 reformat retry -> failed
+            "[]",  # synthesis over a.py + b.py only
+        ],
+        batch_files=[{"a.py": 100}, {"b.py": 100}, {"c.py": 100}],
+        diff=_three_file_diff(),
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 5
+    synthesis_prompt = fake_adapter.calls[4]["prompt"]
+    assert "### a.py" in synthesis_prompt
+    assert "### b.py" in synthesis_prompt
+    assert "c.py" not in synthesis_prompt
+
+
+def test_ai_review_findings_no_synthesis_when_only_one_batch_succeeded(monkeypatch):
+    """With 2 focus files but only 1 reviewed (other batch failed), synthesis is
+    skipped: there is nothing cross-file among a single reviewed path."""
+    ctx, fake_adapter = _synthesis_ctx(
+        [
+            "[]",  # batch_1 (a.py) ok
+            "no json",  # batch_2 (b.py) main call
+            "still no json",  # batch_2 reformat retry -> failed
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    # 3 calls: batch_1 + batch_2 + retry. No 4th (synthesis) call.
+    assert len(fake_adapter.calls) == 3
+
+
+# ============================================================================
+# Timeout fallback for worktree_reference batches (+ early worktree release)
+# ============================================================================
+
+
+class _FakeExitCodeAdapter:
+    """Fake adapter scripted with (exit_code, stdout) tuples, one per call."""
+
+    cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = False
+    supports_tool_restriction = False
+    supports_effort_control = False
+
+    def __init__(self, script: list[tuple[int, str]]):
+        self._script = list(script)
+        self.calls: list[dict] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
+        self.calls.append({"prompt": prompt, "effort": effort})
+        exit_code, stdout = self._script[len(self.calls) - 1]
+        return HeadlessResponse(stdout=stdout, stderr="", exit_code=exit_code)
+
+
+def _timeout_ctx(adapter_script: list[tuple[int, str]], *, worktree_reference: bool = True):
+    fake_adapter = _FakeExitCodeAdapter(adapter_script)
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_profile"] = ReviewProfile(findings_batch_concurrency=1)
+    if worktree_reference:
+        ctx.data["review_context_batches"] = [
+            _make_worktree_reference_batch("batch_1", "border.py")
+        ]
+    else:
+        ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"border.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["review_diff"] = (
+        "diff --git a/border.py b/border.py\n"
+        "index 111..222 100644\n"
+        "--- a/border.py\n"
+        "+++ b/border.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " context\n"
+        "+added line\n"
+        " context\n"
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+    return ctx, fake_adapter
+
+
+def test_ai_review_findings_retries_timed_out_worktree_batch_with_hunks(monkeypatch):
+    """A timed-out worktree_reference batch reviewed NOTHING — one bounded retry with
+    inline hunks turns a total loss into guaranteed coverage of the batch's files."""
+    ctx, fake_adapter = _timeout_ctx(
+        [
+            (124, ""),  # batch_1: CLI timeout while exploring the worktree
+            (0, '[{"title": "Found on retry", "path": "border.py"}]'),  # batch_1_retry
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    retry_prompt = fake_adapter.calls[1]["prompt"]
+    assert "added line" in retry_prompt  # inline hunks, no worktree exploration
+    assert "Read from worktree" not in retry_prompt
+    assert ctx.data["raw_findings"] == [{"title": "Found on retry", "path": "border.py"}]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_no_timeout_retry_for_inline_batches(monkeypatch):
+    """Timeouts on batches that already had inline hunks don't retry — the fallback
+    only exists for worktree_reference exploration blowups."""
+    ctx, fake_adapter = _timeout_ctx([(124, "")], worktree_reference=False)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Error)  # 0/1 batches produced output (005)
+    assert len(fake_adapter.calls) == 1
+
+
+def test_ai_review_findings_timeout_retry_failure_keeps_batch_failed(monkeypatch):
+    ctx, fake_adapter = _timeout_ctx(
+        [
+            (124, ""),  # batch_1 timeout
+            (1, ""),  # retry also fails
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Error)  # still 0/N succeeded
+    assert len(fake_adapter.calls) == 2
+
+
+def test_release_review_worktree_cleans_and_clears_context(monkeypatch):
+    import titan_plugin_github.operations as gh_operations
+
+    removed = []
+    monkeypatch.setattr(
+        gh_operations, "cleanup_worktree", lambda git, path: removed.append(path) or True
+    )
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.git = Mock()
+    ctx.data["worktree_created"] = True
+    ctx.data["worktree_path"] = "/tmp/wt/titan-review-9"
+
+    code_review_steps._release_review_worktree(ctx)
+
+    assert removed == ["/tmp/wt/titan-review-9"]
+    assert ctx.data["worktree_created"] is False
+    assert ctx.data["worktree_path"] is None
+
+
+def test_validate_review_actions_releases_worktree_even_with_no_actions(monkeypatch):
+    """The early-release must also cover the no-actions path: the user can still quit
+    at the submit prompt afterwards, and the worktree must not depend on reaching the
+    final cleanup step."""
+    import titan_plugin_github.operations as gh_operations
+
+    removed = []
+    monkeypatch.setattr(
+        gh_operations, "cleanup_worktree", lambda git, path: removed.append(path) or True
+    )
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.git = Mock()
+    ctx.data["review_action_proposals"] = []
+    ctx.data["worktree_created"] = True
+    ctx.data["worktree_path"] = "/tmp/wt/titan-review-9"
+
+    result = code_review_steps.validate_review_actions(ctx)
+
+    assert isinstance(result, Skip)
+    assert removed == ["/tmp/wt/titan-review-9"]

--- a/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
+++ b/plugins/titan-plugin-github/tests/unit/test_code_review_steps.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import Mock
 
 from titan_cli.core.result import ClientError, ClientSuccess
@@ -683,6 +684,8 @@ def test_ai_review_findings_partial_batch_failure_still_succeeds_with_flag(monke
     """One batch fails parse (main + retry), the other returns findings: the step
     succeeds but ai_findings_failed must be True so the outcome isn't presented
     as a fully clean review."""
+    from titan_plugin_github.models.review_profile_models import ReviewProfile
+
     fake_adapter = _FakeSequentialAdapter(
         [
             "Reported one finding: fix the null check.",  # batch_1 main call (prose)
@@ -694,6 +697,8 @@ def test_ai_review_findings_partial_batch_failure_still_succeeds_with_flag(monke
 
     ctx = WorkflowContext(secrets=Mock())
     ctx.textual = _FakeTextual()
+    # The canned-stdout sequence assumes batch order — pin the pool to 1.
+    ctx.data["review_profile"] = ReviewProfile(findings_batch_concurrency=1)
     ctx.data["review_context_batches"] = [
         _make_findings_batch("batch_1", {"a.py": 100}),
         _make_findings_batch("batch_2", {"b.py": 100}),
@@ -1418,3 +1423,246 @@ def test_verify_findings_fails_open_when_prompt_over_budget(monkeypatch):
     assert isinstance(result, Skip)
     assert fake_adapter.calls == []
     assert ctx.data["deduped_findings"] == [finding]
+
+
+# ============================================================================
+# ai_review_findings concurrency (review-quality-006)
+# ============================================================================
+
+
+class _FakeConcurrencyTrackingAdapter:
+    """Fake adapter that records how many executes overlap in flight."""
+
+    cli_name = SupportedCLI.CLAUDE
+    supports_structured_output = False
+    supports_tool_restriction = False
+    supports_effort_control = False
+
+    def __init__(self, stdout: str = "[]", block_until: int | None = None):
+        self._stdout = stdout
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+        self.calls = 0
+        # When set, every call waits until `block_until` calls are in flight —
+        # proves genuine overlap (deadlocks under a sequential executor).
+        self._barrier = threading.Barrier(block_until, timeout=10) if block_until else None
+
+    def is_available(self) -> bool:
+        return True
+
+    def execute(self, prompt: str, cwd=None, timeout=None, json_schema=None, disallowed_tools=None, effort=None) -> HeadlessResponse:
+        with self._lock:
+            self.calls += 1
+            self._in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        try:
+            if self._barrier:
+                self._barrier.wait()
+            return HeadlessResponse(stdout=self._stdout, stderr="", exit_code=0)
+        finally:
+            with self._lock:
+                self._in_flight -= 1
+
+
+def _concurrency_ctx(batch_count: int, concurrency: int) -> WorkflowContext:
+    from titan_plugin_github.models.review_profile_models import ReviewProfile
+
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_profile"] = ReviewProfile(findings_batch_concurrency=concurrency)
+    ctx.data["review_context_batches"] = [
+        _make_findings_batch(f"batch_{i}", {f"f{i}.py": 100}) for i in range(batch_count)
+    ]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+    return ctx
+
+
+def test_ai_review_findings_runs_batches_concurrently(monkeypatch):
+    """review-quality-006: with findings_batch_concurrency=2, two batches must be
+    in flight at the same time (the barrier only releases when both arrive — this
+    test deadlocks/times out under a sequential executor)."""
+    fake_adapter = _FakeConcurrencyTrackingAdapter(stdout='[{"title": "Bug"}]', block_until=2)
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _concurrency_ctx(batch_count=2, concurrency=2)
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.max_in_flight == 2
+    assert ctx.data["raw_findings"] == [{"title": "Bug"}, {"title": "Bug"}]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_concurrency_one_stays_sequential(monkeypatch):
+    fake_adapter = _FakeConcurrencyTrackingAdapter(stdout="[]")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _concurrency_ctx(batch_count=3, concurrency=1)
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.calls == 3
+    assert fake_adapter.max_in_flight == 1
+
+
+def test_ai_review_findings_pool_never_exceeds_configured_concurrency(monkeypatch):
+    fake_adapter = _FakeConcurrencyTrackingAdapter(stdout="[]")
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    ctx = _concurrency_ctx(batch_count=6, concurrency=2)
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert fake_adapter.calls == 6
+    assert fake_adapter.max_in_flight <= 2
+
+
+def test_ai_review_findings_worker_crash_marks_batch_failed_not_step_crash(monkeypatch):
+    """An adapter exception inside a worker must degrade to a failed batch (visible),
+    not crash the whole step."""
+
+    class _ExplodingAdapter:
+        cli_name = SupportedCLI.CLAUDE
+        supports_structured_output = False
+        supports_tool_restriction = False
+        supports_effort_control = False
+
+        def is_available(self) -> bool:
+            return True
+
+        def execute(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: _ExplodingAdapter())
+
+    ctx = _concurrency_ctx(batch_count=1, concurrency=2)
+    result = ai_review_findings(ctx)
+
+    # Single batch crashed → 0/1 produced output → visible Error (review-quality-005).
+    assert isinstance(result, Error)
+    assert ctx.data["raw_findings"] == []
+    assert ctx.data["ai_findings_failed"] is True
+
+
+# ============================================================================
+# ai_review_findings empty-findings rescue (review-quality-007)
+# ============================================================================
+
+from titan_plugin_github.models.review_enums import FileReviewPriority
+from titan_plugin_github.models.review_models import ScoredReviewCandidate
+
+
+def _rescue_ctx(adapter_stdouts: list[str]) -> tuple[WorkflowContext, "_FakeSequentialAdapter"]:
+    fake_adapter = _FakeSequentialAdapter(adapter_stdouts)
+    ctx = WorkflowContext(secrets=Mock())
+    ctx.textual = _FakeTextual()
+    ctx.data["review_profile"] = ReviewProfile(findings_batch_concurrency=1)
+    ctx.data["review_context_batches"] = [_make_findings_batch("batch_1", {"a.py": 100})]
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+        suspicious_empty_findings=True,
+    )
+    ctx.data["review_candidates"] = [
+        ScoredReviewCandidate(
+            path="border.py",
+            score=3,
+            priority=FileReviewPriority.LOW,
+            suggested_read_mode=FileReadMode.HUNKS_ONLY,
+        )
+    ]
+    ctx.data["review_diff"] = (
+        "diff --git a/border.py b/border.py\n"
+        "index 111..222 100644\n"
+        "--- a/border.py\n"
+        "+++ b/border.py\n"
+        "@@ -1,2 +1,3 @@\n"
+        " context\n"
+        "+added line\n"
+        " context\n"
+    )
+    ctx.data["cli_preference"] = "auto"
+    ctx.data["project_root"] = "/tmp/project"
+    return ctx, fake_adapter
+
+
+def test_ai_review_findings_runs_rescue_batch_on_suspicious_empty(monkeypatch):
+    """review-quality-007: zero findings + suspicious_empty_findings must trigger ONE
+    extra rescue batch over borderline unreviewed files — not just a dim line."""
+    ctx, fake_adapter = _rescue_ctx(
+        [
+            "[]",  # batch_1: clean review, no findings
+            '[{"title": "Rescued bug", "path": "border.py"}]',  # rescue batch
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 2
+    assert "border.py" in fake_adapter.calls[1]["prompt"]
+    assert ctx.data["raw_findings"] == [{"title": "Rescued bug", "path": "border.py"}]
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_rescue_failure_does_not_fail_the_review(monkeypatch):
+    """The rescue pass is best-effort: if it fails, the review stays a clean Success
+    (the main batches DID complete with zero findings)."""
+    ctx, fake_adapter = _rescue_ctx(
+        [
+            "[]",  # batch_1: clean
+            "no json from the rescue call",  # rescue main call
+            "still no json",  # rescue reformat retry
+        ]
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert ctx.data["raw_findings"] == []
+    assert ctx.data["ai_findings_failed"] is False
+
+
+def test_ai_review_findings_no_rescue_when_findings_exist(monkeypatch):
+    ctx, fake_adapter = _rescue_ctx(['[{"title": "Bug"}]'])
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 1
+
+
+def test_ai_review_findings_no_rescue_when_not_suspicious(monkeypatch):
+    ctx, fake_adapter = _rescue_ctx(["[]"])
+    ctx.data["review_strategy"] = ReviewStrategy(
+        strategy=ReviewStrategyType.BATCHED_FINDINGS,
+        size_class=PRSizeClass.SMALL,
+        max_focus_files=10,
+        max_prompt_chars=20000,
+        max_comment_entries=5,
+        batching_enabled=True,
+        suspicious_empty_findings=False,
+    )
+    monkeypatch.setattr(code_review_steps, "_resolve_headless_adapter", lambda _pref: fake_adapter)
+
+    result = ai_review_findings(ctx)
+
+    assert isinstance(result, Success)
+    assert len(fake_adapter.calls) == 1

--- a/plugins/titan-plugin-github/tests/unit/test_comment_utils.py
+++ b/plugins/titan-plugin-github/tests/unit/test_comment_utils.py
@@ -82,3 +82,49 @@ def test_html_only_decoration_yields_no_elements():
     """A body with nothing but markup (e.g. a bare image badge) renders nothing
     instead of raw tags."""
     assert parse_comment_body(body='<img src="badge.svg">') == []
+
+
+# ============================================================================
+# Regressions caught by Titan's own review of the 014 fix (2026-08-04)
+# ============================================================================
+
+
+def test_prose_comparisons_are_not_mistaken_for_html():
+    """`< a` / `y >` in a human comment used to trigger the HTML path, and the
+    tag-stripping regex then deleted everything between them — silent content loss in
+    an ordinary review comment."""
+    body = "Check that `x < a` and `y > b` before calling this."
+
+    elements = parse_comment_body(body=body)
+
+    assert len(elements) == 1
+    assert elements[0].content == body
+
+
+def test_fenced_code_blocks_keep_generics_verbatim():
+    """Flattening used to run on the WHOLE body before fenced blocks were split, so
+    `List<String>` inside a code block lost its type argument."""
+    body = "Use this instead:\n\n```kotlin\nval names: List<String> = emptyList()\nif (a < p) return\n```"
+
+    elements = parse_comment_body(body=body)
+
+    assert isinstance(elements[1], CodeBlockElement)
+    assert elements[1].code == "val names: List<String> = emptyList()\nif (a < p) return"
+
+
+def test_suggestion_block_is_never_flattened():
+    """A mangled ```suggestion is worse than a blank one: it gets applied to the code."""
+    body = "Fix:\n\n```suggestion\nval x: Map<String, Int> = mapOf()\n```"
+
+    elements = parse_comment_body(body=body)
+
+    suggestion = elements[1]
+    assert suggestion.code == "val x: Map<String, Int> = mapOf()"
+
+
+def test_prose_mixed_with_real_html_still_flattens_the_html():
+    body = "See the table:<br><table><tr><td>:warning:</td><td>be careful</td></tr></table>"
+
+    elements = parse_comment_body(body=body)
+
+    assert elements[0].content == "See the table:\n⚠️ be careful"

--- a/plugins/titan-plugin-github/tests/unit/test_comment_utils.py
+++ b/plugins/titan-plugin-github/tests/unit/test_comment_utils.py
@@ -1,0 +1,84 @@
+"""Tests for comment body parsing/rendering helpers.
+
+Focus: HTML bot bodies. Textual's Markdown widget has no `html_block`/`html_inline`
+handling, so an HTML-only body (how linter/CI bots format their findings) used to
+render as an EMPTY comment — the thread was visible but its message was not.
+"""
+
+from titan_plugin_github.widgets.comment_utils import (
+    CodeBlockElement,
+    TextElement,
+    html_body_to_text,
+    parse_comment_body,
+)
+
+# Real body from masmovil/ragnarok-android PR #3601 (github-actions lint thread).
+BOT_TABLE_BODY = """<table data-meta="generated_by_guuk">
+  <tbody>
+    <tr>
+      <td>:warning:</td>
+      <td width="100%" data-sticky="false"><span data-href="https://github.com/masmovil/ragnarok-android/blob/49cdfb9/app/src/main/kotlin/com/ragnarok/apps/ui/components/webcontent/WebContent.kt#L280"></span><code>onTouch</code> lambda should call <code>View#performClick</code> when a click is detected</td>
+    </tr>
+  </tbody>
+</table>"""
+
+
+def test_bot_table_body_renders_readable_text():
+    elements = parse_comment_body(body=BOT_TABLE_BODY)
+
+    assert len(elements) == 1
+    assert isinstance(elements[0], TextElement)
+    # The severity marker joins the message it qualifies, code spans become backticks,
+    # and no HTML survives.
+    assert elements[0].content == (
+        "⚠️ `onTouch` lambda should call `View#performClick` when a click is detected"
+    )
+    assert "<" not in elements[0].content
+
+
+def test_html_comment_wrapper_is_stripped_but_content_kept():
+    """Danger-style bodies start with an HTML comment holding a summary, then HTML."""
+    body = (
+        "<!--\n  3 Errors: Unit tests failed\n-->\n"
+        "<table><tr><td>:no_entry_sign:</td><td>Unit tests failed for flavor Guuk</td></tr></table>"
+    )
+
+    text = html_body_to_text(body)
+
+    assert "🚫 Unit tests failed for flavor Guuk" in text
+    assert "<!--" not in text
+    assert "3 Errors" not in text  # the hidden summary stays hidden
+
+
+def test_html_entities_and_line_breaks():
+    body = "<div>a &amp; b<br>second line &lt;tag&gt;</div>"
+
+    text = html_body_to_text(body)
+
+    assert text == "a & b\nsecond line <tag>"
+
+
+def test_plain_markdown_body_is_untouched():
+    body = "This is **bold** and `code`.\n\n```kotlin\nval x = 1\n```"
+
+    elements = parse_comment_body(body=body)
+
+    assert isinstance(elements[0], TextElement)
+    assert elements[0].content == "This is **bold** and `code`."
+    assert isinstance(elements[1], CodeBlockElement)
+    assert elements[1].code.strip() == "val x = 1"
+
+
+def test_inline_html_in_otherwise_markdown_body_keeps_the_prose():
+    """A human comment with a stray <img>/<br> must not lose its text."""
+    body = "Please fix this.<br>See <a href='http://x'>the docs</a>."
+
+    elements = parse_comment_body(body=body)
+
+    assert elements[0].content == "Please fix this.\nSee the docs."
+
+
+def test_html_only_decoration_yields_no_elements():
+    """A body with nothing but markup (e.g. a bare image badge) renders nothing
+    instead of raw tags."""
+    assert parse_comment_body(body='<img src="badge.svg">') == []

--- a/plugins/titan-plugin-github/titan_plugin_github/models/review_profile_models.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/review_profile_models.py
@@ -37,6 +37,12 @@ class ReviewProfile(BaseModel):
     candidate_scoring: list[CandidateScoringRule] = Field(default_factory=list)
     candidate_exclusions: CandidateExclusions = Field(default_factory=CandidateExclusions)
     review_axes: dict[ChecklistCategory, ReviewAxisRule] = Field(default_factory=dict)
+    findings_verification_enabled: bool = Field(
+        default=True,
+        description="Run the batched refute-or-confirm AI pass over findings before the "
+        "human gate. Disable in cost-sensitive projects: it adds one extra AI call per "
+        "review when findings exist.",
+    )
 
 
 class ReviewChecklistFile(BaseModel):

--- a/plugins/titan-plugin-github/titan_plugin_github/models/review_profile_models.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/review_profile_models.py
@@ -51,6 +51,13 @@ class ReviewProfile(BaseModel):
         "cost — only wall time. Keep low: each worker is a full CLI session and "
         "provider-side rate limits apply.",
     )
+    findings_synthesis_enabled: bool = Field(
+        default=False,
+        description="Run one extra cross-file synthesis batch (all changed hunks "
+        "together, hunks_only) when the PR touches more than one focus file. It "
+        "re-sends every hunk already reviewed per-file, so it adds one full AI call "
+        "per review; off by default until real cost data justifies it.",
+    )
 
 
 class ReviewChecklistFile(BaseModel):

--- a/plugins/titan-plugin-github/titan_plugin_github/models/review_profile_models.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/models/review_profile_models.py
@@ -43,6 +43,14 @@ class ReviewProfile(BaseModel):
         "human gate. Disable in cost-sensitive projects: it adds one extra AI call per "
         "review when findings exist.",
     )
+    findings_batch_concurrency: int = Field(
+        default=2,
+        ge=1,
+        le=4,
+        description="How many findings batches run against the CLI at once. Zero token "
+        "cost — only wall time. Keep low: each worker is a full CLI session and "
+        "provider-side rate limits apply.",
+    )
 
 
 class ReviewChecklistFile(BaseModel):

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -10,8 +10,16 @@ from .ai_response_parsing_operations import extract_json_payload
 from .prompt_formatting_operations import comment_context_to_json, extract_pr_intent_line
 
 
-def build_findings_prompt_parts(batch: FocusContextBatch) -> dict[str, str]:
-    """Build prompt parts separately so callers can log size breakdowns."""
+def build_findings_prompt_parts(
+    batch: FocusContextBatch, *, instructions_override: str | None = None
+) -> dict[str, str]:
+    """Build prompt parts separately so callers can log size breakdowns.
+
+    `instructions_override` replaces the default instructions block while keeping the
+    rest of the prompt skeleton (PR context, existing comments, axes, code, schema)
+    identical — used by the cross-file synthesis batch, whose review target is
+    different from a normal per-file batch.
+    """
     checklist_json = _checklist_to_json(batch.checklist_applicable)
     comments_json = comment_context_to_json(batch.comment_context)
     files_text = _files_context_to_text(batch.files_context)
@@ -19,7 +27,7 @@ def build_findings_prompt_parts(batch: FocusContextBatch) -> dict[str, str]:
     pr_context = _pr_context_to_text(batch)
     schema = _finding_schema()
 
-    instructions = """- Only report actionable issues: correctness, error handling, security, validation, API, concurrency, meaningful semantic correctness, state consistency, or missing regression coverage when clearly required
+    instructions = instructions_override or """- Only report actionable issues: correctness, error handling, security, validation, API, concurrency, meaningful semantic correctness, state consistency, or missing regression coverage when clearly required
 - Also report changes that preserve execution but alter the observable meaning of data, events, labels, classifications, or results
 - Also report changes that degrade fidelity of recorded, serialized, converted, or displayed data even if the code still runs
 - Also report changes that remove an important previous guarantee such as success/failure signaling, fallback behavior, or state consistency
@@ -355,6 +363,125 @@ def build_empty_findings_rescue_batch(
         checklist_applicable=checklist[:4],
         pr_manifest=pr_manifest,
     )
+
+
+SYNTHESIS_BATCH_ID = "synthesis_1"
+
+FINDINGS_SYNTHESIS_EFFORT = "medium"
+"""The synthesis prompt is the largest findings prompt shape (every hunk of the PR at
+once); cap reasoning at medium like worktree_reference batches — big context, bounded
+reasoning."""
+
+SYNTHESIS_INSTRUCTIONS = """- This batch shows ALL changed hunks of this PR together. Look ONLY for cross-file inconsistencies introduced by this PR
+- Report contract mismatches: a signature, return shape, field, event, or error contract changed in one file while a caller/consumer in another file shown here still uses the old contract
+- Report missed call sites: a rename, parameter change, or behavior change applied in some of these files but not in others shown here
+- Report inconsistent naming or semantics for the same concept across the changed files
+- Do NOT report single-file issues of any kind — those were already reviewed in earlier batches
+- Do not repeat issues already covered by Existing Comments
+- Do not report deleted lines as findings
+- Do not speculate beyond the shown hunks; unchanged call sites outside this diff are out of scope
+- Include a short `snippet` copied from the exact added/context line that should anchor the comment; use null only if no stable inline anchor exists
+- If there are no cross-file inconsistencies, return []"""
+
+
+def build_cross_file_synthesis_batch(
+    focus_paths: list[str],
+    diff: str,
+    pr_manifest,
+    diff_manager=None,
+) -> FocusContextBatch | None:
+    """Build the cross-file synthesis batch: every focus file's hunks together.
+
+    Per-file batches are structurally blind to interactions between the PR's own
+    changes; this batch re-combines all reviewed paths in hunks_only mode (no
+    expansion, no full files) so the model can look for cross-file inconsistencies.
+    ">1 focus file" means >1 distinct path — a single batch holding several files
+    qualifies. Paths without diff hunks (binary, rename-only) are skipped. Returns
+    None when fewer than 2 paths end up with hunks: a synthesis over one file is
+    meaningless. There is deliberately no file cap — the caller's budget check is
+    the cap (over budget -> skip, no split/degrade).
+
+    `checklist_applicable` stays empty: the synthesis instructions are the single
+    review axis, and this batch already re-sends every hunk (D-002 token mandate).
+    """
+    from ..models.review_enums import FileReadMode
+    from ..models.review_models import FileContextEntry
+    from .context_resolution_operations import extract_hunks_only
+
+    files_context: dict[str, FileContextEntry] = {}
+    for path in focus_paths:
+        hunks = extract_hunks_only(diff, path, diff_manager=diff_manager)
+        if not hunks:
+            continue
+        files_context[path] = FileContextEntry(
+            path=path,
+            read_mode=FileReadMode.HUNKS_ONLY,
+            hunks=hunks,
+            approximate_chars=sum(len(hunk) for hunk in hunks),
+        )
+
+    if len(files_context) < 2:
+        return None
+
+    return FocusContextBatch(
+        batch_id=SYNTHESIS_BATCH_ID,
+        files_context=files_context,
+        checklist_applicable=[],
+        pr_manifest=pr_manifest,
+    )
+
+
+def dedupe_synthesis_findings(
+    synthesis_raw: list,
+    existing_raw: list,
+    *,
+    line_window: int = 5,
+    title_similarity_threshold: float = 0.75,
+) -> list:
+    """Drop synthesis findings that duplicate a per-file batch finding.
+
+    Works on raw (pre-normalization) dicts because it runs inside the findings step,
+    before Finding models exist. A synthesis finding is a duplicate when an existing
+    raw finding has the same path AND a line within the window (both-None counts as
+    close, one-None does not) AND a similar title (exact lowercase match or
+    SequenceMatcher ratio above the threshold). Thresholds mirror
+    `validators.is_duplicate`, which cannot be reused directly — it compares a Finding
+    against an existing-comment index entry, not two findings. Non-dict items in
+    either list are tolerated: raw AI output is untrusted.
+    """
+    from difflib import SequenceMatcher
+
+    def _lines_close(line_a, line_b) -> bool:
+        if line_a is None and line_b is None:
+            return True
+        if line_a is None or line_b is None:
+            return False
+        try:
+            return abs(int(line_a) - int(line_b)) <= line_window
+        except (TypeError, ValueError):
+            return False
+
+    def _titles_similar(title_a: str, title_b: str) -> bool:
+        if title_a == title_b:
+            return True
+        return SequenceMatcher(None, title_a, title_b).ratio() > title_similarity_threshold
+
+    existing = [item for item in existing_raw if isinstance(item, dict)]
+    unique: list = []
+    for candidate in synthesis_raw:
+        if not isinstance(candidate, dict):
+            unique.append(candidate)
+            continue
+        candidate_title = str(candidate.get("title", "")).lower()
+        is_duplicate = any(
+            candidate.get("path") == item.get("path")
+            and _lines_close(candidate.get("line"), item.get("line"))
+            and _titles_similar(candidate_title, str(item.get("title", "")).lower())
+            for item in existing
+        )
+        if not is_duplicate:
+            unique.append(candidate)
+    return unique
 
 
 def summarize_findings_prompt_parts(parts: dict[str, str]) -> dict[str, Any]:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -431,6 +431,50 @@ def build_cross_file_synthesis_batch(
     )
 
 
+TIMEOUT_FALLBACK_BATCH_SUFFIX = "_retry"
+
+
+def build_timeout_fallback_batch(
+    batch,
+    diff: str,
+    diff_manager=None,
+):
+    """Rebuild a timed-out worktree_reference batch in bounded hunks_only mode.
+
+    A worktree_reference batch sends a small prompt and lets the CLI explore the
+    file in the worktree — on very large files that exploration can eat the whole
+    timeout and the file ends up with ZERO review. The fallback trades depth for a
+    guaranteed bounded review: same files, inline diff hunks only, no exploration.
+    Returns None when no path has diff hunks (nothing bounded to retry with).
+    """
+    from ..models.review_enums import FileReadMode
+    from ..models.review_models import FileContextEntry, FocusContextBatch
+    from .context_resolution_operations import extract_hunks_only
+
+    files_context: dict[str, FileContextEntry] = {}
+    for path in batch.files_context:
+        hunks = extract_hunks_only(diff, path, diff_manager=diff_manager)
+        if not hunks:
+            continue
+        files_context[path] = FileContextEntry(
+            path=path,
+            read_mode=FileReadMode.HUNKS_ONLY,
+            hunks=hunks,
+            approximate_chars=sum(len(hunk) for hunk in hunks),
+        )
+
+    if not files_context:
+        return None
+
+    return FocusContextBatch(
+        batch_id=f"{batch.batch_id}{TIMEOUT_FALLBACK_BATCH_SUFFIX}",
+        files_context=files_context,
+        checklist_applicable=batch.checklist_applicable,
+        comment_context=batch.comment_context,
+        pr_manifest=batch.pr_manifest,
+    )
+
+
 def dedupe_synthesis_findings(
     synthesis_raw: list,
     existing_raw: list,
@@ -470,7 +514,8 @@ def dedupe_synthesis_findings(
     unique: list = []
     for candidate in synthesis_raw:
         if not isinstance(candidate, dict):
-            unique.append(candidate)
+            # Garbage items would be dropped by normalize anyway, but keeping them
+            # here would inflate the "unique findings" count shown/logged.
             continue
         candidate_title = str(candidate.get("title", "")).lower()
         is_duplicate = any(

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -327,6 +327,7 @@ def build_empty_findings_rescue_batch(
     checklist: list[ReviewChecklistItem],
     pr_manifest,
     diff_manager=None,
+    comment_context=None,
 ) -> FocusContextBatch | None:
     """Build one extra findings batch from borderline candidate files.
 
@@ -334,6 +335,10 @@ def build_empty_findings_rescue_batch(
     suspicious-if-empty: instead of just noting that borderline files went unreviewed,
     review up to RESCUE_MAX_FILES of them in hunks_only mode. Returns None when none
     of the paths have diff hunks.
+
+    `comment_context` carries over from the main batches: the prompt tells the model
+    not to duplicate existing comments, so leaving it empty spends the call on
+    findings that dedupe throws away downstream.
     """
     from ..models.review_enums import FileReadMode
     from ..models.review_models import FileContextEntry
@@ -362,6 +367,7 @@ def build_empty_findings_rescue_batch(
         batch_id=RESCUE_BATCH_ID,
         files_context=files_context,
         checklist_applicable=checklist[:4],
+        comment_context=comment_context or [],
         pr_manifest=pr_manifest,
     )
 
@@ -466,6 +472,7 @@ def build_cross_file_synthesis_batch(
     diff: str,
     pr_manifest,
     diff_manager=None,
+    comment_context=None,
 ) -> FocusContextBatch | None:
     """Build the cross-file synthesis batch: every focus file's hunks together.
 
@@ -479,7 +486,9 @@ def build_cross_file_synthesis_batch(
     the cap (over budget -> skip, no split/degrade).
 
     `checklist_applicable` stays empty: the synthesis instructions are the single
-    review axis, and this batch already re-sends every hunk (D-002 token mandate).
+    review axis, and this batch already re-sends every hunk. `comment_context` does
+    carry over — the synthesis instructions say not to repeat issues already covered
+    by existing comments, which needs those comments in the prompt.
     """
     from ..models.review_enums import FileReadMode
     from ..models.review_models import FileContextEntry
@@ -507,6 +516,7 @@ def build_cross_file_synthesis_batch(
         batch_id=SYNTHESIS_BATCH_ID,
         files_context=files_context,
         checklist_applicable=[],
+        comment_context=comment_context or [],
         pr_manifest=pr_manifest,
     )
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -570,11 +570,12 @@ def dedupe_synthesis_findings(
     Works on raw (pre-normalization) dicts because it runs inside the findings step,
     before Finding models exist. A synthesis finding is a duplicate when an existing
     raw finding has the same path AND a line within the window (both-None counts as
-    close, one-None does not) AND a similar title (exact lowercase match or
-    SequenceMatcher ratio above the threshold). Thresholds mirror
-    `validators.is_duplicate`, which cannot be reused directly — it compares a Finding
-    against an existing-comment index entry, not two findings. Non-dict items in
-    either list are tolerated: raw AI output is untrusted.
+    close, one-None does not) AND either the same category or a similar title (exact
+    lowercase match or SequenceMatcher ratio above the threshold). Path/line/title
+    thresholds match `validators.is_duplicate`, which cannot be reused directly — it
+    compares a Finding against an existing-comment index entry, not two findings, and
+    its resolved/adjudicated branches have no meaning between two fresh findings.
+    Non-dict items in either list are tolerated: raw AI output is untrusted.
     """
     from difflib import SequenceMatcher
 
@@ -598,6 +599,12 @@ def dedupe_synthesis_findings(
         if not lines_close:
             return False
         if title_a == title_b:
+            return True
+        category_a = str(candidate.get("category", "")).lower()
+        category_b = str(item.get("category", "")).lower()
+        if category_a and category_a == category_b:
+            # Same defect class at the same spot: a restatement in different words,
+            # which title similarity alone would let through.
             return True
         return SequenceMatcher(None, title_a, title_b).ratio() > title_similarity_threshold
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -574,17 +574,27 @@ def dedupe_synthesis_findings(
     *,
     line_window: int = 5,
     title_similarity_threshold: float = 0.75,
+    same_category_similarity_threshold: float = 0.5,
 ) -> list:
     """Drop synthesis findings that duplicate a per-file batch finding.
 
     Works on raw (pre-normalization) dicts because it runs inside the findings step,
     before Finding models exist. A synthesis finding is a duplicate when an existing
     raw finding has the same path AND a line within the window (both-None counts as
-    close, one-None does not) AND either the same category or a similar title (exact
-    lowercase match or SequenceMatcher ratio above the threshold). Path/line/title
-    thresholds match `validators.is_duplicate`, which cannot be reused directly — it
-    compares a Finding against an existing-comment index entry, not two findings, and
-    its resolved/adjudicated branches have no meaning between two fresh findings.
+    close, one-None does not) AND the titles match: exactly, or above
+    `title_similarity_threshold`, or above the lower
+    `same_category_similarity_threshold` when both findings share a category.
+
+    Sharing a category is a hint, never proof on its own: cross-file findings land on
+    the call site, so they routinely sit within the window of a per-file finding in
+    the same category while describing a completely different defect — exactly what
+    the synthesis pass exists to surface. `validators.is_duplicate` does treat
+    same-category as decisive, but it compares against an ALREADY PUBLISHED comment
+    (and only an unresolved one); between two fresh findings of the same run that
+    would silently drop real cross-file findings. That validator can't be reused here
+    anyway: it takes a Finding plus an existing-comment index entry, and its
+    resolved/adjudicated branches are meaningless between two fresh findings.
+
     Non-dict items in either list are tolerated: raw AI output is untrusted.
     """
     from difflib import SequenceMatcher
@@ -610,13 +620,15 @@ def dedupe_synthesis_findings(
             return False
         if title_a == title_b:
             return True
+        similarity = SequenceMatcher(None, title_a, title_b).ratio()
         category_a = str(candidate.get("category", "")).lower()
         category_b = str(item.get("category", "")).lower()
         if category_a and category_a == category_b:
-            # Same defect class at the same spot: a restatement in different words,
-            # which title similarity alone would let through.
-            return True
-        return SequenceMatcher(None, title_a, title_b).ratio() > title_similarity_threshold
+            # Same defect class at the same spot: accept a looser wording match (a
+            # restatement in different words), but still require the titles to be
+            # talking about the same thing.
+            return similarity > same_category_similarity_threshold
+        return similarity > title_similarity_threshold
 
     existing = [item for item in existing_raw if isinstance(item, dict)]
     unique: list = []

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -1,6 +1,7 @@
 """Operations for building AI prompts for focused findings review."""
 
 import json
+import re
 from typing import Any
 
 from titan_cli.core.result import ClientError, ClientResult, ClientSuccess
@@ -384,6 +385,82 @@ SYNTHESIS_INSTRUCTIONS = """- This batch shows ALL changed hunks of this PR toge
 - If there are no cross-file inconsistencies, return []"""
 
 
+SYNTHESIS_HUNK_CONTEXT_LINES = 3
+"""Context lines kept around each change in synthesis hunks. The review diff is
+fetched with -U20; combining EVERY hunk of the PR at that width blew the synthesis
+prompt to 225k chars on a real 15-file PR (12.5x any budget) — the synthesis looks
+for cross-file contract mismatches, not line-level detail, so minimal context is
+the right trade."""
+
+_HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def trim_hunks_for_synthesis(
+    hunks: list[str], context_lines: int = SYNTHESIS_HUNK_CONTEXT_LINES
+) -> list[str]:
+    """Re-cut wide-context hunks down to `context_lines` around each change.
+
+    Widely separated changes inside one hunk become separate sub-hunks, each with a
+    RECALCULATED `@@` header — line numbering must stay exact because the prompt
+    annotator derives displayed line numbers from the header, and findings carry
+    those numbers back.
+    """
+    trimmed: list[str] = []
+    for hunk in hunks:
+        trimmed.extend(_retrim_hunk(hunk, context_lines))
+    return trimmed
+
+
+def _retrim_hunk(hunk: str, context_lines: int) -> list[str]:
+    lines = hunk.splitlines()
+    header_match = _HUNK_HEADER_RE.match(lines[0]) if lines else None
+    if not header_match:
+        return [hunk]
+
+    old_no = int(header_match.group(1))
+    new_no = int(header_match.group(3))
+    infos: list[tuple[str, int | None, int | None, bool]] = []
+    for line in lines[1:]:
+        if line.startswith("+"):
+            infos.append((line, None, new_no, True))
+            new_no += 1
+        elif line.startswith("-"):
+            infos.append((line, old_no, None, True))
+            old_no += 1
+        else:
+            infos.append((line, old_no, new_no, False))
+            old_no += 1
+            new_no += 1
+
+    changed_indices = [i for i, info in enumerate(infos) if info[3]]
+    if not changed_indices:
+        return [hunk]
+
+    clusters: list[tuple[int, int]] = []
+    start = end = changed_indices[0]
+    for index in changed_indices[1:]:
+        if index - end <= 2 * context_lines + 1:
+            end = index
+        else:
+            clusters.append((start, end))
+            start = end = index
+    clusters.append((start, end))
+
+    sub_hunks: list[str] = []
+    for cluster_start, cluster_end in clusters:
+        lo = max(0, cluster_start - context_lines)
+        hi = min(len(infos) - 1, cluster_end + context_lines)
+        segment = infos[lo : hi + 1]
+        old_lines = [info[1] for info in segment if info[1] is not None]
+        new_lines = [info[2] for info in segment if info[2] is not None]
+        header = (
+            f"@@ -{old_lines[0] if old_lines else 0},{len(old_lines)} "
+            f"+{new_lines[0] if new_lines else 0},{len(new_lines)} @@"
+        )
+        sub_hunks.append("\n".join([header] + [info[0] for info in segment]))
+    return sub_hunks
+
+
 def build_cross_file_synthesis_batch(
     focus_paths: list[str],
     diff: str,
@@ -413,6 +490,9 @@ def build_cross_file_synthesis_batch(
         hunks = extract_hunks_only(diff, path, diff_manager=diff_manager)
         if not hunks:
             continue
+        # The review diff carries -U20 context; at synthesis scale (every hunk of
+        # the PR at once) that context is what blows the budget, not the changes.
+        hunks = trim_hunks_for_synthesis(hunks)
         files_context[path] = FileContextEntry(
             path=path,
             read_mode=FileReadMode.HUNKS_ONLY,
@@ -445,7 +525,9 @@ def build_timeout_fallback_batch(
     file in the worktree — on very large files that exploration can eat the whole
     timeout and the file ends up with ZERO review. The fallback trades depth for a
     guaranteed bounded review: same files, inline diff hunks only, no exploration.
-    Returns None when no path has diff hunks (nothing bounded to retry with).
+    Checklist, comment context, PR manifest and related files carry over from the
+    original batch. Returns None when no path has diff hunks (nothing bounded to
+    retry with).
     """
     from ..models.review_enums import FileReadMode
     from ..models.review_models import FileContextEntry, FocusContextBatch
@@ -471,6 +553,7 @@ def build_timeout_fallback_batch(
         files_context=files_context,
         checklist_applicable=batch.checklist_applicable,
         comment_context=batch.comment_context,
+        related_files=batch.related_files,
         pr_manifest=batch.pr_manifest,
     )
 
@@ -495,17 +578,25 @@ def dedupe_synthesis_findings(
     """
     from difflib import SequenceMatcher
 
-    def _lines_close(line_a, line_b) -> bool:
+    def _is_duplicate_pair(candidate: dict, item: dict) -> bool:
+        if candidate.get("path") != item.get("path"):
+            return False
+        line_a, line_b = candidate.get("line"), item.get("line")
+        title_a = str(candidate.get("title", "")).lower()
+        title_b = str(item.get("title", "")).lower()
         if line_a is None and line_b is None:
-            return True
+            # With no line information at all, proximity says nothing — only an
+            # exact title repeat is safe to drop; similarity alone could kill a
+            # genuinely distinct cross-file finding.
+            return title_a == title_b
         if line_a is None or line_b is None:
             return False
         try:
-            return abs(int(line_a) - int(line_b)) <= line_window
+            lines_close = abs(int(line_a) - int(line_b)) <= line_window
         except (TypeError, ValueError):
             return False
-
-    def _titles_similar(title_a: str, title_b: str) -> bool:
+        if not lines_close:
+            return False
         if title_a == title_b:
             return True
         return SequenceMatcher(None, title_a, title_b).ratio() > title_similarity_threshold
@@ -517,15 +608,11 @@ def dedupe_synthesis_findings(
             # Garbage items would be dropped by normalize anyway, but keeping them
             # here would inflate the "unique findings" count shown/logged.
             continue
-        candidate_title = str(candidate.get("title", "")).lower()
-        is_duplicate = any(
-            candidate.get("path") == item.get("path")
-            and _lines_close(candidate.get("line"), item.get("line"))
-            and _titles_similar(candidate_title, str(item.get("title", "")).lower())
-            for item in existing
-        )
-        if not is_duplicate:
-            unique.append(candidate)
+        # Compare against the per-file findings AND the synthesis items already
+        # accepted — the synthesis list can repeat itself too.
+        if any(_is_duplicate_pair(candidate, item) for item in existing + unique):
+            continue
+        unique.append(candidate)
     return unique
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/findings_operations.py
@@ -308,6 +308,55 @@ def build_default_findings() -> list[Finding]:
     return []
 
 
+RESCUE_BATCH_ID = "rescue_1"
+RESCUE_MAX_FILES = 2
+
+
+def build_empty_findings_rescue_batch(
+    borderline_paths: list[str],
+    diff: str,
+    checklist: list[ReviewChecklistItem],
+    pr_manifest,
+    diff_manager=None,
+) -> FocusContextBatch | None:
+    """Build one extra findings batch from borderline candidate files.
+
+    Used when the main batches return zero findings on a PR the strategy flagged as
+    suspicious-if-empty: instead of just noting that borderline files went unreviewed,
+    review up to RESCUE_MAX_FILES of them in hunks_only mode. Returns None when none
+    of the paths have diff hunks.
+    """
+    from ..models.review_enums import FileReadMode
+    from ..models.review_models import FileContextEntry
+    from .context_resolution_operations import extract_hunks_only
+
+    files_context: dict[str, FileContextEntry] = {}
+    for path in borderline_paths:
+        if len(files_context) >= RESCUE_MAX_FILES:
+            break
+        hunks = extract_hunks_only(diff, path, diff_manager=diff_manager)
+        # A borderline candidate without hunks (binary, rename-only) shouldn't burn
+        # one of the rescue slots.
+        if not hunks:
+            continue
+        files_context[path] = FileContextEntry(
+            path=path,
+            read_mode=FileReadMode.HUNKS_ONLY,
+            hunks=hunks,
+            approximate_chars=sum(len(hunk) for hunk in hunks),
+        )
+
+    if not files_context:
+        return None
+
+    return FocusContextBatch(
+        batch_id=RESCUE_BATCH_ID,
+        files_context=files_context,
+        checklist_applicable=checklist[:4],
+        pr_manifest=pr_manifest,
+    )
+
+
 def summarize_findings_prompt_parts(parts: dict[str, str]) -> dict[str, Any]:
     """Return character counts for each prompt block."""
     return {

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/review_strategy_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/review_strategy_operations.py
@@ -67,7 +67,6 @@ def classify_pr(
         total_lines=total_lines,
         high_signal_files=high_signal_files,
         role_count=role_count,
-        comment_threads=comment_threads,
         is_repetitive_migration=is_repetitive_migration,
         repetition_ratio=repetition_ratio,
     )
@@ -123,10 +122,13 @@ def _compute_complexity_score(
     total_lines: int,
     high_signal_files: int,
     role_count: int,
-    comment_threads: int,
     is_repetitive_migration: bool,
     repetition_ratio: float,
 ) -> int:
+    # The size class measures the CODE, so review activity deliberately plays no part
+    # here: comments don't make a PR bigger, and counting them meant a review's own
+    # published comments could push the same unchanged PR into a bigger size class on
+    # the next run. Review activity is captured separately as `active_review`.
     score = 0
 
     if files_changed <= 3:
@@ -165,11 +167,6 @@ def _compute_complexity_score(
     elif role_count >= 4:
         score += 2
     elif role_count >= 2:
-        score += 1
-
-    if comment_threads >= 20:
-        score += 2
-    elif comment_threads >= 8:
         score += 1
 
     if is_repetitive_migration:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
@@ -1,0 +1,240 @@
+"""Operations for the adversarial verification pass over review findings.
+
+One batched AI call (effort low) that tries to REFUTE each finding against the code it
+targets, before findings reach the human approval gate. Fail-open by design: any error in
+the pass keeps all findings — verification can only remove findings when the AI refutes
+them with evidence.
+"""
+
+import json
+from typing import Any
+
+from pydantic import BaseModel
+
+from titan_cli.core.result import ClientError, ClientResult, ClientSuccess
+
+from ..models.review_enums import FindingSeverity
+from ..models.review_models import Finding
+from .ai_response_parsing_operations import extract_json_payload
+
+VERIFICATION_EFFORT = "low"
+"""Reasoning-effort tier for the verification call.
+
+The pass re-reads findings against code already reviewed at higher effort — it judges
+claims, it doesn't explore. Low keeps the added latency/cost per review small (D-002).
+"""
+
+VERIFICATION_TIMEOUT_SECONDS = 180
+"""Shorter than the 300s findings timeout: one small prompt, no exploration expected."""
+
+_CODE_BLOCK_CAP_CHARS = 3000
+"""Per-file cap for the code shown to the verifier. The verifier gets each finding's
+focused hunks only — never the full batch context (D-002 token mandate)."""
+
+
+class VerificationVerdict(BaseModel):
+    """AI verdict for one finding in the batched verification call."""
+
+    index: int
+    verdict: str  # "confirmed" | "refuted" | "uncertain"
+    reasoning: str = ""
+
+
+class VerificationOutcome(BaseModel):
+    """Result of applying verdicts to the finding set."""
+
+    kept: list[Finding]
+    refuted: list[Finding]
+    refuted_reasons: list[str]
+
+
+def select_findings_for_verification(findings: list[Finding]) -> tuple[list[Finding], list[Finding]]:
+    """Split findings into (to_verify, exempt).
+
+    Nit-severity findings skip verification (D-002): they are cheap for the human to
+    dismiss and not worth AI time — they go straight to the gate.
+    """
+    to_verify = [finding for finding in findings if finding.severity != FindingSeverity.NIT]
+    exempt = [finding for finding in findings if finding.severity == FindingSeverity.NIT]
+    return to_verify, exempt
+
+
+def build_verification_prompt_parts(
+    findings: list[Finding],
+    code_by_path: dict[str, str],
+    *,
+    code_cap_chars: int = _CODE_BLOCK_CAP_CHARS,
+) -> dict[str, str]:
+    """Build the batched refute-or-confirm prompt.
+
+    `code_by_path` maps each finding's path to the visible code (hunks) it was found
+    in; each block is capped so the pass stays a single small call.
+    """
+    findings_json = json.dumps(
+        [
+            {
+                "index": i,
+                "severity": str(finding.severity),
+                "path": finding.path,
+                "line": finding.line,
+                "title": finding.title,
+                "why": finding.why,
+                "evidence": finding.evidence,
+            }
+            for i, finding in enumerate(findings)
+        ],
+        indent=2,
+    )
+
+    relevant_paths = {finding.path for finding in findings}
+    code_parts: list[str] = []
+    for path in sorted(relevant_paths):
+        content = code_by_path.get(path)
+        if not content:
+            continue
+        code_parts.append(f"### {path}\n```\n{content[:code_cap_chars]}\n```")
+    code_text = "\n".join(code_parts) if code_parts else "(no code context available)"
+
+    instructions = """- For EACH finding, actively try to REFUTE it against the code shown
+- Verdict "refuted": the code visibly contradicts the finding's claim (e.g. the claimed-missing check/handler/parameter is present, the claimed behavior cannot occur in the shown code) — quote the contradicting line in `reasoning`
+- Verdict "confirmed": the code supports the claim
+- Verdict "uncertain": the shown code is insufficient to judge — do NOT refute on missing context
+- Judge only what is claimed; do not invent new findings or re-review the code
+- Return exactly one verdict per finding index"""
+
+    prompt = f"""You are verifying findings from an automated pull request review before they reach a human reviewer. Your job is quality control: catch false positives.
+
+## Findings to Verify
+{findings_json}
+
+## Code the Findings Refer To
+{code_text}
+
+## Instructions
+{instructions}
+
+Respond ONLY with a valid JSON array matching this schema. Do not include any prose before or after the JSON.
+{_verdict_schema()}
+"""
+
+    return {
+        "findings": findings_json,
+        "code": code_text,
+        "instructions": instructions,
+        "prompt": prompt,
+    }
+
+
+def _verdict_schema() -> str:
+    return json.dumps(
+        [
+            {
+                "index": "<finding index from the list above>",
+                "verdict": "<confirmed|refuted|uncertain>",
+                "reasoning": "<short justification; for refuted, quote the contradicting code>",
+            }
+        ],
+        indent=2,
+    )
+
+
+def verification_json_schema() -> dict[str, Any]:
+    """JSON Schema for `--json-schema`, mirroring findings_json_schema()'s object wrapper."""
+    return {
+        "type": "object",
+        "properties": {
+            "verdicts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "index": {"type": "integer"},
+                        "verdict": {"type": "string", "enum": ["confirmed", "refuted", "uncertain"]},
+                        "reasoning": {"type": "string"},
+                    },
+                    "required": ["index", "verdict"],
+                },
+            }
+        },
+        "required": ["verdicts"],
+    }
+
+
+def parse_verification_response(stdout: str, *, structured: bool) -> ClientResult[list]:
+    """Parse the verification CLI response into a list of verdict dicts."""
+    if not structured:
+        return extract_json_payload(stdout, kind="array")
+    match extract_json_payload(stdout, kind="object"):
+        case ClientSuccess(data=payload) if isinstance(payload, dict) and isinstance(payload.get("verdicts"), list):
+            return ClientSuccess(data=payload["verdicts"])
+        case ClientSuccess():
+            return ClientError(
+                error_message="Structured response missing 'verdicts' list",
+                error_code="MISSING_VERDICTS_FIELD",
+                log_level="warning",
+            )
+        case error:
+            return error
+
+
+def apply_verification_verdicts(
+    verified_candidates: list[Finding],
+    raw_verdicts: list,
+    exempt: list[Finding],
+) -> VerificationOutcome:
+    """Apply AI verdicts to the finding set, fail-open.
+
+    Only an explicit "refuted" verdict with non-empty reasoning removes a finding.
+    Findings with no verdict, an out-of-range index, an unknown verdict value, or a
+    reasoning-less refutation are all kept.
+    """
+    verdict_by_index: dict[int, VerificationVerdict] = {}
+    for item in raw_verdicts or []:
+        try:
+            verdict = VerificationVerdict.model_validate(item)
+        except Exception:
+            continue
+        if 0 <= verdict.index < len(verified_candidates):
+            verdict_by_index[verdict.index] = verdict
+
+    kept: list[Finding] = list(exempt)
+    refuted: list[Finding] = []
+    refuted_reasons: list[str] = []
+    for i, finding in enumerate(verified_candidates):
+        verdict = verdict_by_index.get(i)
+        if verdict and verdict.verdict == "refuted" and verdict.reasoning.strip():
+            refuted.append(finding)
+            refuted_reasons.append(verdict.reasoning.strip())
+        else:
+            kept.append(finding)
+
+    return VerificationOutcome(kept=kept, refuted=refuted, refuted_reasons=refuted_reasons)
+
+
+def build_verification_code_map(
+    findings: list[Finding], batches: list, *, cap_chars: int = _CODE_BLOCK_CAP_CHARS
+) -> dict[str, str]:
+    """Map each finding's path to its focused hunks from the review batches.
+
+    Uses hunks (or expanded hunks) only — never `full_content` — so the verification
+    prompt stays small regardless of how the finding's batch read the file.
+    """
+    relevant_paths = {finding.path for finding in findings}
+    code_map: dict[str, str] = {}
+    for batch in batches or []:
+        for path, entry in batch.files_context.items():
+            if path not in relevant_paths or path in code_map:
+                continue
+            hunks = entry.expanded_hunks or entry.hunks
+            if hunks:
+                code_map[path] = "\n".join(hunks)[:cap_chars]
+    return code_map
+
+
+def summarize_verification_prompt_parts(parts: dict[str, str]) -> dict[str, Any]:
+    """Return character counts for each prompt block (telemetry, D-002)."""
+    return {
+        "findings_chars": len(parts["findings"]),
+        "code_chars": len(parts["code"]),
+        "instructions_chars": len(parts["instructions"]),
+    }

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
@@ -91,14 +91,22 @@ def build_verification_prompt_parts(
     for path in sorted(relevant_paths):
         content = code_by_path.get(path)
         if not content:
+            # The finding still gets a verdict slot, so the model must know there is
+            # no code to judge it against — otherwise it can read absence as
+            # contradiction and refute a real finding.
+            code_parts.append(
+                f"### {path}\n(no code context available for this file — "
+                'verdicts for its findings must be "uncertain")'
+            )
             continue
-        code_parts.append(f"### {path}\n```\n{content[:code_cap_chars]}\n```")
+        code_parts.append(f"### {path}\n```\n{_cap_code(content, code_cap_chars)}\n```")
     code_text = "\n".join(code_parts) if code_parts else "(no code context available)"
 
     instructions = """- For EACH finding, actively try to REFUTE it against the code shown
 - Verdict "refuted": the code visibly contradicts the finding's claim (e.g. the claimed-missing check/handler/parameter is present, the claimed behavior cannot occur in the shown code) — quote the contradicting line in `reasoning`
 - Verdict "confirmed": the code supports the claim
 - Verdict "uncertain": the shown code is insufficient to judge — do NOT refute on missing context
+- The code blocks may be truncated: never treat something as absent because it is not visible in the shown excerpt
 - Judge only what is claimed; do not invent new findings or re-review the code
 - Return exactly one verdict per finding index"""
 
@@ -123,6 +131,16 @@ Respond ONLY with a valid JSON array matching this schema. Do not include any pr
         "instructions": instructions,
         "prompt": prompt,
     }
+
+
+_TRUNCATION_MARKER = "\n… [code truncated here — anything beyond this point is NOT shown, not absent]"
+
+
+def _cap_code(content: str, cap_chars: int) -> str:
+    """Cap a code block, marking the cut so the verifier can't read it as complete."""
+    if len(content) <= cap_chars:
+        return content
+    return content[:cap_chars] + _TRUNCATION_MARKER
 
 
 def _verdict_schema() -> str:
@@ -181,12 +199,16 @@ def apply_verification_verdicts(
     verified_candidates: list[Finding],
     raw_verdicts: list,
     exempt: list[Finding],
+    *,
+    paths_with_code: set[str] | None = None,
 ) -> VerificationOutcome:
     """Apply AI verdicts to the finding set, fail-open.
 
     Only an explicit "refuted" verdict with non-empty reasoning removes a finding.
     Findings with no verdict, an out-of-range index, an unknown verdict value, or a
-    reasoning-less refutation are all kept.
+    reasoning-less refutation are all kept. When `paths_with_code` is given, a
+    refutation of a finding whose path had NO code in the prompt is also ignored —
+    the model cannot legitimately contradict code it never saw.
     """
     verdict_by_index: dict[int, VerificationVerdict] = {}
     for item in raw_verdicts or []:
@@ -202,7 +224,8 @@ def apply_verification_verdicts(
     refuted_reasons: list[str] = []
     for i, finding in enumerate(verified_candidates):
         verdict = verdict_by_index.get(i)
-        if verdict and verdict.verdict == "refuted" and verdict.reasoning.strip():
+        refutable = paths_with_code is None or finding.path in paths_with_code
+        if refutable and verdict and verdict.verdict == "refuted" and verdict.reasoning.strip():
             refuted.append(finding)
             refuted_reasons.append(verdict.reasoning.strip())
         else:
@@ -211,13 +234,13 @@ def apply_verification_verdicts(
     return VerificationOutcome(kept=kept, refuted=refuted, refuted_reasons=refuted_reasons)
 
 
-def build_verification_code_map(
-    findings: list[Finding], batches: list, *, cap_chars: int = _CODE_BLOCK_CAP_CHARS
-) -> dict[str, str]:
+def build_verification_code_map(findings: list[Finding], batches: list) -> dict[str, str]:
     """Map each finding's path to its focused hunks from the review batches.
 
     Uses hunks (or expanded hunks) only — never `full_content` — so the verification
-    prompt stays small regardless of how the finding's batch read the file.
+    prompt stays small regardless of how the finding's batch read the file. Capping
+    (with a visible truncation marker) happens once, in
+    `build_verification_prompt_parts` — not here, or the marker could never fire.
     """
     relevant_paths = {finding.path for finding in findings}
     code_map: dict[str, str] = {}
@@ -227,7 +250,7 @@ def build_verification_code_map(
                 continue
             hunks = entry.expanded_hunks or entry.hunks
             if hunks:
-                code_map[path] = "\n".join(hunks)[:cap_chars]
+                code_map[path] = "\n".join(hunks)
     return code_map
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
@@ -32,6 +32,9 @@ _CODE_BLOCK_CAP_CHARS = 3000
 focused hunks only — never the full batch context (D-002 token mandate)."""
 
 
+_KNOWN_VERDICTS = {"confirmed", "refuted", "uncertain"}
+
+
 class VerificationVerdict(BaseModel):
     """AI verdict for one finding in the batched verification call."""
 
@@ -46,6 +49,11 @@ class VerificationOutcome(BaseModel):
     kept: list[Finding]
     refuted: list[Finding]
     refuted_reasons: list[str]
+    invalid_verdicts: int = 0
+    """Verdict entries discarded as unusable (unparseable, out-of-range index, or an
+    unknown verdict value). Dropping them is fail-open and silent, so this count is
+    the only signal that separates "the model confirmed everything" from "every
+    verdict was malformed" — a systematically broken prompt or schema."""
 
 
 def select_findings_for_verification(findings: list[Finding]) -> tuple[list[Finding], list[Finding]]:
@@ -226,15 +234,26 @@ def apply_verification_verdicts(
     reasoning-less refutation are all kept. When `paths_with_code` is given, a
     refutation of a finding whose path had NO code in the prompt is also ignored —
     the model cannot legitimately contradict code it never saw.
+
+    Unusable verdict entries are counted in `invalid_verdicts` so callers can tell a
+    wholly malformed response apart from one that confirmed every finding.
     """
     verdict_by_index: dict[int, VerificationVerdict] = {}
+    invalid_verdicts = 0
     for item in raw_verdicts or []:
         try:
             verdict = VerificationVerdict.model_validate(item)
         except Exception:
+            invalid_verdicts += 1
             continue
         if not (0 <= verdict.index < len(verified_candidates)):
+            invalid_verdicts += 1
             continue
+        if verdict.verdict not in _KNOWN_VERDICTS:
+            # Counted, but still stored: an unknown value must keep its fail-open
+            # weight in the duplicate-index conflict below, where any non-refutation
+            # beats a refutation.
+            invalid_verdicts += 1
         existing = verdict_by_index.get(verdict.index)
         if existing is None:
             verdict_by_index[verdict.index] = verdict
@@ -256,7 +275,12 @@ def apply_verification_verdicts(
 
     kept = [finding for finding in findings if id(finding) not in refuted_ids]
 
-    return VerificationOutcome(kept=kept, refuted=refuted, refuted_reasons=refuted_reasons)
+    return VerificationOutcome(
+        kept=kept,
+        refuted=refuted,
+        refuted_reasons=refuted_reasons,
+        invalid_verdicts=invalid_verdicts,
+    )
 
 
 def build_verification_code_map(findings: list[Finding], batches: list) -> dict[str, str]:

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
@@ -179,12 +179,24 @@ def verification_json_schema() -> dict[str, Any]:
 
 
 def parse_verification_response(stdout: str, *, structured: bool) -> ClientResult[list]:
-    """Parse the verification CLI response into a list of verdict dicts."""
+    """Parse the verification CLI response into a list of verdict dicts.
+
+    Structured mode expects the schema's object wrapper, but the shared prompt text
+    asks for a bare JSON array (the unstructured shape) — a model that honors the
+    prompt over the schema must still be parseable, so structured mode falls back
+    to array extraction before giving up. Fail-open downstream depends on
+    recovering verdicts wherever they are.
+    """
     if not structured:
         return extract_json_payload(stdout, kind="array")
-    match extract_json_payload(stdout, kind="object"):
+    object_result = extract_json_payload(stdout, kind="object")
+    match object_result:
         case ClientSuccess(data=payload) if isinstance(payload, dict) and isinstance(payload.get("verdicts"), list):
             return ClientSuccess(data=payload["verdicts"])
+    match extract_json_payload(stdout, kind="array"):
+        case ClientSuccess(data=payload) if isinstance(payload, list):
+            return ClientSuccess(data=payload)
+    match object_result:
         case ClientSuccess():
             return ClientError(
                 error_message="Structured response missing 'verdicts' list",
@@ -216,7 +228,14 @@ def apply_verification_verdicts(
             verdict = VerificationVerdict.model_validate(item)
         except Exception:
             continue
-        if 0 <= verdict.index < len(verified_candidates):
+        if not (0 <= verdict.index < len(verified_candidates)):
+            continue
+        existing = verdict_by_index.get(verdict.index)
+        if existing is None:
+            verdict_by_index[verdict.index] = verdict
+        elif existing.verdict == "refuted" and verdict.verdict != "refuted":
+            # Duplicate indices are malformed output; when they conflict, fail-open
+            # means the verdict that KEEPS the finding wins, regardless of order.
             verdict_by_index[verdict.index] = verdict
 
     kept: list[Finding] = list(exempt)

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
@@ -208,13 +208,18 @@ def parse_verification_response(stdout: str, *, structured: bool) -> ClientResul
 
 
 def apply_verification_verdicts(
+    findings: list[Finding],
     verified_candidates: list[Finding],
     raw_verdicts: list,
-    exempt: list[Finding],
     *,
     paths_with_code: set[str] | None = None,
 ) -> VerificationOutcome:
     """Apply AI verdicts to the finding set, fail-open.
+
+    This is a pure filter over `findings`: the kept list preserves the input order
+    (most-severe first), because downstream consumers — the human gate and the
+    posted comments — render findings in that order. `verified_candidates` only
+    supplies the index space the verdicts refer to.
 
     Only an explicit "refuted" verdict with non-empty reasoning removes a finding.
     Findings with no verdict, an out-of-range index, an unknown verdict value, or a
@@ -238,17 +243,18 @@ def apply_verification_verdicts(
             # means the verdict that KEEPS the finding wins, regardless of order.
             verdict_by_index[verdict.index] = verdict
 
-    kept: list[Finding] = list(exempt)
     refuted: list[Finding] = []
     refuted_reasons: list[str] = []
+    refuted_ids: set[int] = set()
     for i, finding in enumerate(verified_candidates):
         verdict = verdict_by_index.get(i)
         refutable = paths_with_code is None or finding.path in paths_with_code
         if refutable and verdict and verdict.verdict == "refuted" and verdict.reasoning.strip():
             refuted.append(finding)
             refuted_reasons.append(verdict.reasoning.strip())
-        else:
-            kept.append(finding)
+            refuted_ids.add(id(finding))
+
+    kept = [finding for finding in findings if id(finding) not in refuted_ids]
 
     return VerificationOutcome(kept=kept, refuted=refuted, refuted_reasons=refuted_reasons)
 

--- a/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/operations/verification_operations.py
@@ -274,8 +274,12 @@ def build_verification_code_map(findings: list[Finding], batches: list) -> dict[
             if path not in relevant_paths or path in code_map:
                 continue
             hunks = entry.expanded_hunks or entry.hunks
-            if hunks:
-                code_map[path] = "\n".join(hunks)
+            # Only store truthy content: callers derive `paths_with_code` from these
+            # keys, and `build_verification_prompt_parts` treats an empty string as
+            # "no code context". A blank entry would let a refutation stand for a
+            # file the model was told it could not judge.
+            if joined := "\n".join(hunks or []).strip():
+                code_map[path] = joined
     return code_map
 
 

--- a/plugins/titan-plugin-github/titan_plugin_github/plugin.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/plugin.py
@@ -172,6 +172,7 @@ class GitHubPlugin(TitanPlugin):
             ai_review_findings,
             normalize_findings,
             dedupe_findings,
+            verify_findings,
             build_new_comment_actions,
             validate_review_actions,
             submit_review_actions,
@@ -228,6 +229,7 @@ class GitHubPlugin(TitanPlugin):
             "ai_review_findings": ai_review_findings,
             "normalize_findings": normalize_findings,
             "dedupe_findings": dedupe_findings,
+            "verify_findings": verify_findings,
             # Phase 5: UI + submit
             "build_new_comment_actions": build_new_comment_actions,
             "validate_review_actions": validate_review_actions,

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -2796,8 +2796,15 @@ def verify_findings(ctx: WorkflowContext) -> WorkflowResult:
         exempt_nits=len(exempt),
         refuted=len(outcome.refuted),
         kept=len(outcome.kept),
+        invalid_verdicts=outcome.invalid_verdicts,
         duration_seconds=round(adapter_duration_seconds, 3),
     )
+    if outcome.invalid_verdicts and not outcome.refuted:
+        # Every verdict unusable looks exactly like "confirmed everything" otherwise:
+        # say it out loud so a broken prompt or schema is visible.
+        ctx.textual.warning_text(
+            f"⚠ {outcome.invalid_verdicts} unusable verdict(s) — verification may not have run correctly."
+        )
     for finding, reason in zip(outcome.refuted, outcome.refuted_reasons):
         ctx.textual.dim_text(
             f"✗ Refuted: {finding.title} @ {finding.path}:{finding.line} — {reason[:200]}"

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -530,6 +530,7 @@ def select_pr_for_code_review(ctx: WorkflowContext) -> WorkflowResult:
     ctx.textual.begin_step("Select PR to Review")
 
     if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
         ctx.textual.end_step("error")
         return Error("GitHub client not available")
 
@@ -585,6 +586,7 @@ def select_pr_for_code_review(ctx: WorkflowContext) -> WorkflowResult:
     try:
         selected = ctx.textual.ask_option(question, options)
     except Exception as e:
+        ctx.textual.error_text(str(e))
         ctx.textual.end_step("error")
         return Error(str(e))
 
@@ -595,6 +597,7 @@ def select_pr_for_code_review(ctx: WorkflowContext) -> WorkflowResult:
 
     selected_pr = next((pr for pr in sorted_prs if pr.number == selected), None)
     if not selected_pr:
+        ctx.textual.error_text(f"PR #{selected} not found in list")
         ctx.textual.end_step("error")
         return Error(f"PR #{selected} not found in list")
 
@@ -642,10 +645,12 @@ def fetch_pr_review_bundle(ctx: WorkflowContext) -> WorkflowResult:
 
     pr_number = ctx.get("review_pr_number")
     if not pr_number:
+        ctx.textual.error_text("No PR number in context (run select_pr_for_code_review first)")
         ctx.textual.end_step("error")
         return Error("No PR number in context (run select_pr_for_code_review first)")
 
     if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
         ctx.textual.end_step("error")
         return Error("GitHub client not available")
 
@@ -927,12 +932,14 @@ def build_change_manifest(ctx: WorkflowContext) -> WorkflowResult:
     files = ctx.get("review_changed_files_with_stats", [])
 
     if not pr:
+        ctx.textual.error_text("No PR data in context (run fetch_pr_review_bundle first)")
         ctx.textual.end_step("error")
         return Error("No PR data in context (run fetch_pr_review_bundle first)")
 
     try:
         manifest = build_change_manifest_operation(pr, files)
     except Exception as e:
+        ctx.textual.error_text(f"Failed to build change manifest: {e}")
         ctx.textual.end_step("error")
         return Error(f"Failed to build change manifest: {e}")
 
@@ -999,6 +1006,7 @@ def build_existing_comments_index(ctx: WorkflowContext) -> WorkflowResult:
             bug_risk_only=True,
         )
     except Exception as e:
+        ctx.textual.error_text(f"Failed to build comments index: {e}")
         ctx.textual.end_step("error")
         return Error(f"Failed to build comments index: {e}")
 
@@ -1059,6 +1067,7 @@ def classify_pr(ctx: WorkflowContext) -> WorkflowResult:
     review_profile = _get_review_profile(ctx)
 
     if not manifest:
+        ctx.textual.error_text("No change manifest in context")
         ctx.textual.end_step("error")
         return Error("No change manifest in context")
 
@@ -1116,6 +1125,7 @@ def score_review_candidates(ctx: WorkflowContext) -> WorkflowResult:
     manifest = ctx.get("change_manifest")
     review_profile = _get_review_profile(ctx)
     if not manifest:
+        ctx.textual.error_text("No change manifest in context")
         ctx.textual.end_step("error")
         return Error("No change manifest in context")
 
@@ -1177,6 +1187,8 @@ def build_review_checklist(ctx: WorkflowContext) -> WorkflowResult:
     ctx.textual.begin_step("Build Review Checklist")
 
     if not ctx.github_managers:
+        ctx.textual.error_text("GitHub managers are not available in workflow context.")
+        ctx.textual.end_step("error")
         return Error("GitHub managers are not available in workflow context.")
 
     checklist = ctx.github_managers.checklist.get_effective_checklist()
@@ -1242,6 +1254,7 @@ def select_review_strategy(ctx: WorkflowContext) -> WorkflowResult:
 
     classification = ctx.get("pr_classification")
     if not classification:
+        ctx.textual.error_text("No pr_classification in context")
         ctx.textual.end_step("error")
         return Error("No pr_classification in context")
 
@@ -1321,6 +1334,7 @@ def ai_review_plan(ctx: WorkflowContext) -> WorkflowResult:
     project_root = ctx.data.get("project_root")
 
     if not manifest or not strategy:
+        ctx.textual.error_text("Missing change_manifest or review_strategy in context")
         ctx.textual.end_step("error")
         return Error("Missing change_manifest or review_strategy in context")
 
@@ -1402,9 +1416,13 @@ def ai_review_plan(ctx: WorkflowContext) -> WorkflowResult:
     )
 
     if not response.succeeded:
-        ctx.textual.warning_text(f"CLI call failed (exit {response.exit_code}) — using default plan")
-        if response.stderr:
-            ctx.textual.dim_text(response.stderr[:200])
+        # Raw stderr means nothing to the reviewer; the actionable fact is that the
+        # AI plan failed and a deterministic plan takes over. Details go to the log
+        # (already captured in full by _log_ai_response above).
+        ctx.textual.warning_text(
+            "The AI couldn't produce a review plan — falling back to the automatic plan "
+            "(top-scored files)."
+        )
         fallback = build_default_review_plan(
             candidates,
             excluded_files,
@@ -1429,7 +1447,12 @@ def ai_review_plan(ctx: WorkflowContext) -> WorkflowResult:
             parse_error = err
 
     if parse_error is not None:
-        ctx.textual.warning_text(f"Plan parsing failed ({parse_error}) — using default plan")
+        # Same as the CLI-failure path: no raw pydantic/JSON error dumps on screen.
+        logger.debug("review_plan_parse_failed", parse_error=parse_error)
+        ctx.textual.warning_text(
+            "The AI's review plan couldn't be read — falling back to the automatic plan "
+            "(top-scored files)."
+        )
         fallback = build_default_review_plan(
             candidates,
             excluded_files,
@@ -1483,6 +1506,7 @@ def validate_review_plan(ctx: WorkflowContext) -> WorkflowResult:
     review_profile = _get_review_profile(ctx)
 
     if not plan or not manifest:
+        ctx.textual.error_text("Missing review_plan or change_manifest in context")
         ctx.textual.end_step("error")
         return Error("Missing review_plan or change_manifest in context")
 
@@ -1792,10 +1816,12 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
     project_root = worktree_path or ctx.data.get("project_root")
 
     if not plan or not manifest or not strategy:
+        ctx.textual.error_text("Missing validated_review_plan, change_manifest or review_strategy in context")
         ctx.textual.end_step("error")
         return Error("Missing validated_review_plan, change_manifest or review_strategy in context")
 
     if not diff:
+        ctx.textual.error_text("No diff in context (run fetch_pr_review_bundle first)")
         ctx.textual.end_step("error")
         return Error("No diff in context (run fetch_pr_review_bundle first)")
 
@@ -1828,6 +1854,7 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
                 allow_file_reads=read_access.allowed,
             )
     except Exception as e:
+        ctx.textual.error_text(f"Failed to resolve review context: {e}")
         ctx.textual.end_step("error")
         return Error(f"Failed to resolve review context: {e}")
 
@@ -2005,6 +2032,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     project_root = ctx.data.get("worktree_path") or ctx.data.get("project_root")
 
     if not batches:
+        ctx.textual.error_text("No review_context_batches in context (run resolve_review_context first)")
         ctx.textual.end_step("error")
         return Error("No review_context_batches in context (run resolve_review_context first)")
 
@@ -2402,6 +2430,7 @@ def normalize_findings(ctx: WorkflowContext) -> WorkflowResult:
     raw = ctx.get("raw_findings")
 
     if raw is None:
+        ctx.textual.error_text("No raw_findings in context (run ai_review_findings first)")
         ctx.textual.end_step("error")
         return Error("No raw_findings in context (run ai_review_findings first)")
 
@@ -2414,10 +2443,12 @@ def normalize_findings(ctx: WorkflowContext) -> WorkflowResult:
         try:
             raw = json.loads(raw)
         except json.JSONDecodeError as e:
+            ctx.textual.error_text(f"Failed to parse raw_findings JSON: {e}")
             ctx.textual.end_step("error")
             return Error(f"Failed to parse raw_findings JSON: {e}")
 
     if not isinstance(raw, list):
+        ctx.textual.error_text(f"raw_findings must be a list, got {type(raw).__name__}")
         ctx.textual.end_step("error")
         return Error(f"raw_findings must be a list, got {type(raw).__name__}")
 
@@ -2470,6 +2501,7 @@ def dedupe_findings(ctx: WorkflowContext) -> WorkflowResult:
     existing_index = ctx.get("existing_comments_index", [])
 
     if findings is None:
+        ctx.textual.error_text("No normalized_findings in context (run normalize_findings first)")
         ctx.textual.end_step("error")
         return Error("No normalized_findings in context (run normalize_findings first)")
 
@@ -2555,6 +2587,7 @@ def verify_findings(ctx: WorkflowContext) -> WorkflowResult:
 
     findings = ctx.get("deduped_findings")
     if findings is None:
+        ctx.textual.error_text("No deduped_findings in context (run dedupe_findings first)")
         ctx.textual.end_step("error")
         return Error("No deduped_findings in context (run dedupe_findings first)")
 
@@ -2923,10 +2956,12 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     diff_manager = ctx.get("review_diff_manager")
 
     if not pr_number:
+        ctx.textual.error_text("No PR number in context")
         ctx.textual.end_step("error")
         return Error("No PR number in context")
 
     if not ctx.github:
+        ctx.textual.error_text("GitHub client not available")
         ctx.textual.end_step("error")
         return Error("GitHub client not available")
 
@@ -3019,6 +3054,7 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     try:
         event = ctx.textual.ask_option("Select review type:", event_options)
     except Exception as e:
+        ctx.textual.error_text(str(e))
         ctx.textual.end_step("error")
         return Error(str(e))
 
@@ -3049,6 +3085,13 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     has_inline_comments = bool(payload.get("comments"))
     has_body = bool(payload.get("body"))
     is_empty_payload = not has_inline_comments and not has_body
+    # Human label for the GitHub review event ('COMMENT'/'APPROVE'/'REQUEST_CHANGES').
+    event_labels = {
+        "COMMENT": "Comment",
+        "APPROVE": "Approve",
+        "REQUEST_CHANGES": "Request Changes",
+    }
+    event_label = event_labels.get(event, event)
 
     if is_empty_payload:
         ctx.textual.dim_text("Submitting review without comments...")
@@ -3056,7 +3099,7 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
             submit_result = ctx.github.submit_review(pr_number, None, event, "")
         match submit_result:
             case ClientSuccess():
-                ctx.textual.success_text(f"✓ Review submitted as '{event}' on PR #{pr_number}")
+                ctx.textual.success_text(f"✓ Review submitted ({event_label}) on PR #{pr_number}")
                 ctx.textual.end_step("success")
                 return Success(f"Review submitted on PR #{pr_number}")
             case ClientError(error_message=err, error_code="PENDING_REVIEW_EXISTS"):
@@ -3082,7 +3125,9 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
                 inline_comment_count=len(payload.get("comments", [])),
             )
             if payload.get("comments"):
-                ctx.textual.warning_text("Draft review failed. Probing inline comments individually...")
+                ctx.textual.warning_text(
+                    "GitHub rejected the review — checking which comments it will accept…"
+                )
                 filtered_payload, rejected_comments = _filter_invalid_inline_comments(ctx, pr_number, payload)
                 if rejected_comments:
                     rejection_breakdown: dict[str, int] = {}
@@ -3090,12 +3135,12 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
                         kind = classify_github_review_rejection(comment.get("error", ""))
                         rejection_breakdown[kind] = rejection_breakdown.get(kind, 0) + 1
                     ctx.textual.warning_text(
-                        f"Filtered out {len(rejected_comments)} inline comment(s) rejected by GitHub"
+                        f"⚠ {len(rejected_comments)} comment(s) can't be placed inline and will be "
+                        "left out:"
                     )
                     for comment in rejected_comments:
-                        rejection_kind = classify_github_review_rejection(comment.get("error", ""))
                         ctx.textual.dim_text(
-                            f"Rejected inline: {comment.get('path')}:{comment.get('line')} -> {rejection_kind}"
+                            f"  {comment.get('path')}:{comment.get('line')}"
                         )
                     logger.debug(
                         "inline_comments_filtered_after_422",
@@ -3112,9 +3157,6 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
                         valid_count=len(filtered_payload.get("comments", [])),
                         rejection_breakdown=rejection_breakdown,
                     )
-                    ctx.textual.dim_text(
-                        f"Inline submit success rate: {len(filtered_payload.get('comments', []))}/{len(payload.get('comments', []))}"
-                    )
                     if filtered_payload.get("comments") or filtered_payload.get("body"):
                         payload = filtered_payload
                         with ctx.textual.loading("Retrying review creation with valid comments only..."):
@@ -3122,7 +3164,7 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
                         match retry_result:
                             case ClientSuccess(data=review_id):
                                 ctx.textual.success_text(
-                                    f"✓ Review #{review_id} created after filtering invalid comments"
+                                    f"✓ Review #{review_id} created without the rejected comment(s)"
                                 )
                             case ClientError(error_message=retry_err):
                                 ctx.textual.error_text(f"Failed to create review: {retry_err}")
@@ -3149,7 +3191,7 @@ def submit_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     match submit_result:
         case ClientSuccess():
             ctx.textual.success_text(
-                f"✓ Review submitted as '{event}' on PR #{pr_number}"
+                f"✓ Review submitted ({event_label}) on PR #{pr_number}"
                 + (f" with {len(comment_actions)} comment(s)" if comment_actions else "")
             )
             ctx.textual.end_step("success")
@@ -3469,10 +3511,12 @@ def normalize_thread_decisions(ctx: WorkflowContext) -> WorkflowResult:
         try:
             raw = json.loads(raw)
         except json.JSONDecodeError as e:
+            ctx.textual.error_text(f"Failed to parse raw_thread_decisions JSON: {e}")
             ctx.textual.end_step("error")
             return Error(f"Failed to parse raw_thread_decisions JSON: {e}")
 
     if not isinstance(raw, list):
+        ctx.textual.error_text(f"raw_thread_decisions must be a list, got {type(raw).__name__}")
         ctx.textual.end_step("error")
         return Error(f"raw_thread_decisions must be a list, got {type(raw).__name__}")
 

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1868,6 +1868,96 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
 # ============================================================================
 
 
+def _execute_findings_batch(
+    adapter,
+    batch,
+    prompt: str,
+    *,
+    project_root: Optional[str],
+    findings_schema: Optional[dict],
+    disallowed_tools: Optional[list],
+    effort: Optional[str],
+    use_structured_output: bool,
+    strategy_name: Optional[str],
+) -> dict:
+    """Run one findings batch end-to-end: CLI call, parse, reformat retry.
+
+    Runs inside a worker thread when batches execute concurrently, so it must not
+    touch `ctx`/the UI — it returns an outcome dict the step thread renders:
+    {"status": "success" | "failed", "raw": list | None, "detail": str}.
+    """
+    from ..operations.findings_operations import parse_findings_response
+
+    adapter_started_at = time.monotonic()
+    response = adapter.execute(
+        prompt,
+        cwd=project_root,
+        timeout=300,
+        json_schema=findings_schema,
+        disallowed_tools=disallowed_tools,
+        effort=effort,
+    )
+    adapter_duration_seconds = time.monotonic() - adapter_started_at
+    worktree_reference_count = sum(
+        1 for entry in batch.files_context.values() if entry.worktree_reference
+    )
+    logger.info(
+        "findings_batch_adapter_call",
+        batch_id=batch.batch_id,
+        cli=adapter.cli_name.value,
+        files_context=len(batch.files_context),
+        worktree_reference_count=worktree_reference_count,
+        prompt_actual_chars=len(prompt),
+        duration_seconds=round(adapter_duration_seconds, 3),
+        exit_code=response.exit_code,
+        timed_out=response.exit_code == 124,
+        structured_output=use_structured_output,
+        effort=effort,
+    )
+    _log_ai_response(
+        step_name="ai_review_findings",
+        cli_name=adapter.cli_name.value,
+        stdout=response.stdout,
+        stderr=response.stderr,
+        exit_code=response.exit_code,
+        batch_id=batch.batch_id,
+        files_context=len(batch.files_context),
+        related_files=len(batch.related_files),
+        checklist_items=len(batch.checklist_applicable),
+        comment_entries=len(batch.comment_context),
+        strategy=strategy_name,
+    )
+
+    if not response.succeeded:
+        logger.debug("findings_batch_failed", batch_id=batch.batch_id, exit_code=response.exit_code)
+        return {"status": "failed", "raw": None, "detail": f"CLI exit {response.exit_code}"}
+
+    match parse_findings_response(response.stdout, structured=use_structured_output):
+        case ClientSuccess(data=raw) if isinstance(raw, list):
+            return {"status": "success", "raw": raw, "detail": ""}
+        case ClientSuccess(data=raw):
+            # A structured success whose payload isn't a findings list (e.g. a dict)
+            # must not vanish silently — treat it like any other parse failure.
+            parse_error = f"non-list findings payload ({type(raw).__name__})"
+        case ClientError(error_message=err):
+            parse_error = err
+
+    logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=parse_error)
+    match _retry_findings_batch_reformat(
+        adapter, response.stdout, project_root, batch.batch_id, use_structured_output, effort
+    ):
+        case ClientSuccess(data=raw) if isinstance(raw, list):
+            logger.debug(
+                "findings_batch_reformat_recovered",
+                batch_id=batch.batch_id,
+                findings_count=len(raw),
+            )
+            return {"status": "success", "raw": raw, "detail": ""}
+        case _:
+            logger.debug("findings_batch_reformat_failed", batch_id=batch.batch_id)
+            return {"status": "failed", "raw": None, "detail": "parse error"}
+
+
 def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     """
     Second AI call: find actionable problems in the exact code context.
@@ -1911,7 +2001,6 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         build_default_findings,
         build_findings_prompt_parts,
         findings_json_schema,
-        parse_findings_response,
         summarize_findings_prompt_parts,
     )
 
@@ -1940,6 +2029,10 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     batch_queue = list(batches)
     ctx.textual.dim_text(f"Reviewing {len(batch_queue)} batch(es) with {cli_display}")
 
+    # Phase 1 — budget fitting stays sequential and deterministic: splits/degradations
+    # requeue, so the set of ready-to-execute batches isn't known until this loop
+    # reaches a fixpoint. No AI calls happen here.
+    ready: list[tuple] = []  # (batch, prompt, effort)
     while batch_queue:
         batch = batch_queue.pop(0)
         prompt_parts = build_findings_prompt_parts(batch)
@@ -1969,7 +2062,6 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
 
         batch = fitted_batches[0]
         batches_attempted += 1
-        _render_findings_batch_started(ctx, batch)
         prompt_parts = build_findings_prompt_parts(batch)
         prompt = prompt_parts["prompt"]
         prompt_breakdown = summarize_findings_prompt_parts(prompt_parts)
@@ -2018,99 +2110,69 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             if worktree_reference_count and adapter.supports_effort_control
             else None
         )
-        adapter_started_at = time.monotonic()
-        with ctx.textual.loading(f"Asking {cli_display} to review {len(batch.files_context)} file(s) in {batch.batch_id}…"):
-            response = adapter.execute(
-                prompt,
-                cwd=project_root,
-                timeout=300,
-                json_schema=findings_schema,
+        _render_findings_batch_started(ctx, batch)
+        ready.append((batch, prompt, effort))
+
+    # Phase 2 — execute ready batches through a small worker pool. Adapter calls are
+    # independent subprocesses, so the only sequential cost was the loop itself
+    # (real baseline: 307s wall for 6 batches, PR #3596). Workers never touch the UI;
+    # results render here, on the step thread, as each batch completes.
+    def _run(entry: tuple) -> dict:
+        entry_batch, entry_prompt, entry_effort = entry
+        try:
+            return _execute_findings_batch(
+                adapter,
+                entry_batch,
+                entry_prompt,
+                project_root=project_root,
+                findings_schema=findings_schema,
                 disallowed_tools=disallowed_tools,
-                effort=effort,
+                effort=entry_effort,
+                use_structured_output=use_structured_output,
+                strategy_name=str(strategy.strategy) if strategy else None,
             )
-        adapter_duration_seconds = time.monotonic() - adapter_started_at
-        logger.info(
-            "findings_batch_adapter_call",
-            batch_id=batch.batch_id,
-            cli=adapter.cli_name.value,
-            files_context=len(batch.files_context),
-            worktree_reference_count=worktree_reference_count,
-            prompt_actual_chars=len(prompt),
-            duration_seconds=round(adapter_duration_seconds, 3),
-            exit_code=response.exit_code,
-            timed_out=response.exit_code == 124,
-            structured_output=use_structured_output,
-            effort=effort,
+        except Exception as exc:
+            logger.error("findings_batch_crashed", batch_id=entry_batch.batch_id, error=str(exc))
+            return {"status": "failed", "raw": None, "detail": f"adapter error: {exc}"}
+
+    if ready:
+        pool_size = min(
+            max(1, _get_review_profile(ctx).findings_batch_concurrency), len(ready)
         )
-        _log_ai_response(
-            step_name="ai_review_findings",
-            cli_name=adapter.cli_name.value,
-            stdout=response.stdout,
-            stderr=response.stderr,
-            exit_code=response.exit_code,
-            batch_id=batch.batch_id,
-            files_context=len(batch.files_context),
-            related_files=len(batch.related_files),
-            checklist_items=len(batch.checklist_applicable),
-            comment_entries=len(batch.comment_context),
-            strategy=str(strategy.strategy) if strategy else None,
-        )
-
-        if not response.succeeded:
-            findings_failed = True
-            logger.debug("findings_batch_failed", batch_id=batch.batch_id, exit_code=response.exit_code)
-            _render_findings_batch_result(
-                ctx,
-                batch.batch_id,
-                status="failed",
-                detail=f"CLI exit {response.exit_code}",
-            )
-            continue
-
-        match parse_findings_response(response.stdout, structured=use_structured_output):
-            case ClientSuccess(data=raw) if isinstance(raw, list):
-                batches_succeeded += 1
-                aggregated_raw.extend(raw)
-                _render_findings_batch_result(
-                    ctx,
-                    batch.batch_id,
-                    status="success",
-                    findings_count=len(raw),
-                )
-                continue
-            case ClientSuccess(data=raw):
-                # A structured success whose payload isn't a findings list (e.g. a dict)
-                # must not vanish silently — treat it like any other parse failure.
-                parse_error = f"non-list findings payload ({type(raw).__name__})"
-            case ClientError(error_message=err):
-                parse_error = err
-
-        logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=parse_error)
-        match _retry_findings_batch_reformat(
-            adapter, response.stdout, project_root, batch.batch_id, use_structured_output, effort
+        with ctx.textual.loading(
+            f"Asking {cli_display} to review {len(ready)} batch(es)"
+            + (f" ({pool_size} in parallel)…" if pool_size > 1 else "…")
         ):
-            case ClientSuccess(data=raw) if isinstance(raw, list):
+            if pool_size == 1:
+                completed = ((entry[0], _run(entry)) for entry in ready)
+                outcomes = list(completed)
+            else:
+                from concurrent.futures import ThreadPoolExecutor, as_completed
+
+                with ThreadPoolExecutor(max_workers=pool_size) as executor:
+                    future_to_batch = {executor.submit(_run, entry): entry[0] for entry in ready}
+                    outcomes = [
+                        (future_to_batch[future], future.result())
+                        for future in as_completed(future_to_batch)
+                    ]
+
+        for batch, outcome in outcomes:
+            if outcome["status"] == "success":
                 batches_succeeded += 1
-                aggregated_raw.extend(raw)
-                logger.debug(
-                    "findings_batch_reformat_recovered",
-                    batch_id=batch.batch_id,
-                    findings_count=len(raw),
-                )
+                aggregated_raw.extend(outcome["raw"])
                 _render_findings_batch_result(
                     ctx,
                     batch.batch_id,
                     status="success",
-                    findings_count=len(raw),
+                    findings_count=len(outcome["raw"]),
                 )
-            case _:
+            else:
                 findings_failed = True
-                logger.debug("findings_batch_reformat_failed", batch_id=batch.batch_id)
                 _render_findings_batch_result(
                     ctx,
                     batch.batch_id,
                     status="failed",
-                    detail="parse error",
+                    detail=outcome["detail"],
                 )
 
     if batches_attempted and not batches_succeeded:
@@ -2129,11 +2191,86 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         return Error(f"AI findings failed: 0/{batches_attempted} batches produced output")
 
     if not aggregated_raw and strategy and strategy.suspicious_empty_findings:
+        # Empty review on a PR the strategy flagged as suspicious-if-empty: instead of
+        # only noting that borderline files went unreviewed, run ONE rescue batch over
+        # up to 2 of them (hunks_only, budget-respecting). Rescue findings are the
+        # signal that the main candidate selection was too aggressive.
+        from ..operations.findings_operations import build_empty_findings_rescue_batch
+
         candidates = ctx.get("review_candidates", [])
         already_reviewed = {fp.path for batch in batches for fp in batch.files_context.values()}
-        borderline = [candidate for candidate in candidates if candidate.path not in already_reviewed][:2]
-        if borderline:
-            ctx.textual.dim_text("No findings from main batches; borderline files remain unreviewed.")
+        borderline_paths = [
+            candidate.path for candidate in candidates if candidate.path not in already_reviewed
+        ]
+        rescue_batch = (
+            build_empty_findings_rescue_batch(
+                borderline_paths,
+                ctx.get("review_diff", ""),
+                ctx.get("review_checklist", []),
+                batches[0].pr_manifest if batches else None,
+                diff_manager=ctx.get("review_diff_manager"),
+            )
+            if borderline_paths
+            else None
+        )
+        if rescue_batch:
+            rescue_prompt = build_findings_prompt_parts(rescue_batch)["prompt"]
+            if len(rescue_prompt) > strategy.max_prompt_chars:
+                logger.debug(
+                    "rescue_batch_over_budget",
+                    prompt_actual_chars=len(rescue_prompt),
+                    prompt_budget_target_chars=strategy.max_prompt_chars,
+                )
+                ctx.textual.dim_text(
+                    "No findings from main batches; borderline files remain unreviewed (rescue over budget)."
+                )
+            else:
+                ctx.textual.dim_text(
+                    f"No findings from main batches — reviewing {len(rescue_batch.files_context)} "
+                    "borderline file(s) as a rescue batch."
+                )
+                _log_ai_prompt(
+                    step_name="ai_review_findings",
+                    cli_name=adapter.cli_name.value,
+                    prompt=rescue_prompt,
+                    batch_id=rescue_batch.batch_id,
+                    files_context=len(rescue_batch.files_context),
+                    prompt_budget_target_chars=strategy.max_prompt_chars,
+                    prompt_actual_chars=len(rescue_prompt),
+                )
+                _render_findings_batch_started(ctx, rescue_batch)
+                with ctx.textual.loading(f"Asking {cli_display} to review the rescue batch…"):
+                    rescue_outcome = _run((rescue_batch, rescue_prompt, None))
+                if rescue_outcome["status"] == "success":
+                    aggregated_raw.extend(rescue_outcome["raw"])
+                    _render_findings_batch_result(
+                        ctx,
+                        rescue_batch.batch_id,
+                        status="success",
+                        findings_count=len(rescue_outcome["raw"]),
+                    )
+                    if rescue_outcome["raw"]:
+                        # The rescue pass finding real issues means files the scorer
+                        # considered borderline held findings — candidate selection was
+                        # too aggressive for this PR shape.
+                        logger.info(
+                            "rescue_batch_found_findings",
+                            findings_count=len(rescue_outcome["raw"]),
+                            rescued_paths=sorted(rescue_batch.files_context),
+                        )
+                else:
+                    # The rescue pass is best-effort: its failure must not mark an
+                    # otherwise-clean review as failed.
+                    _render_findings_batch_result(
+                        ctx,
+                        rescue_batch.batch_id,
+                        status="failed",
+                        detail=rescue_outcome["detail"],
+                    )
+        elif borderline_paths:
+            ctx.textual.dim_text(
+                "No findings from main batches; borderline files remain unreviewed (no diff hunks)."
+            )
 
     ctx.data["raw_findings"] = aggregated_raw or build_default_findings()
     ctx.data["ai_findings_failed"] = findings_failed

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -2465,6 +2465,17 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                         status="failed",
                         detail=synthesis_outcome["detail"],
                     )
+        else:
+            # Nothing to synthesize: fewer than 2 reviewed paths, or the reviewed paths
+            # have no diff hunks (unavailable diff, binary, rename-only). Surfaced so a
+            # skipped synthesis never looks like one that ran clean.
+            logger.debug(
+                "synthesis_batch_skipped",
+                focus_paths_count=len(focus_paths),
+            )
+            ctx.textual.dim_text(
+                "Cross-file synthesis skipped (fewer than 2 reviewed files with diff hunks)."
+            )
 
     ctx.data["raw_findings"] = aggregated_raw or build_default_findings()
     ctx.data["ai_findings_failed"] = findings_failed

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -580,7 +580,7 @@ def select_pr_for_code_review(ctx: WorkflowContext) -> WorkflowResult:
     ]
 
     assigned_count = len(assigned_numbers)
-    question = f"Select a PR to review ({len(all_prs_list)} total{f', {assigned_count} asignados ⭐' if assigned_count else ''}):"
+    question = f"Select a PR to review ({len(all_prs_list)} total{f', {assigned_count} assigned to you ⭐' if assigned_count else ''}):"
 
     try:
         selected = ctx.textual.ask_option(question, options)
@@ -947,17 +947,14 @@ def build_change_manifest(ctx: WorkflowContext) -> WorkflowResult:
         + (f" ({test_count} test files)" if test_count else "")
         + f" · +{manifest.total_additions} -{manifest.total_deletions}"
     )
-    ctx.textual.dim_text(
-        " · ".join(
-            [
-                f"tests: {test_count}",
-                f"docs: {docs_count}",
-                f"config: {config_count}",
-                f"generated: {generated_count}",
-                f"lockfiles: {lockfile_count}",
-                f"rename-only: {rename_only_count}",
-            ]
-        )
+    logger.debug(
+        "change_manifest_census",
+        tests=test_count,
+        docs=docs_count,
+        config=config_count,
+        generated=generated_count,
+        lockfiles=lockfile_count,
+        rename_only=rename_only_count,
     )
     ctx.textual.end_step("success")
     return Success("Change manifest built", metadata={"change_manifest": manifest})
@@ -1011,9 +1008,6 @@ def build_existing_comments_index(ctx: WorkflowContext) -> WorkflowResult:
     if resolved_count:
         msg += f" ({resolved_count} resolved)"
     ctx.textual.success_text(msg)
-    ctx.textual.dim_text(
-        f"prompt comments: {len(comment_context)} · adjudicated threads: {adjudicated_count}"
-    )
     logger.debug(
         "existing_comments_index_built",
         existing_comments_total=len(index),
@@ -1265,15 +1259,17 @@ def select_review_strategy(ctx: WorkflowContext) -> WorkflowResult:
         max_prompt_chars=strategy.max_prompt_chars,
         max_comment_entries=strategy.max_comment_entries,
     )
+    # Speak outcome, not mechanics: strategy enum names and prompt budgets in chars
+    # mean nothing to the reviewer — what matters is how the review will proceed and
+    # how many files it will focus on. Mechanics stay in the debug log above.
+    strategy_labels = {
+        "direct_findings": "direct review in one pass",
+        "light_plan": "lightweight plan, then focused review",
+        "batched_findings": "planned review in batches",
+    }
+    approach = strategy_labels.get(strategy.strategy.value, strategy.strategy.value)
     ctx.textual.success_text(
-        f"✓ {strategy.strategy.value} · focus {strategy.max_focus_files} · "
-        f"prompt budget {strategy.max_prompt_chars} chars"
-    )
-    ctx.textual.text(" ")
-    ctx.textual.dim_text(
-        f"up to {strategy.max_focus_files} focus files per plan · "
-        f"{strategy.max_prompt_chars} chars per batch"
-        + (" · batching enabled" if strategy.batching_enabled else "")
+        f"✓ Review approach: {approach} · up to {strategy.max_focus_files} focus file(s)"
     )
     if strategy.reason:
         ctx.textual.dim_text(strategy.reason)
@@ -1538,37 +1534,37 @@ def _get_review_profile(ctx: WorkflowContext) -> ReviewProfile:
 
 
 def _render_pr_classification(ctx: WorkflowContext, classification: PRClassification) -> None:
-    """Render deterministic PR classification in a compact, structured format."""
-    roles_text = ", ".join(classification.roles) if classification.roles else "none"
-    rationale = classification.rationale or "Classification derived from deterministic PR composition signals."
+    """Render the classification as one human-readable summary.
 
+    On screen: the size class, the two numbers that explain it, and the signals that
+    change how the review will behave. Scoring internals (complexity score, roles,
+    repeated call sites, machine-composed rationale) go to the debug log — they help
+    diagnose a misclassification, not decide anything during a review.
+    """
     ctx.textual.success_text(f"✓ PR classified as {classification.size_class.value.upper()}")
-
-    ctx.textual.text(" ")
-    ctx.textual.text("Scope")
-    ctx.textual.dim_text(f"Files changed: {classification.files_changed}")
-    ctx.textual.dim_text(f"Lines changed: {classification.total_lines_changed}")
     ctx.textual.dim_text(
-        f"Review activity: {classification.comment_threads} threads, {classification.comment_entries} comment entries"
+        f"{classification.files_changed} file(s) · "
+        f"{classification.total_lines_changed} changed line(s)"
     )
-
-    ctx.textual.text(" ")
-    ctx.textual.text("Signals")
-    ctx.textual.dim_text(f"High-signal files: {classification.high_signal_files}")
-    ctx.textual.dim_text(f"Repeated call sites: {classification.repeated_callsite_files}")
-    ctx.textual.dim_text(f"Roles: {roles_text}")
-    ctx.textual.dim_text(f"Complexity score: {classification.complexity_score}/20")
-
-    ctx.textual.text(" ")
-    ctx.textual.text("Flags")
-    ctx.textual.dim_text(
-        f"Repetitive migration: {'yes' if classification.is_repetitive_migration else 'no'}"
+    signals = []
+    if classification.high_signal_files:
+        signals.append(f"{classification.high_signal_files} critical file(s) touched")
+    if classification.is_repetitive_migration:
+        signals.append("repetitive change pattern (many similar call sites)")
+    if classification.active_review:
+        signals.append(f"review already in progress ({classification.comment_threads} thread(s))")
+    if signals:
+        ctx.textual.dim_text("Signals: " + " · ".join(signals))
+    logger.debug(
+        "pr_classification_detail",
+        size_class=classification.size_class.value,
+        complexity_score=classification.complexity_score,
+        roles=classification.roles,
+        repeated_callsite_files=classification.repeated_callsite_files,
+        comment_threads=classification.comment_threads,
+        comment_entries=classification.comment_entries,
+        rationale=classification.rationale,
     )
-    ctx.textual.dim_text(f"Active review: {'yes' if classification.active_review else 'no'}")
-
-    ctx.textual.text(" ")
-    ctx.textual.text("Why")
-    ctx.textual.dim_text(rationale)
 
 
 def _build_review_checklist_preview(ctx: WorkflowContext, checklist: list) -> set[str]:
@@ -1594,7 +1590,8 @@ def _render_review_checklist(
     )
     ctx.textual.text(" ")
     for item in checklist:
-        label = f"{item.id}"
+        # Show the human-readable name, not the snake_case category id.
+        label = item.name or str(item.id)
         if str(item.id) in applicable_preview_ids:
             ctx.textual.bold_text(label)
         else:
@@ -1606,16 +1603,16 @@ def _show_review_context_batches(ctx: WorkflowContext, batches: list) -> None:
     for batch in batches:
         file_paths = list(getattr(batch, "files_context", {}).keys())
         related_count = len(getattr(batch, "related_files", {}) or {})
-        checklist_count = len(getattr(batch, "checklist_applicable", []) or [])
         degraded = getattr(batch, "degraded_context", False)
 
         ctx.textual.text(" ")
-        ctx.textual.bold_text(batch.batch_id)
-        ctx.textual.dim_text(
-            f"files: {len(file_paths)} · checklist: {checklist_count}"
-            + (f" · related: {related_count}" if related_count else "")
-            + (" · degraded" if degraded else "")
-        )
+        # Keep the raw batch_id as the label: the findings step references the same
+        # ids ("Reviewing batch_1…", "✓ batch_1 complete"), so the user can correlate.
+        ctx.textual.bold_text(f"{batch.batch_id} · {len(file_paths)} file(s)")
+        if related_count:
+            ctx.textual.dim_text(f"  +{related_count} related file(s) included for context")
+        if degraded:
+            ctx.textual.dim_text("  context reduced to fit the AI prompt size limit")
         for path in file_paths:
             ctx.textual.dim_text(f"  {path}")
 
@@ -1667,14 +1664,14 @@ def _retry_findings_batch_reformat(
 
 def _render_findings_batch_split(ctx: WorkflowContext, batch_id: str, produced_batches: list[str]) -> None:
     """Render a batch split caused by prompt budget constraints."""
-    ctx.textual.warning_text(
-        f"{batch_id} exceeded prompt budget and was split into {', '.join(produced_batches)}"
+    ctx.textual.dim_text(
+        f"{batch_id} was too large for one AI call — split into {', '.join(produced_batches)}"
     )
 
 
 def _render_findings_batch_degraded(ctx: WorkflowContext, batch_id: str) -> None:
     """Render an in-place context reduction (no new batches) caused by prompt budget constraints."""
-    ctx.textual.warning_text(f"{batch_id} exceeded prompt budget and was degraded to fit")
+    ctx.textual.dim_text(f"{batch_id} was too large — file context reduced to fit the AI call")
 
 
 def _render_findings_batch_result(
@@ -1846,10 +1843,21 @@ def resolve_review_context(ctx: WorkflowContext) -> WorkflowResult:
         f"✓ Context: {files_count} focus file(s) in {batch_count} batch(es)"
         + (f" · {related_count} related file(s)" if related_count else "")
     )
-    trimmed_count = sum(len(batch.excluded_files) for batch in package.batches)
-    ctx.textual.dim_text(
-        f"comments in context: {sum(len(batch.comment_context) for batch in package.batches)} · "
-        f"trimmed by budget: {trimmed_count}"
+    # Coverage honesty: name the files that will NOT be reviewed instead of hiding
+    # them behind a count — silent coverage loss is indistinguishable from a full
+    # review otherwise.
+    trimmed_paths = sorted(
+        {entry.path for batch in package.batches for entry in batch.excluded_files}
+    )
+    if trimmed_paths:
+        ctx.textual.warning_text(
+            f"⚠ {len(trimmed_paths)} file(s) will NOT be reviewed (context budget exceeded): "
+            + ", ".join(trimmed_paths)
+        )
+    logger.debug(
+        "review_context_summary",
+        comments_in_context=sum(len(batch.comment_context) for batch in package.batches),
+        trimmed_paths=trimmed_paths,
     )
     _show_review_context_batches(ctx, package.batches)
     ctx.textual.end_step("success")
@@ -2094,14 +2102,10 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 prompt_budget_target_chars=strategy.max_prompt_chars,
                 prompt_actual_chars=len(prompt),
             )
+            skipped_paths = ", ".join(sorted(batch.files_context)) or "unknown files"
             ctx.textual.warning_text(
-                f"Skipping {batch.batch_id}: prompt still too large ({len(prompt)} chars > {strategy.max_prompt_chars})"
-            )
-            _render_findings_batch_result(
-                ctx,
-                batch.batch_id,
-                status="skipped",
-                detail="prompt still too large",
+                f"⚠ {batch.batch_id} skipped — too large even after reduction. "
+                f"NOT reviewed: {skipped_paths}"
             )
             continue
         worktree_reference_count = sum(
@@ -2495,7 +2499,16 @@ def dedupe_findings(ctx: WorkflowContext) -> WorkflowResult:
 
     summary = f"✓ {len(deduped)} finding(s) ready"
     if removed:
-        summary += f" ({removed} duplicate(s) removed)"
+        # Say WHY findings were dropped: "already commented on the PR" explains why a
+        # re-run reports different things than the first pass — "duplicates removed"
+        # does not.
+        if removed_existing:
+            summary += f" ({removed_existing} skipped: already commented on this PR"
+            if removed > removed_existing:
+                summary += f"; {removed - removed_existing} internal duplicate(s)"
+            summary += ")"
+        else:
+            summary += f" ({removed} internal duplicate(s) removed)"
     ctx.textual.success_text(summary)
     logger.debug(
         "findings_deduplicated",
@@ -2766,7 +2779,7 @@ def validate_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     if not ctx.textual:
         return Error("Textual UI context is not available for this step.")
 
-    ctx.textual.begin_step("Validate Review Actions")
+    ctx.textual.begin_step("Validate & Approve Actions")
 
     actions: List[ReviewActionProposal] = ctx.get("review_action_proposals", [])
 

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -2315,6 +2315,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 ctx.get("review_checklist", []),
                 batches[0].pr_manifest if batches else None,
                 diff_manager=ctx.get("review_diff_manager"),
+                comment_context=ctx.get("comment_review_context", []),
             )
             if borderline_paths
             else None
@@ -2405,6 +2406,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 ctx.get("review_diff", ""),
                 batches[0].pr_manifest if batches else None,
                 diff_manager=ctx.get("review_diff_manager"),
+                comment_context=ctx.get("comment_review_context", []),
             )
             if len(focus_paths) > 1
             else None

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1971,6 +1971,11 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     by total AI failure must not look like a clean review — while still publishing
     empty raw_findings so downstream steps run via the workflow's on_error: continue.
 
+    When ReviewProfile.findings_synthesis_enabled is on and the PR touches more than
+    one focus file, one extra best-effort cross-file synthesis batch (all hunks
+    together, hunks_only) runs after the per-file batches; its findings are deduped
+    against theirs before aggregation.
+
     Requires (from ctx.data):
         review_context_package (ReviewContextPackage)
         cli_preference (str): "claude" | "gemini" | "codex" | "auto"
@@ -2271,6 +2276,88 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             ctx.textual.dim_text(
                 "No findings from main batches; borderline files remain unreviewed (no diff hunks)."
             )
+
+    # Cross-file synthesis (off by default): per-file batches are structurally blind to
+    # interactions between the PR's own changes, so re-combine every reviewed path's
+    # hunks into one extra batch that looks ONLY for cross-file inconsistencies. Runs
+    # after the rescue block so the rescue's empty-findings gate is unaffected, and
+    # best-effort like it: failure never marks the review as failed, and it stays
+    # outside the attempted/succeeded counters.
+    if _get_review_profile(ctx).findings_synthesis_enabled and strategy:
+        from ..operations.findings_operations import (
+            FINDINGS_SYNTHESIS_EFFORT,
+            SYNTHESIS_INSTRUCTIONS,
+            build_cross_file_synthesis_batch,
+            dedupe_synthesis_findings,
+        )
+
+        focus_paths = sorted({path for batch in batches for path in batch.files_context})
+        synthesis_batch = (
+            build_cross_file_synthesis_batch(
+                focus_paths,
+                ctx.get("review_diff", ""),
+                batches[0].pr_manifest if batches else None,
+                diff_manager=ctx.get("review_diff_manager"),
+            )
+            if len(focus_paths) > 1
+            else None
+        )
+        if synthesis_batch:
+            synthesis_prompt = build_findings_prompt_parts(
+                synthesis_batch, instructions_override=SYNTHESIS_INSTRUCTIONS
+            )["prompt"]
+            if len(synthesis_prompt) > strategy.max_prompt_chars:
+                # No split/degrade machinery for this batch: the whole point is seeing
+                # every hunk together, so a partial synthesis is not worth the spend.
+                logger.debug(
+                    "synthesis_batch_over_budget",
+                    prompt_actual_chars=len(synthesis_prompt),
+                    prompt_budget_target_chars=strategy.max_prompt_chars,
+                )
+                ctx.textual.dim_text("Cross-file synthesis skipped (combined hunks over budget).")
+            else:
+                _log_ai_prompt(
+                    step_name="ai_review_findings",
+                    cli_name=adapter.cli_name.value,
+                    prompt=synthesis_prompt,
+                    batch_id=synthesis_batch.batch_id,
+                    files_context=len(synthesis_batch.files_context),
+                    prompt_budget_target_chars=strategy.max_prompt_chars,
+                    prompt_actual_chars=len(synthesis_prompt),
+                )
+                _render_findings_batch_started(ctx, synthesis_batch)
+                synthesis_effort = (
+                    FINDINGS_SYNTHESIS_EFFORT if adapter.supports_effort_control else None
+                )
+                with ctx.textual.loading(
+                    f"Asking {cli_display} to run the cross-file synthesis batch…"
+                ):
+                    synthesis_outcome = _run((synthesis_batch, synthesis_prompt, synthesis_effort))
+                if synthesis_outcome["status"] == "success":
+                    unique_findings = dedupe_synthesis_findings(
+                        synthesis_outcome["raw"], aggregated_raw
+                    )
+                    aggregated_raw.extend(unique_findings)
+                    logger.info(
+                        "synthesis_batch_result",
+                        findings_count_raw=len(synthesis_outcome["raw"]),
+                        findings_count_unique=len(unique_findings),
+                        focus_files=len(synthesis_batch.files_context),
+                    )
+                    _render_findings_batch_result(
+                        ctx,
+                        synthesis_batch.batch_id,
+                        status="success",
+                        findings_count=len(unique_findings),
+                    )
+                else:
+                    logger.debug("synthesis_batch_failed", detail=synthesis_outcome["detail"])
+                    _render_findings_batch_result(
+                        ctx,
+                        synthesis_batch.batch_id,
+                        status="failed",
+                        detail=synthesis_outcome["detail"],
+                    )
 
     ctx.data["raw_findings"] = aggregated_raw or build_default_findings()
     ctx.data["ai_findings_failed"] = findings_failed

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -342,7 +342,11 @@ def _is_derived_from_central(finding, central) -> bool:
         token in finding_text and token in central_text
         for token in ("launchcustomtab", "openurlordialog", "checkinternalorexternaluri", "ishostallowed", "onopenfailed", "onopensuccess")
     )
-    mentions_central = central_stem in finding_text or central_stem in central_text
+    # Only the FINDING mentioning the central file counts as a derivation signal —
+    # the central finding mentions its own file stem practically by definition, so
+    # checking central_text here would make this clause always true and reduce the
+    # whole collapse condition to a 0.32 title similarity.
+    mentions_central = central_stem in finding_text
     title_similarity = SequenceMatcher(None, finding.title.lower(), central.title.lower()).ratio()
 
     return (shared_api or mentions_central) and title_similarity >= 0.32
@@ -2091,8 +2095,15 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     if not adapter:
         ctx.textual.warning_text("No headless CLI available — skipping AI findings")
         ctx.data["raw_findings"] = build_default_findings()
+        # Keep the outputs consistent with every other exit of this step: downstream
+        # reads ai_findings_failed, and it must be explicitly False here (nothing
+        # failed — nothing ran).
+        ctx.data["ai_findings_failed"] = False
         ctx.textual.end_step("success")
-        return Success("No findings (no CLI available)", metadata={"raw_findings": []})
+        return Success(
+            "No findings (no CLI available)",
+            metadata={"raw_findings": [], "ai_findings_failed": False},
+        )
 
     # Structured output forces the CLI to return findings via a schema-validated tool
     # call instead of relying on the model to follow a "respond only with JSON" prompt
@@ -2292,9 +2303,10 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
         from ..operations.findings_operations import build_empty_findings_rescue_batch
 
         candidates = ctx.get("review_candidates", [])
-        already_reviewed = {fp.path for batch in batches for fp in batch.files_context.values()}
+        # "Already reviewed" means a batch actually PRODUCED output for the path — a
+        # failed/skipped batch's files are as unreviewed as any borderline candidate.
         borderline_paths = [
-            candidate.path for candidate in candidates if candidate.path not in already_reviewed
+            candidate.path for candidate in candidates if candidate.path not in reviewed_paths
         ]
         rescue_batch = (
             build_empty_findings_rescue_batch(
@@ -2766,8 +2778,13 @@ def verify_findings(ctx: WorkflowContext) -> WorkflowResult:
             ctx.textual.end_step("skip")
             return Skip("Verification response unparseable")
 
+    # Truthy contents only — the prompt builder treats an empty block as "no code
+    # available", so the refutation guard must agree with it.
     outcome = apply_verification_verdicts(
-        to_verify, raw_verdicts, exempt, paths_with_code=set(code_map)
+        to_verify,
+        raw_verdicts,
+        exempt,
+        paths_with_code={path for path, content in code_map.items() if content},
     )
     ctx.data["deduped_findings"] = outcome.kept
     ctx.data["refuted_findings"] = outcome.refuted

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -69,10 +69,6 @@ logger = get_logger(__name__)
 _PROMPT_PREVIEW_CHARS = 2000
 _RESPONSE_PREVIEW_CHARS = 1500
 _COMMIT_SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b", re.IGNORECASE)
-_STRONG_API_CLAIM_RE = re.compile(
-    r"(does not accept|does not provide|does not compile|overload|signature|parameter(?:s)? .* not)",
-    re.IGNORECASE,
-)
 _CENTRAL_PATH_HINTS = ("/utils/", "/configuration/", "/interceptors/", "/base/", "Utils.kt", "Configuration.kt")
 _MAX_REFERENCED_COMMITS_PER_THREAD = 3
 _MAX_REFERENCED_COMMIT_FILES = 3
@@ -218,49 +214,6 @@ def _load_referenced_commit_contexts(
             contexts_by_thread[thread.thread_id] = referenced_contexts
 
     return contexts_by_thread
-
-
-def _build_visible_file_context_map(batches: list) -> dict[str, str]:
-    """Flatten current review batches into a path -> visible text map."""
-    file_map: dict[str, str] = {}
-    for batch in batches or []:
-        for path, entry in batch.files_context.items():
-            parts = []
-            if entry.full_content:
-                parts.append(entry.full_content)
-            parts.extend(entry.expanded_hunks)
-            parts.extend(entry.hunks)
-            if parts:
-                file_map[path] = "\n".join(parts)
-    return file_map
-
-
-def _looks_like_contradicted_api_claim(finding, visible_content: str) -> bool:
-    """Detect strong API/signature claims contradicted by the visible code context."""
-    claim_text = " ".join(
-        part for part in (finding.title, finding.why, finding.suggested_comment) if part
-    )
-    if not _STRONG_API_CLAIM_RE.search(claim_text):
-        return False
-
-    identifiers = set(re.findall(r"`([A-Za-z_][A-Za-z0-9_]*)`", claim_text))
-    identifiers.update(re.findall(r"\b(on[A-Z][A-Za-z0-9_]+|manageResult)\b", claim_text))
-    if not identifiers:
-        return False
-
-    lower_visible = visible_content.lower()
-    if "fun " not in lower_visible:
-        return False
-
-    contradicted = any(identifier.lower() in lower_visible for identifier in identifiers)
-    if contradicted:
-        logger.debug(
-            "finding_contradicted_by_visible_context",
-            path=finding.path,
-            title=finding.title,
-            identifiers=sorted(identifiers),
-        )
-    return contradicted
 
 
 def _show_review_plan_summary(ctx: WorkflowContext, plan) -> None:
@@ -2219,7 +2172,6 @@ def normalize_findings(ctx: WorkflowContext) -> WorkflowResult:
     ctx.textual.begin_step("Normalize Findings")
 
     raw = ctx.get("raw_findings")
-    review_batches = ctx.get("review_context_batches", [])
 
     if raw is None:
         ctx.textual.end_step("error")
@@ -2243,21 +2195,10 @@ def normalize_findings(ctx: WorkflowContext) -> WorkflowResult:
 
     findings: list[Finding] = []
     skipped = 0
-    visible_file_context = _build_visible_file_context_map(review_batches)
 
     for i, item in enumerate(raw):
         try:
-            finding = Finding.model_validate(item)
-            if finding.path in visible_file_context and _looks_like_contradicted_api_claim(
-                finding,
-                visible_file_context[finding.path],
-            ):
-                skipped += 1
-                ctx.textual.dim_text(
-                    f"⚠ Finding {i + 1} contradicted by visible code context, skipping"
-                )
-                continue
-            findings.append(finding)
+            findings.append(Finding.model_validate(item))
         except ValidationError as e:
             skipped += 1
             ctx.textual.dim_text(f"⚠ Finding {i + 1} invalid, skipping: {e.error_count()} error(s)")
@@ -2342,6 +2283,185 @@ def dedupe_findings(ctx: WorkflowContext) -> WorkflowResult:
     )
     ctx.textual.end_step("success")
     return Success("Findings deduplicated", metadata={"deduped_findings_count": len(deduped)})
+
+
+def verify_findings(ctx: WorkflowContext) -> WorkflowResult:
+    """
+    Adversarial verification pass: try to REFUTE each finding before the human gate.
+
+    One batched AI call (effort low, structured output, same adapter infra as
+    ai_review_findings) receives all non-nit findings plus the focused hunks they
+    refer to, and judges each as confirmed/refuted/uncertain. Findings refuted with
+    evidence are dropped (and shown, with the refutation reasoning); everything else
+    passes through. Fail-open: any CLI/parse/budget problem keeps all findings.
+
+    Generalizes the retired `_looks_like_contradicted_api_claim` heuristic.
+    Gated by ReviewProfile.findings_verification_enabled (default True).
+
+    Requires (from ctx.data):
+        deduped_findings (List[Finding])
+        review_context_batches (List[FocusContextBatch])
+        review_strategy (ReviewStrategy)
+        cli_preference (str)
+
+    Outputs (saved to ctx.data):
+        deduped_findings (List[Finding]): verified set, refuted findings removed
+        refuted_findings (List[Finding]): findings dropped by this pass
+
+    Returns:
+        Success or Skip
+    """
+    if not ctx.textual:
+        return Error("Textual UI context is not available for this step.")
+
+    ctx.textual.begin_step("Verify Findings")
+
+    findings = ctx.get("deduped_findings")
+    if findings is None:
+        ctx.textual.end_step("error")
+        return Error("No deduped_findings in context (run dedupe_findings first)")
+
+    if not findings:
+        ctx.textual.dim_text("No findings to verify.")
+        ctx.textual.end_step("skip")
+        return Skip("No findings to verify")
+
+    profile = _get_review_profile(ctx)
+    if not profile.findings_verification_enabled:
+        ctx.textual.dim_text("Findings verification disabled by review profile.")
+        ctx.textual.end_step("skip")
+        return Skip("Verification disabled by review profile")
+
+    from ..operations.findings_operations import FINDINGS_DISALLOWED_TOOLS
+    from ..operations.verification_operations import (
+        VERIFICATION_EFFORT,
+        VERIFICATION_TIMEOUT_SECONDS,
+        apply_verification_verdicts,
+        build_verification_code_map,
+        build_verification_prompt_parts,
+        parse_verification_response,
+        select_findings_for_verification,
+        summarize_verification_prompt_parts,
+        verification_json_schema,
+    )
+
+    to_verify, exempt = select_findings_for_verification(findings)
+    if not to_verify:
+        ctx.textual.dim_text("Only nit-severity findings — skipping verification.")
+        ctx.textual.end_step("skip")
+        return Skip("No findings eligible for verification")
+
+    adapter = _resolve_headless_adapter(ctx.data.get("cli_preference", "auto"))
+    if not adapter:
+        ctx.textual.dim_text("No headless CLI available — findings pass unverified.")
+        ctx.textual.end_step("skip")
+        return Skip("No CLI available for verification")
+
+    strategy = ctx.get("review_strategy")
+    batches = ctx.get("review_context_batches", [])
+    project_root = ctx.data.get("worktree_path") or ctx.data.get("project_root")
+
+    code_map = build_verification_code_map(to_verify, batches)
+    prompt_parts = build_verification_prompt_parts(to_verify, code_map)
+    prompt = prompt_parts["prompt"]
+
+    max_prompt_chars = strategy.max_prompt_chars if strategy else None
+    if max_prompt_chars and len(prompt) > max_prompt_chars:
+        # Fail-open on budget too: verification is an optional quality filter, never
+        # worth degrading or splitting like the findings pass.
+        logger.warning(
+            "verification_prompt_over_budget",
+            prompt_actual_chars=len(prompt),
+            prompt_budget_target_chars=max_prompt_chars,
+        )
+        ctx.textual.dim_text(
+            f"Verification prompt too large ({len(prompt)} chars) — findings pass unverified."
+        )
+        ctx.textual.end_step("skip")
+        return Skip("Verification prompt over budget")
+
+    use_structured_output = adapter.supports_structured_output
+    disallowed_tools = list(FINDINGS_DISALLOWED_TOOLS) if adapter.supports_tool_restriction else None
+    effort = VERIFICATION_EFFORT if adapter.supports_effort_control else None
+    cli_display = adapter.cli_name.value.capitalize()
+
+    _log_ai_prompt(
+        step_name="verify_findings",
+        cli_name=adapter.cli_name.value,
+        prompt=prompt,
+        findings_to_verify=len(to_verify),
+        findings_exempt=len(exempt),
+        prompt_actual_chars=len(prompt),
+        effort=effort,
+        **summarize_verification_prompt_parts(prompt_parts),
+    )
+    adapter_started_at = time.monotonic()
+    with ctx.textual.loading(f"Asking {cli_display} to verify {len(to_verify)} finding(s)…"):
+        response = adapter.execute(
+            prompt,
+            cwd=project_root,
+            timeout=VERIFICATION_TIMEOUT_SECONDS,
+            json_schema=verification_json_schema() if use_structured_output else None,
+            disallowed_tools=disallowed_tools,
+            effort=effort,
+        )
+    adapter_duration_seconds = time.monotonic() - adapter_started_at
+    _log_ai_response(
+        step_name="verify_findings",
+        cli_name=adapter.cli_name.value,
+        stdout=response.stdout,
+        stderr=response.stderr,
+        exit_code=response.exit_code,
+        duration_seconds=round(adapter_duration_seconds, 3),
+        findings_to_verify=len(to_verify),
+    )
+
+    if not response.succeeded:
+        logger.warning("verification_call_failed", exit_code=response.exit_code)
+        ctx.textual.warning_text(
+            f"Verification call failed (exit {response.exit_code}) — findings pass unverified."
+        )
+        ctx.textual.end_step("skip")
+        return Skip("Verification call failed")
+
+    match parse_verification_response(response.stdout, structured=use_structured_output):
+        case ClientSuccess(data=raw_verdicts) if isinstance(raw_verdicts, list):
+            pass
+        case _:
+            logger.warning("verification_parse_failed")
+            ctx.textual.warning_text("Could not parse verification response — findings pass unverified.")
+            ctx.textual.end_step("skip")
+            return Skip("Verification response unparseable")
+
+    outcome = apply_verification_verdicts(to_verify, raw_verdicts, exempt)
+    ctx.data["deduped_findings"] = outcome.kept
+    ctx.data["refuted_findings"] = outcome.refuted
+
+    logger.info(
+        "findings_verification_applied",
+        findings_in=len(findings),
+        verified=len(to_verify),
+        exempt_nits=len(exempt),
+        refuted=len(outcome.refuted),
+        kept=len(outcome.kept),
+        duration_seconds=round(adapter_duration_seconds, 3),
+    )
+    for finding, reason in zip(outcome.refuted, outcome.refuted_reasons):
+        ctx.textual.dim_text(
+            f"✗ Refuted: {finding.title} @ {finding.path}:{finding.line} — {reason[:200]}"
+        )
+    summary = f"✓ {len(outcome.kept)} finding(s) verified"
+    if outcome.refuted:
+        summary += f" ({len(outcome.refuted)} refuted and dropped)"
+    ctx.textual.success_text(summary)
+    ctx.textual.end_step("success")
+    return Success(
+        "Findings verified",
+        metadata={
+            "deduped_findings": outcome.kept,
+            "refuted_findings": outcome.refuted,
+        },
+    )
 
 
 # ============================================================================

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -2781,9 +2781,9 @@ def verify_findings(ctx: WorkflowContext) -> WorkflowResult:
     # Truthy contents only — the prompt builder treats an empty block as "no code
     # available", so the refutation guard must agree with it.
     outcome = apply_verification_verdicts(
+        findings,
         to_verify,
         raw_verdicts,
-        exempt,
         paths_with_code={path for path, content in code_map.items() if content},
     )
     ctx.data["deduped_findings"] = outcome.kept

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1698,6 +1698,42 @@ def _render_findings_batch_degraded(ctx: WorkflowContext, batch_id: str) -> None
     ctx.textual.dim_text(f"{batch_id} was too large — file context reduced to fit the AI call")
 
 
+def _retry_timed_out_worktree_batch(ctx: WorkflowContext, batch, run, strategy) -> Optional[tuple]:
+    """Retry a timed-out worktree_reference batch once in bounded hunks_only mode.
+
+    Runs on the step thread (UI access is fine). Returns (fallback_batch, outcome)
+    when the retry was executed, or None when no bounded fallback was possible
+    (no hunks, or the fallback prompt itself exceeds the budget) — the caller then
+    keeps the original failed outcome.
+    """
+    from ..operations.findings_operations import (
+        build_findings_prompt_parts,
+        build_timeout_fallback_batch,
+    )
+
+    fallback = build_timeout_fallback_batch(
+        batch, ctx.get("review_diff", ""), diff_manager=ctx.get("review_diff_manager")
+    )
+    if not fallback:
+        return None
+    prompt = build_findings_prompt_parts(fallback)["prompt"]
+    if strategy and len(prompt) > strategy.max_prompt_chars:
+        return None
+
+    ctx.textual.dim_text(
+        f"{batch.batch_id} timed out exploring the worktree — retrying with inline diff hunks only"
+    )
+    logger.info(
+        "findings_batch_timeout_fallback",
+        batch_id=batch.batch_id,
+        fallback_batch_id=fallback.batch_id,
+        prompt_actual_chars=len(prompt),
+    )
+    with ctx.textual.loading(f"Retrying {batch.batch_id} with inline hunks…"):
+        outcome = run((fallback, prompt, None))
+    return fallback, outcome
+
+
 def _render_findings_batch_result(
     ctx: WorkflowContext,
     batch_id: str,
@@ -1965,7 +2001,12 @@ def _execute_findings_batch(
 
     if not response.succeeded:
         logger.debug("findings_batch_failed", batch_id=batch.batch_id, exit_code=response.exit_code)
-        return {"status": "failed", "raw": None, "detail": f"CLI exit {response.exit_code}"}
+        return {
+            "status": "failed",
+            "raw": None,
+            "detail": f"CLI exit {response.exit_code}",
+            "timed_out": response.exit_code == 124,
+        }
 
     match parse_findings_response(response.stdout, structured=use_structured_output):
         case ClientSuccess(data=raw) if isinstance(raw, list):
@@ -2067,6 +2108,9 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     findings_failed = False
     batches_attempted = 0
     batches_succeeded = 0
+    # Paths whose batch actually produced output — a failed/skipped batch's files were
+    # NOT reviewed, and downstream passes (synthesis) must not claim they were.
+    reviewed_paths: set[str] = set()
     batch_queue = list(batches)
     ctx.textual.dim_text(f"Reviewing {len(batch_queue)} batch(es) with {cli_display}")
 
@@ -2194,8 +2238,21 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                     ]
 
         for batch, outcome in outcomes:
+            if (
+                outcome["status"] == "failed"
+                and outcome.get("timed_out")
+                and any(entry.worktree_reference for entry in batch.files_context.values())
+            ):
+                # A timed-out worktree_reference batch means the CLI spent the whole
+                # budget exploring a (usually huge) file and reviewed NOTHING. One
+                # bounded retry with inline hunks trades depth for guaranteed
+                # coverage of the batch's files.
+                retried = _retry_timed_out_worktree_batch(ctx, batch, _run, strategy)
+                if retried:
+                    batch, outcome = retried
             if outcome["status"] == "success":
                 batches_succeeded += 1
+                reviewed_paths.update(batch.files_context)
                 aggregated_raw.extend(outcome["raw"])
                 _render_findings_batch_result(
                     ctx,
@@ -2279,6 +2336,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                 with ctx.textual.loading(f"Asking {cli_display} to review the rescue batch…"):
                     rescue_outcome = _run((rescue_batch, rescue_prompt, None))
                 if rescue_outcome["status"] == "success":
+                    reviewed_paths.update(rescue_batch.files_context)
                     aggregated_raw.extend(rescue_outcome["raw"])
                     _render_findings_batch_result(
                         ctx,
@@ -2323,7 +2381,12 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             dedupe_synthesis_findings,
         )
 
-        focus_paths = sorted({path for batch in batches for path in batch.files_context})
+        # Only paths whose batch actually SUCCEEDED: the synthesis instructions tell
+        # the model "single-file issues in these files were already reviewed" — that
+        # claim must not cover files whose batch failed or was skipped over budget
+        # (their single-file issues would be silently suppressed with no one having
+        # looked at them).
+        focus_paths = sorted(reviewed_paths)
         synthesis_batch = (
             build_cross_file_synthesis_batch(
                 focus_paths,
@@ -2703,7 +2766,9 @@ def verify_findings(ctx: WorkflowContext) -> WorkflowResult:
             ctx.textual.end_step("skip")
             return Skip("Verification response unparseable")
 
-    outcome = apply_verification_verdicts(to_verify, raw_verdicts, exempt)
+    outcome = apply_verification_verdicts(
+        to_verify, raw_verdicts, exempt, paths_with_code=set(code_map)
+    )
     ctx.data["deduped_findings"] = outcome.kept
     ctx.data["refuted_findings"] = outcome.refuted
 
@@ -2793,6 +2858,26 @@ def build_new_comment_actions(ctx: WorkflowContext) -> WorkflowResult:
     return Success("Actions built")
 
 
+def _release_review_worktree(ctx: WorkflowContext) -> None:
+    """Remove the review worktree as soon as nothing will read from it again.
+
+    The workflow's final cleanup step only runs when the workflow reaches it —
+    abandoning the review at an interactive gate (exit button, quitting the app at
+    the submit prompt) used to leave the worktree on disk. Failure here is fine:
+    the final cleanup step remains as backstop.
+    """
+    if not ctx.get("worktree_created") or not ctx.get("worktree_path") or not ctx.git:
+        return
+    from ..operations import cleanup_worktree as cleanup_worktree_operation
+
+    if cleanup_worktree_operation(ctx.git, ctx.data["worktree_path"]):
+        ctx.textual.dim_text("Review worktree removed (no longer needed).")
+        ctx.data["worktree_created"] = False
+        ctx.data["worktree_path"] = None
+    else:
+        logger.warning("early_worktree_release_failed", worktree_path=ctx.data.get("worktree_path"))
+
+
 def validate_review_actions(ctx: WorkflowContext) -> WorkflowResult:
     """
     Present each ReviewActionProposal to the user for approval, editing, or skipping.
@@ -2818,6 +2903,7 @@ def validate_review_actions(ctx: WorkflowContext) -> WorkflowResult:
 
     if not actions:
         ctx.textual.dim_text("No actions to validate.")
+        _release_review_worktree(ctx)
         ctx.textual.end_step("skip")
         return Skip("No actions to validate")
 
@@ -2834,19 +2920,29 @@ def validate_review_actions(ctx: WorkflowContext) -> WorkflowResult:
         key=lambda a: severity_order.get(a.severity.value if a.severity else "", 99),
     )
 
+    # Precompute every action's code context NOW: anchors are resolved and the diff
+    # hunks / file excerpts below are the last reads from the worktree. Releasing it
+    # before the interactive loop means abandoning the review mid-gate (exit button,
+    # quitting the app at the submit prompt) can no longer leave a stale worktree —
+    # the final cleanup_worktree step becomes a no-op backstop.
+    prepared: List[tuple] = []
+    for action in sorted_actions:
+        diff_hunk = extract_diff_hunk_for_action(action, diff, diff_manager=diff_manager)
+        # Unanchored findings have no diff hunk by definition — read the real file so the
+        # user judges the finding against its code instead of a bare assertion.
+        file_excerpt = extract_file_excerpt_for_action(action, diff_manager=diff_manager)
+        prepared.append((action, diff_hunk, file_excerpt))
+    _release_review_worktree(ctx)
+
     approved: List[ReviewActionProposal] = []
     skipped = 0
     exit_requested = False
 
-    for idx, action in enumerate(sorted_actions):
+    for idx, (action, diff_hunk, file_excerpt) in enumerate(prepared):
         if exit_requested:
             break
 
         current = action
-        diff_hunk = extract_diff_hunk_for_action(current, diff, diff_manager=diff_manager)
-        # Unanchored findings have no diff hunk by definition — read the real file so the
-        # user judges the finding against its code instead of a bare assertion.
-        file_excerpt = extract_file_excerpt_for_action(current, diff_manager=diff_manager)
 
         while True:
             choice = _show_review_action_and_get_decision(

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/code_review_steps.py
@@ -1923,7 +1923,10 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     existing comments) to the selected headless CLI. The AI reviews only the
     code it was specifically directed to read in the planning phase.
 
-    On parse failure or CLI error, falls back to empty findings (safe default).
+    On parse failure or CLI error a batch is retried (reformat) and then marked
+    failed. If every batch fails, the step returns Error — an empty result caused
+    by total AI failure must not look like a clean review — while still publishing
+    empty raw_findings so downstream steps run via the workflow's on_error: continue.
 
     Requires (from ctx.data):
         review_context_package (ReviewContextPackage)
@@ -1979,6 +1982,8 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
     cli_display = adapter.cli_name.value.capitalize()
     aggregated_raw = []
     findings_failed = False
+    batches_attempted = 0
+    batches_succeeded = 0
     batch_queue = list(batches)
     ctx.textual.dim_text(f"Reviewing {len(batch_queue)} batch(es) with {cli_display}")
 
@@ -2010,6 +2015,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
             continue
 
         batch = fitted_batches[0]
+        batches_attempted += 1
         _render_findings_batch_started(ctx, batch)
         prompt_parts = build_findings_prompt_parts(batch)
         prompt = prompt_parts["prompt"]
@@ -2110,6 +2116,7 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
 
         match parse_findings_response(response.stdout, structured=use_structured_output):
             case ClientSuccess(data=raw) if isinstance(raw, list):
+                batches_succeeded += 1
                 aggregated_raw.extend(raw)
                 _render_findings_batch_result(
                     ctx,
@@ -2117,35 +2124,56 @@ def ai_review_findings(ctx: WorkflowContext) -> WorkflowResult:
                     status="success",
                     findings_count=len(raw),
                 )
-            case ClientSuccess():
-                pass
+                continue
+            case ClientSuccess(data=raw):
+                # A structured success whose payload isn't a findings list (e.g. a dict)
+                # must not vanish silently — treat it like any other parse failure.
+                parse_error = f"non-list findings payload ({type(raw).__name__})"
             case ClientError(error_message=err):
-                logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=err)
-                match _retry_findings_batch_reformat(
-                    adapter, response.stdout, project_root, batch.batch_id, use_structured_output, effort
-                ):
-                    case ClientSuccess(data=raw) if isinstance(raw, list):
-                        aggregated_raw.extend(raw)
-                        logger.debug(
-                            "findings_batch_reformat_recovered",
-                            batch_id=batch.batch_id,
-                            findings_count=len(raw),
-                        )
-                        _render_findings_batch_result(
-                            ctx,
-                            batch.batch_id,
-                            status="success",
-                            findings_count=len(raw),
-                        )
-                    case _:
-                        findings_failed = True
-                        logger.debug("findings_batch_reformat_failed", batch_id=batch.batch_id)
-                        _render_findings_batch_result(
-                            ctx,
-                            batch.batch_id,
-                            status="failed",
-                            detail="parse error",
-                        )
+                parse_error = err
+
+        logger.debug("findings_batch_parse_failed", batch_id=batch.batch_id, error=parse_error)
+        match _retry_findings_batch_reformat(
+            adapter, response.stdout, project_root, batch.batch_id, use_structured_output, effort
+        ):
+            case ClientSuccess(data=raw) if isinstance(raw, list):
+                batches_succeeded += 1
+                aggregated_raw.extend(raw)
+                logger.debug(
+                    "findings_batch_reformat_recovered",
+                    batch_id=batch.batch_id,
+                    findings_count=len(raw),
+                )
+                _render_findings_batch_result(
+                    ctx,
+                    batch.batch_id,
+                    status="success",
+                    findings_count=len(raw),
+                )
+            case _:
+                findings_failed = True
+                logger.debug("findings_batch_reformat_failed", batch_id=batch.batch_id)
+                _render_findings_batch_result(
+                    ctx,
+                    batch.batch_id,
+                    status="failed",
+                    detail="parse error",
+                )
+
+    if batches_attempted and not batches_succeeded:
+        # Every batch failed or was skipped: an "empty" review here means the AI never
+        # ran, not that the code is clean. Publish empty findings so downstream steps
+        # (and the worktree cleanup) still run via on_error: continue, but fail the step
+        # visibly instead of masquerading as a clean review.
+        ctx.data["raw_findings"] = build_default_findings()
+        ctx.data["ai_findings_failed"] = True
+        logger.error("findings_all_batches_failed", batches_attempted=batches_attempted)
+        ctx.textual.error_text(
+            f"AI findings failed: 0 of {batches_attempted} batch(es) produced output. "
+            "No code was reviewed — do not treat this as a clean review."
+        )
+        ctx.textual.end_step("error")
+        return Error(f"AI findings failed: 0/{batches_attempted} batches produced output")
 
     if not aggregated_raw and strategy and strategy.suspicious_empty_findings:
         candidates = ctx.get("review_candidates", [])

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/worktree_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/worktree_steps.py
@@ -33,6 +33,7 @@ def create_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
     head_branch = ctx.get("selected_pr_head_branch") or ctx.get("review_pr_head") or ""
 
     if not pr_number:
+        ctx.textual.error_text("Missing required data")
         ctx.textual.end_step("error")
         return Error("Missing required data")
 

--- a/plugins/titan-plugin-github/titan_plugin_github/steps/worktree_steps.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/steps/worktree_steps.py
@@ -27,7 +27,7 @@ def create_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
     if not ctx.textual:
         return Error("Textual UI context is not available for this step.")
 
-    ctx.textual.begin_step("Create Worktree")
+    ctx.textual.begin_step("Create PR Worktree")
 
     pr_number = ctx.get("selected_pr_number") or ctx.get("review_pr_number")
     head_branch = ctx.get("selected_pr_head_branch") or ctx.get("review_pr_head") or ""
@@ -83,7 +83,7 @@ def cleanup_worktree_step(ctx: WorkflowContext) -> WorkflowResult:
     if not ctx.textual:
         return Error("Textual UI context is not available for this step.")
 
-    ctx.textual.begin_step("Cleanup Worktree")
+    ctx.textual.begin_step("Cleanup PR Worktree")
 
     worktree_created = ctx.get("worktree_created", False)
     worktree_path = ctx.get("worktree_path")

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_utils.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_utils.py
@@ -49,9 +49,17 @@ CommentElement = Union[TextElement, SuggestionElement, CodeBlockElement]
 _HUNK_HEADER_RE = re.compile(r'@@ -\d+,?\d* \+(\d+),?\d* @@')
 
 
-_HTML_BLOCK_HINT = re.compile(r"<\s*(table|tbody|tr|td|div|p|span|a|img|picture|details|br)\b", re.I)
+# The tag name must follow `<` immediately and be closed like a real tag: prose such as
+# "check that x < a and y > b" must NOT be mistaken for markup, or the tag-stripping
+# below would delete everything between the two comparison operators.
+_HTML_BLOCK_HINT = re.compile(
+    r"</?(table|tbody|thead|tr|td|th|div|p|span|a|img|picture|source|details|summary|br|ul|ol|li|code)"
+    r"(\s[^<>]*)?/?>",
+    re.I,
+)
 _HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
-_HTML_TAG = re.compile(r"<[^>]+>")
+# Only well-formed tags: `<name>`, `</name>`, `<name attr="…">`, `<name/>`.
+_HTML_TAG = re.compile(r"</?[a-zA-Z][a-zA-Z0-9-]*(\s[^<>]*)?/?>")
 _BLANK_RUN = re.compile(r"\n{3,}")
 
 _LINE_BREAK_TAGS = re.compile(r"<\s*/?\s*(br|/tr|/p|/div|/li|/h[1-6])\b[^>]*>", re.I)
@@ -108,6 +116,18 @@ def html_body_to_text(body: str) -> str:
     return _BLANK_RUN.sub("\n\n", "\n".join(merged)).strip()
 
 
+def _flatten_html_if_needed(text: str) -> str:
+    """Flatten HTML in a PROSE segment only.
+
+    Called per text segment, never on the whole body: fenced code blocks must keep
+    their content verbatim (`List<String>` in a Kotlin snippet is not a tag, and a
+    mangled ```suggestion block would be applied to the code as-is).
+    """
+    if _HTML_BLOCK_HINT.search(text) or text.lstrip().startswith("<!--"):
+        return html_body_to_text(text)
+    return text
+
+
 def parse_comment_body(
     body: str,
     diff_hunk: Optional[str] = None,
@@ -128,22 +148,18 @@ def parse_comment_body(
         return []
 
     body = body.replace("\r\n", "\n")
-    if _HTML_BLOCK_HINT.search(body) or body.lstrip().startswith("<!--"):
-        # Bot bodies are HTML; without this they render as an empty comment.
-        body = html_body_to_text(body)
-        if not body:
-            return []
     elements: List[CommentElement] = []
 
     code_block_pattern = re.compile(r"```(\w+)?\n(.*?)```", re.DOTALL)
     matches = list(code_block_pattern.finditer(body))
 
     if not matches:
-        return [TextElement(content=body.strip())]
+        flattened = _flatten_html_if_needed(body).strip()
+        return [TextElement(content=flattened)] if flattened else []
 
     last_end = 0
     for match in matches:
-        text_before = body[last_end : match.start()].strip()
+        text_before = _flatten_html_if_needed(body[last_end : match.start()]).strip()
         if text_before:
             elements.append(TextElement(content=text_before))
 
@@ -173,7 +189,7 @@ def parse_comment_body(
 
         last_end = match.end()
 
-    text_after = body[last_end:].strip()
+    text_after = _flatten_html_if_needed(body[last_end:]).strip()
     if text_after:
         elements.append(TextElement(content=text_after))
 

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_utils.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_utils.py
@@ -49,6 +49,65 @@ CommentElement = Union[TextElement, SuggestionElement, CodeBlockElement]
 _HUNK_HEADER_RE = re.compile(r'@@ -\d+,?\d* \+(\d+),?\d* @@')
 
 
+_HTML_BLOCK_HINT = re.compile(r"<\s*(table|tbody|tr|td|div|p|span|a|img|picture|details|br)\b", re.I)
+_HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+_HTML_TAG = re.compile(r"<[^>]+>")
+_BLANK_RUN = re.compile(r"\n{3,}")
+
+_LINE_BREAK_TAGS = re.compile(r"<\s*/?\s*(br|/tr|/p|/div|/li|/h[1-6])\b[^>]*>", re.I)
+_CELL_END = re.compile(r"<\s*/\s*(td|th)\s*>", re.I)
+_CODE_SPAN = re.compile(r"<\s*code\s*[^>]*>(.*?)<\s*/\s*code\s*>", re.DOTALL | re.I)
+
+_EMOJI_SHORTCODES = {
+    ":warning:": "⚠️",
+    ":x:": "❌",
+    ":no_entry_sign:": "🚫",
+    ":heavy_check_mark:": "✅",
+    ":white_check_mark:": "✅",
+    ":bangbang:": "‼️",
+    ":information_source:": "ℹ️",
+    ":bulb:": "💡",
+    ":memo:": "📝",
+}
+
+
+def html_body_to_text(body: str) -> str:
+    """Flatten an HTML comment body into readable text.
+
+    Linter and CI bots (github-actions, Danger, Wiz…) post their findings as HTML
+    tables. Textual's Markdown widget has no `html_block`/`html_inline` handling, so
+    such a body renders as NOTHING and the comment looks empty — the reader can see
+    the thread but not what it says. Converting to text keeps the message readable;
+    the exact HTML layout is irrelevant in a terminal.
+    """
+    text = _HTML_COMMENT.sub("", body)
+    text = _CODE_SPAN.sub(lambda m: f"`{m.group(1).strip()}`", text)
+    text = _LINE_BREAK_TAGS.sub("\n", text)
+    # Cells on one source line would otherwise be glued together ("⚠️Unit tests…").
+    text = _CELL_END.sub(" ", text)
+    text = _HTML_TAG.sub("", text)
+    text = (
+        text.replace("&nbsp;", " ")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", '"')
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")
+    )
+    for shortcode, emoji in _EMOJI_SHORTCODES.items():
+        text = text.replace(shortcode, emoji)
+    lines = [line.strip() for line in text.splitlines()]
+    # A severity marker alone on its line (bots put it in its own table cell) reads
+    # better attached to the message it qualifies.
+    merged: List[str] = []
+    for line in lines:
+        if merged and merged[-1] in _EMOJI_SHORTCODES.values() and line:
+            merged[-1] = f"{merged[-1]} {line}"
+        else:
+            merged.append(line)
+    return _BLANK_RUN.sub("\n\n", "\n".join(merged)).strip()
+
+
 def parse_comment_body(
     body: str,
     diff_hunk: Optional[str] = None,
@@ -69,6 +128,11 @@ def parse_comment_body(
         return []
 
     body = body.replace("\r\n", "\n")
+    if _HTML_BLOCK_HINT.search(body) or body.lstrip().startswith("<!--"):
+        # Bot bodies are HTML; without this they render as an empty comment.
+        body = html_body_to_text(body)
+        if not body:
+            return []
     elements: List[CommentElement] = []
 
     code_block_pattern = re.compile(r"```(\w+)?\n(.*?)```", re.DOTALL)

--- a/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
+++ b/plugins/titan-plugin-github/titan_plugin_github/widgets/comment_view.py
@@ -438,11 +438,12 @@ def _build_action_line_label(action: Any) -> Optional[str]:
     """
     resolved_line = getattr(action, "resolved_line", None)
     original_line = getattr(action, "original_line", None) or getattr(action, "line", None)
-    resolution_source = getattr(action, "resolution_source", None)
 
     if resolved_line and original_line and resolved_line != original_line:
-        suffix = f" via {resolution_source}" if resolution_source else ""
-        return f"Line {resolved_line} (AI {original_line}{suffix})"
+        # resolution_source is an internal classifier value ("snippet", "evidence",
+        # "validated_line"…) — what the reviewer needs is that the AI's line was
+        # corrected against the diff, not which mechanism did it.
+        return f"Line {resolved_line} (adjusted from AI's line {original_line})"
     if resolved_line:
         return f"Line {resolved_line}"
 

--- a/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr.yaml
+++ b/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr.yaml
@@ -84,6 +84,14 @@ steps:
     plugin: github
     step: dedupe_findings
 
+  # Fail-open quality filter: refuted findings are dropped before the human gate;
+  # any verification failure just passes findings through unverified.
+  - id: verify
+    name: "Verify Findings"
+    plugin: github
+    step: verify_findings
+    on_error: continue
+
   - id: build_actions
     name: "Build Comment Actions"
     plugin: github

--- a/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr.yaml
+++ b/plugins/titan-plugin-github/titan_plugin_github/workflows/review-pr.yaml
@@ -110,8 +110,10 @@ steps:
     step: submit_review_actions
     on_error: continue
 
-  # Runs last on purpose: the worktree is the source of real file content while the
-  # user inspects findings in validate_actions and while comments are being placed.
+  # Backstop only: validate_actions releases the worktree itself right after
+  # precomputing every action's code context (so abandoning the review at an
+  # interactive gate can't leave a stale worktree). This step covers the paths that
+  # never reach validate_actions and the rare early-release failure.
   # on_error: continue so a failed cleanup never masks the review's outcome.
   - id: cleanup_worktree
     name: "Cleanup PR Worktree"


### PR DESCRIPTION
# Pull Request

## 📝 Summary
<!-- Brief description of what this PR does (2-3 sentences) -->
Introduces an adversarial `verify_findings` step to the code review pipeline that uses a low-effort AI pass to refute false-positive findings before they reach the human gate (fail-open). Adds a cross-file synthesis batch to detect inconsistencies spanning multiple files, a rescue batch for borderline files that returned no findings, and improves error visibility and output clarity throughout the review workflow.

## 🔧 Changes Made
<!-- Bullet list of key changes -->
- **`verify_findings` step**: New adversarial AI verification pass that attempts to refute each non-nit finding against the code it targets; refuted findings are dropped and surfaced in the UI with reasons. Gated by `findings_verification_enabled` in the project review profile (default `true`); fail-open on any CLI, parse, or budget error.
- **Cross-file synthesis batch**: When `findings_synthesis_enabled` is `true` and the PR touches more than one focus file, a best-effort batch runs across all reviewed files' hunks to detect cross-file inconsistencies introduced by the PR; findings are deduped against per-file results before aggregation.
- **Rescue batch for empty findings**: `build_empty_findings_rescue_batch` re-examines borderline files that produced zero findings (hunks-only, capped at 2 files) to reduce missed issues on near-threshold PRs.
- **Error visibility & UX**: Improved error messages and reduced UI output verbosity in code review steps; comment threads removed from complexity scoring.
- **Concurrent batch execution**: `verify_findings` runs its verification batches concurrently for reduced latency.
- **Documentation**: `workflow-steps.md` updated with full contracts for `verify_findings` and the new `ai_review_findings` synthesis behaviour.

## 🧪 Testing
<!-- How has this been tested? Check all that apply -->
- [x] Unit tests added/updated (`poetry run pytest`)
- [ ] All tests passing (`make test`)
- [ ] Manual testing with `titan-dev`

<!-- If unit tests were added, briefly describe what is covered -->
New tests in `test_findings_operations.py` cover:
- `build_empty_findings_rescue_batch`: hunks-only entry construction, file cap enforcement, paths-without-hunks skipping, and `None` return when no paths match.
- `build_cross_file_synthesis_batch`: hunks-only entries for all paths, no file cap, correct `batch_id`, and `None` return when under the multi-file threshold.
- `dedupe_synthesis_findings`: cross-batch deduplication logic.
- AI batch failure and non-list payload edge cases in the code review step.

## 📊 Logs
<!-- List new log events introduced by this PR, or check the box if none -->
- [ ] No new log events

## ✅ Checklist
- [x] Self-review done
- [ ] Follows the project's [logging rules](.claude/docs/logging.md) (no secrets, no content in logs)
- [x] New and existing tests pass
- [x] Documentation updated if needed
- [x] Plugin documentation updated when plugin functions or parameters changed (`Plugins > Git Plugin`, `GitHub Plugin`, `Jira Plugin`)